### PR TITLE
Retry on conflicts in Trigger finalizer

### DIFF
--- a/control-plane/pkg/reconciler/trigger/trigger.go
+++ b/control-plane/pkg/reconciler/trigger/trigger.go
@@ -59,6 +59,12 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, trigger *eventing.Trigge
 }
 
 func (r *Reconciler) FinalizeKind(ctx context.Context, trigger *eventing.Trigger) reconciler.Event {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		return r.finalizeKind(ctx, trigger)
+	})
+}
+
+func (r *Reconciler) finalizeKind(ctx context.Context, trigger *eventing.Trigger) reconciler.Event {
 
 	logger := log.Logger(ctx, "trigger", trigger)
 


### PR DESCRIPTION
It's better to retry with a controlled backoff instead of relying on the reconciler queue.

## Proposed Changes

- Retry on conflicts in Trigger finalizer