### PR TITLE
Upper-case broker class name

### DIFF
--- a/control-plane/pkg/reconciler/kafka/broker_class.go
+++ b/control-plane/pkg/reconciler/kafka/broker_class.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// Kafka broker class annotation value
-	BrokerClass = "kafka"
+	BrokerClass = "Kafka"
 )
 
 func BrokerClassFilter() func(interface{}) bool {


### PR DESCRIPTION
Fixes #94

## Proposed Changes

- Change broker class name from `kafka` to `Kafka`