### PR TITLE
Get WebClient config from config map

### DIFF
--- a/data-plane/config/100-config-kafka-broker-data-plane.yaml
+++ b/data-plane/config/100-config-kafka-broker-data-plane.yaml
@@ -111,3 +111,5 @@ data:
     # ssl.keymanager.algorithm
     # ssl.secure.random.implementation
     # ssl.trustmanager.algorithm
+  config-kafka-broker-webclient.properties: |
+    idleTimeout=10000

--- a/data-plane/config/template/500-dispatcher.yaml
+++ b/data-plane/config/template/500-dispatcher.yaml
@@ -58,6 +58,8 @@ spec:
               value: /etc/config/config-kafka-broker-producer.properties
             - name: CONSUMER_CONFIG_FILE_PATH
               value: /etc/config/config-kafka-broker-consumer.properties
+            - name: WEBCLIENT_CONFIG_FILE_PATH
+              value: /etc/config/config-kafka-broker-webclient.properties
             - name: BROKERS_TRIGGERS_PATH
               value: /etc/brokers-triggers/data
             - name: BROKERS_INITIAL_CAPACITY

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/Configurations.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/Configurations.java
@@ -1,0 +1,61 @@
+package dev.knative.eventing.kafka.broker.dispatcher;
+
+import static net.logstash.logback.argument.StructuredArguments.keyValue;
+
+import io.vertx.config.ConfigRetriever;
+import io.vertx.config.ConfigRetrieverOptions;
+import io.vertx.config.ConfigStoreOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Configurations {
+
+  private static final Logger logger = LoggerFactory.getLogger(Configurations.class);
+
+  static Properties getKafkaProperties(final String path) {
+    if (path == null) {
+      return new Properties();
+    }
+
+    final var props = new Properties();
+    try (final var configReader = new FileReader(path)) {
+      props.load(configReader);
+    } catch (IOException e) {
+      logger.error("failed to load configurations from file {}", keyValue("path", path), e);
+    }
+
+    return props;
+  }
+
+  static JsonObject getFileConfigurations(final Vertx vertx, String file) throws ExecutionException, InterruptedException {
+    final var fileConfigs = new ConfigStoreOptions()
+      .setType("file")
+      .setFormat("properties")
+      .setConfig(new JsonObject().put("path", file));
+
+    return ConfigRetriever.create(vertx, new ConfigRetrieverOptions().addStore(fileConfigs))
+      .getConfig()
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get();
+  }
+
+  static JsonObject getEnvConfigurations(final Vertx vertx) throws InterruptedException, ExecutionException {
+    final var envConfigs = new ConfigStoreOptions()
+      .setType("env")
+      .setOptional(false)
+      .setConfig(new JsonObject().put("raw-data", true));
+
+    return ConfigRetriever.create(vertx, new ConfigRetrieverOptions().addStore(envConfigs))
+      .getConfig()
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get();
+  }
+}


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #141

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🎁 Now the webclient used by dispatcher can be configured using the config map `config-kafka-broker-data-plane`
- 🧽 Some reorg of config file loading (maybe needs another pass in future)

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Now you can configure the web client options https://vertx-web-site.github.io/docs/apidocs/io/vertx/ext/web/client/WebClientOptions.html modifying the config map `config-kafka-broker-data-plane`
```
