### PR TITLE
Hide transfer progress

### DIFF
--- a/data-plane/docker/Dockerfile
+++ b/data-plane/docker/Dockerfile
@@ -30,11 +30,11 @@ COPY checkstyle/suppression.xml checkstyle/suppression.xml
 COPY ./mvnw .
 COPY ./.mvn/wrapper .mvn/wrapper
 
-RUN ./mvnw install -DskipTests -Dcheckstyle.skip
+RUN ./mvnw install -DskipTests -Dcheckstyle.skip --no-transfer-progress
 
 COPY . .
 
-RUN ./mvnw package -DskipTests -Dcheckstyle.skip
+RUN ./mvnw package -DskipTests -Dcheckstyle.skip --no-transfer-progress
 
 FROM ${JAVA_IMAGE} as running
 

--- a/data-plane/docker/test/Dockerfile
+++ b/data-plane/docker/test/Dockerfile
@@ -21,4 +21,4 @@ WORKDIR /app
 
 COPY . .
 
-RUN ./mvnw clean verify -B
+RUN ./mvnw clean verify --no-transfer-progress


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Hide maven transfer progress, since it pollutes a lot the CI logs