### PR TITLE
Update Broker and Trigger status when there is a failure

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -141,6 +141,9 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 
 	// Update the configuration map with the new brokersTriggers data.
 	if err := r.UpdateDataPlaneConfigMap(brokersTriggers, brokersTriggersConfigMap); err != nil {
+		logger.Error("failed to update data plane config map", zap.Error(
+			statusConditionManager.failedToUpdateBrokersTriggersConfigMap(err),
+		))
 		return err
 	}
 	statusConditionManager.brokersTriggersConfigMapUpdated()
@@ -155,6 +158,9 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 
 	// Update volume generation annotation of receiver pods
 	if err := r.UpdateReceiverPodsAnnotation(logger, brokersTriggers.VolumeGeneration); err != nil {
+		logger.Error("Failed to update receiver pod annotation", zap.Error(
+			statusConditionManager.failedToUpdateReceiverPodsAnnotation(err),
+		))
 		return err
 	}
 

--- a/control-plane/pkg/reconciler/trigger/trigger.go
+++ b/control-plane/pkg/reconciler/trigger/trigger.go
@@ -273,6 +273,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, trigger *eventing.Trigge
 
 	// Update the configuration map with the new dataPlaneConfig data.
 	if err := r.UpdateDataPlaneConfigMap(dataPlaneConfig, dataPlaneConfigMap); err != nil {
+		trigger.Status.MarkDependencyFailed(string(brokerreconciler.ConditionConfigMapUpdated), err.Error())
 		return err
 	}
 


### PR DESCRIPTION
The PR https://github.com/knative-sandbox/eventing-kafka-broker/pull/156 raises an issue,
we don't update the Broker and Trigger status when there is a failure.

## Proposed Changes

- Update Broker and Trigger status when there is a failure

**Release Note**

```release-note
- 🐛 Fix bug 
Update Broker and Trigger status when there is a failure.
```