### PR TITLE
Use release 2.0.0-milestone1 of cloudevents/sdk-java

### DIFF
--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -39,7 +39,7 @@
     <jacoco.plugin.version>0.8.5</jacoco.plugin.version>
     <!-- vertx version should be aligned with cloud events SDK -->
     <vertx.version>3.9.1</vertx.version>
-    <cloudevents.sdk.version>2.0.0-SNAPSHOT</cloudevents.sdk.version>
+    <cloudevents.sdk.version>2.0.0-milestone1</cloudevents.sdk.version>
     <assertj.version>3.16.1</assertj.version>
     <protobuf.version>3.12.2</protobuf.version>
     <build.helper.maven.plugin.version>3.1.0</build.helper.maven.plugin.version>


### PR DESCRIPTION
## Proposed Changes

- Use release 2.0.0-milestone1 of cloudevents/sdk-java