### PR TITLE
Run e2e tests multiple times

### DIFF
--- a/test/e2e/broker_event_trasformation_test.go
+++ b/test/e2e/broker_event_trasformation_test.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/eventing/test/e2e/helpers"
 
 	testbroker "knative.dev/eventing-kafka-broker/test/pkg/broker"
+	pkgtesting "knative.dev/eventing-kafka-broker/test/pkg/testing"
 )
 
 func TestEventTransformationForTriggerV1BrokerV1(t *testing.T) {
@@ -41,11 +42,13 @@ func TestEventTransformationForTriggerV1BrokerV1Beta1(t *testing.T) {
 }
 
 func runTest(t *testing.T, brokerVersion string, triggerVersion string) {
+	pkgtesting.RunMultiple(t, func(t *testing.T) {
 
-	helpers.EventTransformationForTriggerTestHelper(
-		t,
-		brokerVersion,
-		triggerVersion,
-		testbroker.Creator,
-	)
+		helpers.EventTransformationForTriggerTestHelper(
+			t,
+			brokerVersion,
+			triggerVersion,
+			testbroker.Creator,
+		)
+	})
 }

--- a/test/e2e/conformance/control_plane_conformance_test.go
+++ b/test/e2e/conformance/control_plane_conformance_test.go
@@ -21,11 +21,12 @@ package conformance
 import (
 	"testing"
 
-	"knative.dev/eventing/test/conformance/helpers"
+	conformance "knative.dev/eventing/test/conformance/helpers"
 	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/resources"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
+	pkgtesting "knative.dev/eventing-kafka-broker/test/pkg/testing"
 )
 
 func brokerCreator(client *testlib.Client, name string) {
@@ -38,5 +39,7 @@ func brokerCreator(client *testlib.Client, name string) {
 }
 
 func TestBrokerV1Beta1ControlPlane(t *testing.T) {
-	helpers.BrokerV1Beta1ControlPlaneTest(t, brokerCreator)
+	pkgtesting.RunMultiple(t, func(t *testing.T) {
+		conformance.BrokerV1Beta1ControlPlaneTest(t, brokerCreator)
+	})
 }

--- a/test/e2e/conformance/data_plane_conformance_test.go
+++ b/test/e2e/conformance/data_plane_conformance_test.go
@@ -27,28 +27,34 @@ import (
 	"knative.dev/eventing/test/lib/resources"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
+	pkgtesting "knative.dev/eventing-kafka-broker/test/pkg/testing"
 )
 
 func TestBrokerIngressV1Beta1(t *testing.T) {
+	pkgtesting.RunMultiple(t, func(t *testing.T) {
 
-	client := testlib.Setup(t, true)
-	defer testlib.TearDown(client)
+		client := testlib.Setup(t, true)
+		defer testlib.TearDown(client)
 
-	broker := createBroker(client)
+		broker := createBroker(client)
 
-	conformance.BrokerV1Beta1IngressDataPlaneTestHelper(t, client, broker)
+		conformance.BrokerV1Beta1IngressDataPlaneTestHelper(t, client, broker)
+	})
 }
 
 func TestBrokerConsumerV1Beta1(t *testing.T) {
 	// TODO re-enable this test
 	t.Skip("This scenario is already covered by TestEventTransformationForTrigger*")
 
-	client := testlib.Setup(t, true)
-	defer testlib.TearDown(client)
+	pkgtesting.RunMultiple(t, func(t *testing.T) {
 
-	broker := createBroker(client)
+		client := testlib.Setup(t, true)
+		defer testlib.TearDown(client)
 
-	conformance.BrokerV1Beta1ConsumerDataPlaneTestHelper(t, client, broker)
+		broker := createBroker(client)
+
+		conformance.BrokerV1Beta1ConsumerDataPlaneTestHelper(t, client, broker)
+	})
 }
 
 func createBroker(client *testlib.Client) *eventing.Broker {

--- a/test/pkg/testing/run.go
+++ b/test/pkg/testing/run.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testing
+
+import (
+	"fmt"
+	"testing"
+)
+
+const (
+	// Number of times to run a test function.
+	rerunTimes = 5
+)
+
+// RunMultiple run test function f `rerunTimes` times
+func RunMultiple(t *testing.T, f func(t *testing.T)) {
+	RunMultipleN(t, rerunTimes, f)
+}
+
+// RunMultiple run test function f n times
+func RunMultipleN(t *testing.T, n int, f func(t *testing.T)) {
+	t.Parallel()
+
+	for i := 0; i < n; i++ {
+		t.Run(fmt.Sprintf("%d", i), f)
+	}
+}


### PR DESCRIPTION
To reduce the introduction of new flaky tests (bugs), 
we can run the same e2e tests multiple times, so that 
we catch bugs as soon as possible.

Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>

## Proposed Changes

- Run e2e tests multiple times