### PR TITLE
Install Eventing release if it's a release branch

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -50,7 +50,8 @@ function knative_eventing() {
     ko $1 -f "${EVENTING_CONFIG}"
     popd || fail_test "Failed to set up Eventing"
   else
-    fail_test "Not ready for a release"
+    echo ">> Install Knative Eventing from ${KNATIVE_EVENTING_RELEASE}"
+    kubectl apply -f ${KNATIVE_EVENTING_RELEASE}
   fi
 
   # Publish test images.


### PR DESCRIPTION
If it's a release branch, we need to install the respective eventing release as we do in `eventing-contrib` here:
https://github.com/knative/eventing-contrib/blob/48505ce5b1e7f370b0b4afe526b739be8481967f/test/e2e-tests.sh#L81-L82.

## Proposed Changes

- Install Eventing release if it's a release branch