### PR TITLE
Fix duplicate resources in nightly release

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -31,6 +31,8 @@ function fail() {
 
 function build_release() {
 
+  [ -f "${EVENTING_KAFKA_BROKER_ARTIFACT}" ] && rm "${EVENTING_KAFKA_BROKER_ARTIFACT}"
+
   control_plane_setup
   if [[ $? -ne 0 ]]; then
     fail "failed to setup control plane artifact"


### PR DESCRIPTION
[Nightly release](https://console.cloud.google.com/storage/browser/_details/knative-nightly/eventing-kafka-broker/latest/eventing-kafka-broker.yaml) contains duplicate entries because 
we run tests and build the release at the same time
producing the same artifact, so remove the artifact
before building the release.

## Proposed Changes

- remove the artifact before building the release