### PR TITLE
Configure Vert.x HTTP server through a config map

### DIFF
--- a/data-plane/config/100-config-kafka-broker-data-plane.yaml
+++ b/data-plane/config/100-config-kafka-broker-data-plane.yaml
@@ -113,3 +113,4 @@ data:
     # ssl.trustmanager.algorithm
   config-kafka-broker-webclient.properties: |
     idleTimeout=10000
+  config-kafka-broker-httpserver.properties: |

--- a/data-plane/config/100-config-kafka-broker-data-plane.yaml
+++ b/data-plane/config/100-config-kafka-broker-data-plane.yaml
@@ -114,3 +114,4 @@ data:
   config-kafka-broker-webclient.properties: |
     idleTimeout=10000
   config-kafka-broker-httpserver.properties: |
+    idleTimeout=0

--- a/data-plane/config/template/500-dispatcher.yaml
+++ b/data-plane/config/template/500-dispatcher.yaml
@@ -60,7 +60,7 @@ spec:
               value: /etc/config/config-kafka-broker-consumer.properties
             - name: WEBCLIENT_CONFIG_FILE_PATH
               value: /etc/config/config-kafka-broker-webclient.properties
-            - name: BROKERS_TRIGGERS_PATH
+            - name: DATA_PLANE_CONFIG_FILE_PATH
               value: /etc/brokers-triggers/data
             - name: BROKERS_INITIAL_CAPACITY
               value: "100"

--- a/data-plane/config/template/500-receiver.yaml
+++ b/data-plane/config/template/500-receiver.yaml
@@ -58,6 +58,8 @@ spec:
               value: "8080"
             - name: PRODUCER_CONFIG_FILE_PATH
               value: /etc/config/config-kafka-broker-producer.properties
+            - name: HTTPSERVER_CONFIG_FILE_PATH
+              value: /etc/config/config-kafka-broker-httpserver.properties
             - name: DATA_PLANE_CONFIG_FILE_PATH
               value: /etc/brokers-triggers/data
             - name: LIVENESS_PROBE_PATH

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/BaseEnv.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/BaseEnv.java
@@ -1,0 +1,35 @@
+package dev.knative.eventing.kafka.broker.core.utils;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+
+public abstract class BaseEnv {
+
+  public static final String PRODUCER_CONFIG_FILE_PATH = "PRODUCER_CONFIG_FILE_PATH";
+  public static final String DATA_PLANE_CONFIG_FILE_PATH = "DATA_PLANE_CONFIG_FILE_PATH";
+
+  private final String producerConfigFilePath;
+  private final String dataPlaneConfigFilePath;
+
+  public BaseEnv(Function<String, String> envProvider) {
+    this.producerConfigFilePath = requireNonNull(envProvider.apply(PRODUCER_CONFIG_FILE_PATH));
+    this.dataPlaneConfigFilePath = requireNonNull(envProvider.apply(DATA_PLANE_CONFIG_FILE_PATH));
+  }
+
+  public String getProducerConfigFilePath() {
+    return producerConfigFilePath;
+  }
+
+  public String getDataPlaneConfigFilePath() {
+    return dataPlaneConfigFilePath;
+  }
+
+  @Override
+  public String toString() {
+    return "BaseEnv{" +
+      "producerConfigFilePath='" + producerConfigFilePath + '\'' +
+      ", dataPlaneConfigFilePath='" + dataPlaneConfigFilePath + '\'' +
+      '}';
+  }
+}

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/Configurations.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/Configurations.java
@@ -1,4 +1,4 @@
-package dev.knative.eventing.kafka.broker.dispatcher;
+package dev.knative.eventing.kafka.broker.core.utils;
 
 import static net.logstash.logback.argument.StructuredArguments.keyValue;
 
