### PR TITLE
Remove hardcoded GOPATH from developer docs.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -47,7 +47,7 @@ recommend adding them to your `.bashrc`):
 `.bashrc` example:
 
 ```shell
-export GOPATH="$HOME/go"
+export GOPATH="$(go env GOPATH)"
 export PATH="${PATH}:${GOPATH}/bin"
 export KO_DOCKER_REPO=docker.io/<your_docker_id>
 # export KO_DOCKER_REPO=gcr.io/<your_gcr_id>


### PR DESCRIPTION
Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use `go env GOPATH` to retrieve the path to a  user's Go directory