### PR TITLE
Disable SELinux when using protobuf compiler

### DIFF
--- a/proto/hack/generate_proto
+++ b/proto/hack/generate_proto
@@ -10,7 +10,7 @@ CONTROL_PLANE_OUTPUT_DIR=./
 mkdir -p $DATA_PLANE_OUTPUT_DIR
 mkdir -p $CONTROL_PLANE_OUTPUT_DIR
 
-docker run --rm -u "$(id -g)":"$(id -u)" -v "${PWD}":"${PWD}":z -w "${PWD}" jaegertracing/protobuf:latest \
+docker run --rm -v "${PWD}":"${PWD}" --security-opt label:disable -w "${PWD}" jaegertracing/protobuf:latest \
   --proto_path="${PWD}" \
   --java_out=$DATA_PLANE_OUTPUT_DIR \
   --go_out=$CONTROL_PLANE_OUTPUT_DIR \


### PR DESCRIPTION
Related: https://github.com/knative-sandbox/eventing-kafka-broker/pull/154

## Proposed Changes

- Disable SELinux when using protobuf compiler