### PR TITLE
Use KO_FLAGS when run ko resolve

### DIFF
--- a/test/control-plane/library.sh
+++ b/test/control-plane/library.sh
@@ -28,6 +28,6 @@ fi
 
 # Note: do not change this function name, it's used during releases.
 function control_plane_setup() {
-  ko resolve --strict -f "${CONTROL_PLANE_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_BROKER_ARTIFACT}"
+  ko resolve ${KO_FLAGS} --strict -f "${CONTROL_PLANE_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_BROKER_ARTIFACT}"
   return $?
 }


### PR DESCRIPTION
`KO_FLAGS` variable is used by the `release.sh` in `test-infra` to inject custom flags, so we need to use it.

Fixes #85  

## Proposed Changes

- Use `KO_FLAGS` when run ko resolve