@@ -18,7 +18,7 @@ public class Configurations {
 
   private static final Logger logger = LoggerFactory.getLogger(Configurations.class);
 
-  static Properties getKafkaProperties(final String path) {
+  public static Properties getKafkaProperties(final String path) {
     if (path == null) {
       return new Properties();
     }
@@ -33,26 +33,13 @@ public class Configurations {
     return props;
   }
 
-  static JsonObject getFileConfigurations(final Vertx vertx, String file) throws ExecutionException, InterruptedException {
+  public static JsonObject getFileConfigurations(final Vertx vertx, String file) throws ExecutionException, InterruptedException {
     final var fileConfigs = new ConfigStoreOptions()
       .setType("file")
       .setFormat("properties")
       .setConfig(new JsonObject().put("path", file));
 
     return ConfigRetriever.create(vertx, new ConfigRetrieverOptions().addStore(fileConfigs))
-      .getConfig()
-      .toCompletionStage()
-      .toCompletableFuture()
-      .get();
-  }
-
-  static JsonObject getEnvConfigurations(final Vertx vertx) throws InterruptedException, ExecutionException {
-    final var envConfigs = new ConfigStoreOptions()
-      .setType("env")
-      .setOptional(false)
-      .setConfig(new JsonObject().put("raw-data", true));
-
-    return ConfigRetriever.create(vertx, new ConfigRetrieverOptions().addStore(envConfigs))
       .getConfig()
       .toCompletionStage()
       .toCompletableFuture()

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/DispatcherEnv.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/DispatcherEnv.java
@@ -1,0 +1,54 @@
+package dev.knative.eventing.kafka.broker.dispatcher;
+
+import static java.util.Objects.requireNonNull;
+
+import dev.knative.eventing.kafka.broker.core.utils.BaseEnv;
+import java.util.function.Function;
+
+public class DispatcherEnv extends BaseEnv {
+
+  public static final String CONSUMER_CONFIG_FILE_PATH = "CONSUMER_CONFIG_FILE_PATH";
+  public static final String WEBCLIENT_CONFIG_FILE_PATH = "WEBCLIENT_CONFIG_FILE_PATH";
+  public static final String BROKERS_INITIAL_CAPACITY = "BROKERS_INITIAL_CAPACITY";
+  public static final String TRIGGERS_INITIAL_CAPACITY = "TRIGGERS_INITIAL_CAPACITY";
+
+  private final String consumerConfigFilePath;
+  private final String webClientConfigFilePath;
+  private final int brokersInitialCapacity;
+  private final int triggersInitialCapacity;
+
+  public DispatcherEnv(Function<String, String> envProvider) {
+    super(envProvider);
+
+    this.consumerConfigFilePath = requireNonNull(envProvider.apply(CONSUMER_CONFIG_FILE_PATH));
+    this.webClientConfigFilePath = requireNonNull(envProvider.apply(WEBCLIENT_CONFIG_FILE_PATH));
+    this.brokersInitialCapacity = Integer.parseInt(requireNonNull(envProvider.apply(BROKERS_INITIAL_CAPACITY)));
+    this.triggersInitialCapacity = Integer.parseInt(requireNonNull(envProvider.apply(TRIGGERS_INITIAL_CAPACITY)));
+  }
+
+  public String getConsumerConfigFilePath() {
+    return consumerConfigFilePath;
+  }
+
+  public String getWebClientConfigFilePath() {
+    return webClientConfigFilePath;
+  }
+
+  public int getBrokersInitialCapacity() {
+    return brokersInitialCapacity;
+  }
+
+  public int getTriggersInitialCapacity() {
+    return triggersInitialCapacity;
+  }
+
+  @Override
+  public String toString() {
+    return "DispatcherEnv{" +
+      "consumerConfigFilePath='" + consumerConfigFilePath + '\'' +
+      ", webClientConfigFilePath='" + webClientConfigFilePath + '\'' +
+      ", brokersInitialCapacity=" + brokersInitialCapacity +
+      ", triggersInitialCapacity=" + triggersInitialCapacity +
+      "} " + super.toString();
+  }
+}

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/Main.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/Main.java
@@ -55,9 +55,9 @@ public class Main {
     final var vertx = Vertx.vertx();
     Runtime.getRuntime().addShutdownHook(new Thread(vertx::close));
 
-    final var producerConfig = Configurations.getKafkaProperties(env.getProducerConfigFilePath());
-    final var consumerConfig = Configurations.getKafkaProperties(env.getConsumerConfigFilePath());
-    final var webClientConfig = Configurations.getFileConfigurations(vertx, env.getWebClientConfigFilePath());
+    final var producerConfig = Configurations.getProperties(env.getProducerConfigFilePath());
+    final var consumerConfig = Configurations.getProperties(env.getConsumerConfigFilePath());
+    final var webClientConfig = Configurations.getPropertiesAsJson(env.getWebClientConfigFilePath());
 
     final ConsumerRecordOffsetStrategyFactory<String, CloudEvent>
       consumerRecordOffsetStrategyFactory = ConsumerRecordOffsetStrategyFactory.unordered();

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/Main.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/Main.java
@@ -18,10 +18,10 @@ package dev.knative.eventing.kafka.broker.dispatcher;
 
 import dev.knative.eventing.kafka.broker.core.ObjectsCreator;
 import dev.knative.eventing.kafka.broker.core.file.FileWatcher;
+import dev.knative.eventing.kafka.broker.core.utils.Configurations;
 import dev.knative.eventing.kafka.broker.dispatcher.http.HttpConsumerVerticleFactory;
 import io.cloudevents.CloudEvent;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import java.io.File;
@@ -35,21 +35,12 @@ public class Main {
 
   private static final Logger logger = LoggerFactory.getLogger(Main.class);
 
-  private static final String BROKERS_TRIGGERS_PATH = "BROKERS_TRIGGERS_PATH";
-  private static final String PRODUCER_CONFIG_FILE_PATH = "PRODUCER_CONFIG_FILE_PATH";
-  private static final String CONSUMER_CONFIG_FILE_PATH = "CONSUMER_CONFIG_FILE_PATH";
-  private static final String WEBCLIENT_CONFIG_FILE_PATH = "WEBCLIENT_CONFIG_FILE_PATH";
-  private static final String BROKERS_INITIAL_CAPACITY = "BROKERS_INITIAL_CAPACITY";
-  private static final String TRIGGERS_INITIAL_CAPACITY = "TRIGGERS_INITIAL_CAPACITY";
-  public static final String INSTANCE_ID = "INSTANCE_ID";
-
   /**
    * Dispatcher entry point.
    *
    * @param args command line arguments.
    */
   public static void main(final String[] args) throws Exception {
-
     // HACK HACK HACK
     // maven-shade-plugin doesn't include the LogstashEncoder class, neither by specifying the
     // dependency with scope `provided` nor `runtime`, and adding include rules to
@@ -57,15 +48,16 @@ public class Main {
     // Instantiating an Encoder here we force it to include the class.
     new LogstashEncoder().getFieldNames();
 
+    DispatcherEnv env = new DispatcherEnv(System::getenv);
+
     logger.info("Starting Dispatcher");
 
     final var vertx = Vertx.vertx();
     Runtime.getRuntime().addShutdownHook(new Thread(vertx::close));
 
-    final JsonObject envConfig = Configurations.getEnvConfigurations(vertx);
-    final var producerConfig = Configurations.getKafkaProperties(envConfig.getString(PRODUCER_CONFIG_FILE_PATH));
-    final var consumerConfig = Configurations.getKafkaProperties(envConfig.getString(CONSUMER_CONFIG_FILE_PATH));
-    final var webClientConfig = Configurations.getFileConfigurations(vertx, envConfig.getString(WEBCLIENT_CONFIG_FILE_PATH));
+    final var producerConfig = Configurations.getKafkaProperties(env.getProducerConfigFilePath());
+    final var consumerConfig = Configurations.getKafkaProperties(env.getConsumerConfigFilePath());
+    final var webClientConfig = Configurations.getFileConfigurations(vertx, env.getWebClientConfigFilePath());
 
     final ConsumerRecordOffsetStrategyFactory<String, CloudEvent>
       consumerRecordOffsetStrategyFactory = ConsumerRecordOffsetStrategyFactory.unordered();
@@ -81,8 +73,8 @@ public class Main {
     final var brokersManager = new BrokersManager<>(
       vertx,
       consumerVerticleFactory,
-      Integer.parseInt(envConfig.getString(BROKERS_INITIAL_CAPACITY)),
-      Integer.parseInt(envConfig.getString(TRIGGERS_INITIAL_CAPACITY))
+      env.getBrokersInitialCapacity(),
+      env.getTriggersInitialCapacity()
     );
 
     final var objectCreator = new ObjectsCreator(brokersManager);
@@ -91,7 +83,7 @@ public class Main {
       final var fw = new FileWatcher(
         FileSystems.getDefault().newWatchService(),
         objectCreator,
-        new File(envConfig.getString(BROKERS_TRIGGERS_PATH))
+        new File(env.getDataPlaneConfigFilePath())
       );
 
       fw.watch(); // block forever

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -213,11 +213,6 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>vertx-config</artifactId>
-      <version>${vertx.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>
       <version>${vertx.version}</version>
       <scope>test</scope>

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/Main.java
@@ -20,15 +20,14 @@ import static net.logstash.logback.argument.StructuredArguments.keyValue;
 
 import dev.knative.eventing.kafka.broker.core.ObjectsCreator;
 import dev.knative.eventing.kafka.broker.core.file.FileWatcher;
+import dev.knative.eventing.kafka.broker.core.utils.Configurations;
 import io.cloudevents.kafka.CloudEventSerializer;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.FileSystems;
-import java.util.Properties;
 import net.logstash.logback.encoder.LogstashEncoder;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -45,7 +44,7 @@ public class Main {
    * @param args command line arguments.
    */
   public static void main(final String[] args) {
-    final var env = new Env(System::getenv);
+    final var env = new ReceiverEnv(System::getenv);
 
     // HACK HACK HACK
     // maven-shade-plugin doesn't include the LogstashEncoder class, neither by specifying the
@@ -56,13 +55,7 @@ public class Main {
 
     logger.info("Starting Receiver {}", keyValue("env", env));
 
-    final var producerConfigs = new Properties();
-    try (final var configReader = new FileReader(env.getProducerConfigFilePath())) {
-      producerConfigs.load(configReader);
-    } catch (IOException e) {
-      e.printStackTrace();
-      System.exit(1);
-    }
+    final var producerConfigs = Configurations.getKafkaProperties(env.getProducerConfigFilePath());
 
     final var vertx = Vertx.vertx();
     producerConfigs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, CloudEventSerializer.class);

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/Main.java
@@ -55,7 +55,7 @@ public class Main {
 
     logger.info("Starting Receiver {}", keyValue("env", env));
 
-    final var producerConfigs = Configurations.getKafkaProperties(env.getProducerConfigFilePath());
+    final var producerConfigs = Configurations.getProperties(env.getProducerConfigFilePath());
 
     final var vertx = Vertx.vertx();
 
@@ -68,7 +68,7 @@ public class Main {
     );
 
     final var httpServerOptions = new HttpServerOptions(
-      Configurations.getFileConfigurations(vertx, env.getHttpServerConfigFilePath())
+      Configurations.getPropertiesAsJson(env.getHttpServerConfigFilePath())
     );
     httpServerOptions.setPort(env.getIngressPort());
     final var verticle = new HttpVerticle(httpServerOptions, new SimpleProbeHandlerDecorator(

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/ReceiverEnv.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/ReceiverEnv.java
@@ -18,39 +18,30 @@ package dev.knative.eventing.kafka.broker.receiver;
 
 import static java.util.Objects.requireNonNull;
 
+import dev.knative.eventing.kafka.broker.core.utils.BaseEnv;
 import java.util.function.Function;
 
-class Env {
+class ReceiverEnv extends BaseEnv {
 
-  static final String INGRESS_PORT = "INGRESS_PORT";
+  public static final String INGRESS_PORT = "INGRESS_PORT";
   private final int ingressPort;
 
-  static final String PRODUCER_CONFIG_FILE_PATH = "PRODUCER_CONFIG_FILE_PATH";
-  private final String producerConfigFilePath;
-
-  static final String LIVENESS_PROBE_PATH = "LIVENESS_PROBE_PATH";
+  public static final String LIVENESS_PROBE_PATH = "LIVENESS_PROBE_PATH";
   private final String livenessProbePath;
 
-  static final String READINESS_PROBE_PATH = "READINESS_PROBE_PATH";
+  public static final String READINESS_PROBE_PATH = "READINESS_PROBE_PATH";
   private final String readinessProbePath;
 
-  static final String DATA_PLANE_CONFIG_FILE_PATH = "DATA_PLANE_CONFIG_FILE_PATH";
-  private final String dataPlaneConfigFilePath;
+  ReceiverEnv(final Function<String, String> envProvider) {
+    super(envProvider);
 
-  Env(final Function<String, String> envProvider) {
     this.ingressPort = Integer.parseInt(envProvider.apply(INGRESS_PORT));
-    this.producerConfigFilePath = requireNonNull(envProvider.apply(PRODUCER_CONFIG_FILE_PATH));
     this.livenessProbePath = requireNonNull(envProvider.apply(LIVENESS_PROBE_PATH));
     this.readinessProbePath = requireNonNull(envProvider.apply(READINESS_PROBE_PATH));
-    this.dataPlaneConfigFilePath = requireNonNull(envProvider.apply(DATA_PLANE_CONFIG_FILE_PATH));
   }
 
   public int getIngressPort() {
     return ingressPort;
-  }
-
-  public String getProducerConfigFilePath() {
-    return producerConfigFilePath;
   }
 
   public String getLivenessProbePath() {
@@ -61,18 +52,12 @@ class Env {
     return readinessProbePath;
   }
 
-  public String getDataPlaneConfigFilePath() {
-    return dataPlaneConfigFilePath;
-  }
-
   @Override
   public String toString() {
-    return "Env{"
-      + "ingressPort=" + ingressPort
-      + ", producerConfigFilePath='" + producerConfigFilePath + '\''
-      + ", livenessProbePath='" + livenessProbePath + '\''
-      + ", readinessProbePath='" + readinessProbePath + '\''
-      + ", dataPlaneConfigFilePath='" + dataPlaneConfigFilePath + '\''
-      + '}';
+    return "ReceiverEnv{" +
+      "ingressPort=" + ingressPort +
+      ", livenessProbePath='" + livenessProbePath + '\'' +
+      ", readinessProbePath='" + readinessProbePath + '\'' +
+      "} " + super.toString();
   }
 }

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/ReceiverEnv.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/ReceiverEnv.java
@@ -32,12 +32,16 @@ class ReceiverEnv extends BaseEnv {
   public static final String READINESS_PROBE_PATH = "READINESS_PROBE_PATH";
   private final String readinessProbePath;
 
+  public static final String HTTPSERVER_CONFIG_FILE_PATH = "HTTPSERVER_CONFIG_FILE_PATH";
+  private final String httpServerConfigFilePath;
+
   ReceiverEnv(final Function<String, String> envProvider) {
     super(envProvider);
 
     this.ingressPort = Integer.parseInt(envProvider.apply(INGRESS_PORT));
     this.livenessProbePath = requireNonNull(envProvider.apply(LIVENESS_PROBE_PATH));
     this.readinessProbePath = requireNonNull(envProvider.apply(READINESS_PROBE_PATH));
+    this.httpServerConfigFilePath = requireNonNull(envProvider.apply(HTTPSERVER_CONFIG_FILE_PATH));
   }
 
   public int getIngressPort() {
@@ -52,12 +56,17 @@ class ReceiverEnv extends BaseEnv {
     return readinessProbePath;
   }
 
+  public String getHttpServerConfigFilePath() {
+    return httpServerConfigFilePath;
+  }
+
   @Override
   public String toString() {
     return "ReceiverEnv{" +
       "ingressPort=" + ingressPort +
       ", livenessProbePath='" + livenessProbePath + '\'' +
       ", readinessProbePath='" + readinessProbePath + '\'' +
+      ", httpServerConfigFilePath='" + httpServerConfigFilePath + '\'' +
       "} " + super.toString();
   }
 }

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/ReceiverEnvTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/ReceiverEnvTest.java
@@ -28,6 +28,7 @@ class ReceiverEnvTest {
   private static final String READINESS_PATH = "/readyz";
   private static final String PRODUCER_CONFIG_PATH = "/etc/producer";
   private static final String DATA_PLANE_CONFIG_FILE_PATH = "/etc/brokers";
+  private static final String HTTPSERVER_CONFIG_FILE_PATH = "/etc/http-server-config";
 
   @Test
   public void create() {
@@ -36,6 +37,7 @@ class ReceiverEnvTest {
         case ReceiverEnv.INGRESS_PORT -> PORT;
         case ReceiverEnv.LIVENESS_PROBE_PATH -> LIVENESS_PATH;
         case ReceiverEnv.READINESS_PROBE_PATH -> READINESS_PATH;
+        case ReceiverEnv.HTTPSERVER_CONFIG_FILE_PATH -> HTTPSERVER_CONFIG_FILE_PATH;
         case BaseEnv.PRODUCER_CONFIG_FILE_PATH -> PRODUCER_CONFIG_PATH;
         case BaseEnv.DATA_PLANE_CONFIG_FILE_PATH -> DATA_PLANE_CONFIG_FILE_PATH;
         default -> throw new IllegalArgumentException();
@@ -47,6 +49,7 @@ class ReceiverEnvTest {
     assertThat(env.getReadinessProbePath()).isEqualTo(READINESS_PATH);
     assertThat(env.getProducerConfigFilePath()).isEqualTo(PRODUCER_CONFIG_PATH);
     assertThat(env.getDataPlaneConfigFilePath()).isEqualTo(DATA_PLANE_CONFIG_FILE_PATH);
+    assertThat(env.getHttpServerConfigFilePath()).isEqualTo(HTTPSERVER_CONFIG_FILE_PATH);
 
     // Check toString is overridden
     assertThat(env.toString()).doesNotContain("@");

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/ReceiverEnvTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/ReceiverEnvTest.java
@@ -18,9 +18,10 @@ package dev.knative.eventing.kafka.broker.receiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.knative.eventing.kafka.broker.core.utils.BaseEnv;
 import org.junit.jupiter.api.Test;
 
-class EnvTest {
+class ReceiverEnvTest {
 
   private static final String PORT = "8080";
   private static final String LIVENESS_PATH = "/healthz";
@@ -30,13 +31,13 @@ class EnvTest {
 
   @Test
   public void create() {
-    final var env = new Env(
+    final var env = new ReceiverEnv(
       key -> switch (key) {
-        case Env.INGRESS_PORT -> PORT;
-        case Env.LIVENESS_PROBE_PATH -> LIVENESS_PATH;
-        case Env.READINESS_PROBE_PATH -> READINESS_PATH;
-        case Env.PRODUCER_CONFIG_FILE_PATH -> PRODUCER_CONFIG_PATH;
-        case Env.DATA_PLANE_CONFIG_FILE_PATH -> DATA_PLANE_CONFIG_FILE_PATH;
+        case ReceiverEnv.INGRESS_PORT -> PORT;
+        case ReceiverEnv.LIVENESS_PROBE_PATH -> LIVENESS_PATH;
+        case ReceiverEnv.READINESS_PROBE_PATH -> READINESS_PATH;
+        case BaseEnv.PRODUCER_CONFIG_FILE_PATH -> PRODUCER_CONFIG_PATH;
+        case BaseEnv.DATA_PLANE_CONFIG_FILE_PATH -> DATA_PLANE_CONFIG_FILE_PATH;
         default -> throw new IllegalArgumentException();
       }
     );
@@ -46,6 +47,8 @@ class EnvTest {
     assertThat(env.getReadinessProbePath()).isEqualTo(READINESS_PATH);
     assertThat(env.getProducerConfigFilePath()).isEqualTo(PRODUCER_CONFIG_PATH);
     assertThat(env.getDataPlaneConfigFilePath()).isEqualTo(DATA_PLANE_CONFIG_FILE_PATH);
+
+    // Check toString is overridden
     assertThat(env.toString()).doesNotContain("@");
   }
 }


### PR DESCRIPTION
Fixes #150

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🧽 Some reorg of various env retrievers between dispatcher and receiver
- 🎁 Fix #150 adding configuration for http server

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Now you can configure the web client options https://vertx-web-site.github.io/docs/apidocs/io/vertx/core/http/HttpServerOptions.html modifying the config map `config-kafka-broker-data-plane`
```
