### PR TITLE
Read mounted config map when start watching it.

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/file/FileWatcher.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/file/FileWatcher.java
@@ -88,6 +88,9 @@ public class FileWatcher {
    * @throws InterruptedException see {@link WatchService#take()}
    */
   public void watch() throws IOException, InterruptedException {
+    // If the container restarts, the mounted file never gets reconciled, so update as soon as we
+    // start watching
+    update();
 
     while (true) {
       var shouldUpdate = false;


### PR DESCRIPTION
The dispatcher might restart, and as long as
it doesn't receive filesystem updates it never reconciles
existing objects, this PR allow the dispatcher to reconcile
existing objects, if any when it starts.

Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>

## Proposed Changes

- Read the mounted config map when start watching it.
- Add regression unit test