### PR TITLE
Bind addressable-resolver cluster role to kafka-broker-controller SA

### DIFF
--- a/control-plane/config/201-controller-cluster-role-binding.yaml
+++ b/control-plane/config/201-controller-cluster-role-binding.yaml
@@ -28,3 +28,17 @@ roleRef:
   kind: ClusterRole
   name: kafka-broker-controller
   apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kafka-broker-addressable-resolver
+subjects:
+  - kind: ServiceAccount
+    name: kafka-broker-controller
+    namespace: knative-eventing
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: addressable-resolver


### PR DESCRIPTION
While trying the integration with Serving components, the controller
was unable to resolve serving Services due to non-granted permissions.
This PR binds the `addressable-resolver` cluster role to the
`kafka-broker-controller` service account, so that we can resolve all
addressable service we have as `Trigger` subscriber.

## Proposed Changes

- Bind addressable-resolver cluster role to `kafka-broker-controller` service account