### PR TITLE
Check if data plane pods are running

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -88,6 +88,11 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 		Recorder:   controller.GetEventRecorder(ctx),
 	}
 
+	if !r.IsReceiverRunning() || !r.IsDispatcherRunning() {
+		return statusConditionManager.DataPlaneNotAvailable()
+	}
+	statusConditionManager.DataPlaneAvailable()
+
 	topicConfig, err := r.topicConfig(logger, broker)
 	if err != nil {
 		return statusConditionManager.FailedToResolveConfig(err)

--- a/control-plane/pkg/reconciler/broker/broker_test.go
+++ b/control-plane/pkg/reconciler/broker/broker_test.go
@@ -142,6 +142,7 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 					Object: NewBroker(
 						reconcilertesting.WithInitBrokerConditions,
 						BrokerConfigMapUpdatedReady(&configs),
+						BrokerDataPlaneAvailable,
 						BrokerConfigParsed,
 						BrokerTopicReady,
 						BrokerAddressable(&configs),
@@ -199,6 +200,7 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 						WithDelivery(),
 						reconcilertesting.WithInitBrokerConditions,
 						BrokerConfigMapUpdatedReady(&configs),
+						BrokerDataPlaneAvailable,
 						BrokerTopicReady,
 						BrokerConfigParsed,
 						BrokerAddressable(&configs),
@@ -213,6 +215,8 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 			Name: "Failed to create topic",
 			Objects: []runtime.Object{
 				NewBroker(),
+				BrokerReceiverPod(configs.SystemNamespace, nil),
+				BrokerDispatcherPod(configs.SystemNamespace, nil),
 			},
 			Key:     testKey,
 			WantErr: true,
@@ -232,6 +236,7 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 				{
 					Object: NewBroker(
 						reconcilertesting.WithInitBrokerConditions,
+						BrokerDataPlaneAvailable,
 						BrokerConfigParsed,
 						BrokerFailedToCreateTopic,
 					),
@@ -294,8 +299,9 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 				{
 					Object: NewBroker(
 						WithDelivery(),
-						BrokerConfigParsed,
 						reconcilertesting.WithInitBrokerConditions,
+						BrokerConfigParsed,
+						BrokerDataPlaneAvailable,
 						BrokerConfigMapUpdatedReady(&configs),
 						BrokerTopicReady,
 						BrokerAddressable(&configs),
@@ -348,6 +354,7 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 				{
 					Object: NewBroker(
 						reconcilertesting.WithInitBrokerConditions,
+						BrokerDataPlaneAvailable,
 						BrokerConfigMapUpdatedReady(&configs),
 						BrokerConfigParsed,
 						BrokerTopicReady,
@@ -428,6 +435,7 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 				{
 					Object: NewBroker(
 						reconcilertesting.WithInitBrokerConditions,
+						BrokerDataPlaneAvailable,
 						BrokerConfigMapUpdatedReady(&configs),
 						BrokerConfigParsed,
 						BrokerTopicReady,
@@ -524,6 +532,7 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 							}
 						},
 						reconcilertesting.WithInitBrokerConditions,
+						BrokerDataPlaneAvailable,
 						BrokerConfigMapUpdatedReady(&configs),
 						BrokerConfigParsed,
 						BrokerTopicReady,
@@ -607,6 +616,7 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 							broker.Spec.Delivery = &eventingduck.DeliverySpec{}
 						},
 						reconcilertesting.WithInitBrokerConditions,
+						BrokerDataPlaneAvailable,
 						BrokerConfigMapUpdatedReady(&configs),
 						BrokerConfigParsed,
 						BrokerTopicReady,
@@ -683,6 +693,7 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 				{
 					Object: NewBroker(
 						reconcilertesting.WithInitBrokerConditions,
+						BrokerDataPlaneAvailable,
 						BrokerConfigMapUpdatedReady(&configs),
 						BrokerConfigParsed,
 						BrokerTopicReady,
@@ -752,6 +763,7 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 							}
 						},
 						reconcilertesting.WithInitBrokerConditions,
+						BrokerDataPlaneAvailable,
 						BrokerConfigParsed,
 						BrokerTopicReady,
 					),
@@ -769,6 +781,8 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 					Brokers:          []*coreconfig.Broker{},
 					VolumeGeneration: 1,
 				}, &configs),
+				BrokerReceiverPod(configs.SystemNamespace, nil),
+				BrokerDispatcherPod(configs.SystemNamespace, nil),
 			},
 			Key:     testKey,
 			WantErr: true,
@@ -787,6 +801,7 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 				{
 					Object: NewBroker(
 						reconcilertesting.WithInitBrokerConditions,
+						BrokerDataPlaneAvailable,
 						BrokerConfigNotParsed("no bootstrap.servers provided"),
 					),
 				},
@@ -849,6 +864,7 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 						),
 						reconcilertesting.WithInitBrokerConditions,
 						BrokerConfigMapUpdatedReady(&configs),
+						BrokerDataPlaneAvailable,
 						BrokerConfigParsed,
 						BrokerTopicReady,
 						BrokerAddressable(&configs),
@@ -871,6 +887,8 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 						KReference(BrokerConfig(bootstrapServers, 20, 5)),
 					),
 				),
+				BrokerReceiverPod(configs.SystemNamespace, nil),
+				BrokerDispatcherPod(configs.SystemNamespace, nil),
 			},
 			Key:     testKey,
 			WantErr: true,
@@ -892,6 +910,7 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 							KReference(BrokerConfig(bootstrapServers, 20, 5)),
 						),
 						reconcilertesting.WithInitBrokerConditions,
+						BrokerDataPlaneAvailable,
 						BrokerConfigNotParsed(fmt.Sprintf(`failed to get configmap %s/%s: configmap %q not found`, ConfigMapNamespace, ConfigMapName, ConfigMapName)),
 					),
 				},
@@ -921,6 +940,8 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 						Name:      BrokerName,
 					},
 				},
+				BrokerReceiverPod(configs.SystemNamespace, nil),
+				BrokerDispatcherPod(configs.SystemNamespace, nil),
 			},
 			Key:     testKey,
 			WantErr: true,
@@ -945,6 +966,7 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 							APIVersion: "v1",
 						}),
 						reconcilertesting.WithInitBrokerConditions,
+						BrokerDataPlaneAvailable,
 						BrokerConfigNotParsed(`supported config Kind: ConfigMap - got Pod`),
 					),
 				},
@@ -1049,6 +1071,7 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 				{
 					Object: NewBroker(
 						reconcilertesting.WithInitBrokerConditions,
+						BrokerDataPlaneAvailable,
 						BrokerConfigMapUpdatedReady(&configs),
 						BrokerConfigParsed,
 						BrokerTopicReady,
@@ -1058,6 +1081,33 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 			},
 			OtherTestData: map[string]interface{}{
 				BootstrapServersConfigMapKey: bootstrapServers,
+			},
+		},
+		{
+			Name: "no data plane pods running",
+			Objects: []runtime.Object{
+				NewBroker(),
+			},
+			Key:     testKey,
+			WantErr: true,
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+				Eventf(
+					corev1.EventTypeWarning,
+					"InternalError",
+					fmt.Sprintf("%s: %s", base.ReasonDataPlaneNotAvailable, base.MessageDataPlaneNotAvailable),
+				),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: NewBroker(
+						reconcilertesting.WithInitBrokerConditions,
+						BrokerDataPlaneNotAvailable,
+					),
+				},
 			},
 		},
 	}

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -65,6 +65,11 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 		Recorder:   controller.GetEventRecorder(ctx),
 	}
 
+	if !r.IsReceiverRunning() {
+		return statusConditionManager.DataPlaneNotAvailable()
+	}
+	statusConditionManager.DataPlaneAvailable()
+
 	if ks.Spec.NumPartitions != nil && ks.Spec.ReplicationFactor != nil {
 		topicConfig := &kafka.TopicConfig{
 			TopicDetail: sarama.TopicDetail{

--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -147,6 +147,18 @@ func BrokerTopicReady(broker *eventing.Broker) {
 	)
 }
 
+func BrokerDataPlaneAvailable(broker *eventing.Broker) {
+	broker.GetConditionSet().Manage(broker.GetStatus()).MarkTrue(base.ConditionDataPlaneAvailable)
+}
+
+func BrokerDataPlaneNotAvailable(broker *eventing.Broker) {
+	broker.GetConditionSet().Manage(broker.GetStatus()).MarkFalse(
+		base.ConditionDataPlaneAvailable,
+		base.ReasonDataPlaneNotAvailable,
+		base.MessageDataPlaneNotAvailable,
+	)
+}
+
 func BrokerConfigParsed(broker *eventing.Broker) {
 	broker.GetConditionSet().Manage(broker.GetStatus()).MarkTrue(base.ConditionConfigParsed)
 }
@@ -212,6 +224,9 @@ func BrokerDispatcherPod(namespace string, annotations map[string]string) runtim
 				"app": base.BrokerDispatcherLabel,
 			},
 		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
 	}
 }
 
@@ -228,6 +243,9 @@ func BrokerReceiverPod(namespace string, annotations map[string]string) runtime.
 			Labels: map[string]string{
 				"app": base.BrokerReceiverLabel,
 			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
 		},
 	}
 }

--- a/control-plane/pkg/reconciler/testing/objects_sink.go
+++ b/control-plane/pkg/reconciler/testing/objects_sink.go
@@ -117,6 +117,18 @@ func SinkTopicReady(sink *eventing.KafkaSink) {
 	SinkTopicReadyWithName(SinkTopic())(sink)
 }
 
+func SinkDataPlaneAvailable(sink *eventing.KafkaSink) {
+	sink.GetConditionSet().Manage(sink.GetStatus()).MarkTrue(base.ConditionDataPlaneAvailable)
+}
+
+func SinkDataPlaneNotAvailable(sink *eventing.KafkaSink) {
+	sink.GetConditionSet().Manage(sink.GetStatus()).MarkFalse(
+		base.ConditionDataPlaneAvailable,
+		base.ReasonDataPlaneNotAvailable,
+		base.MessageDataPlaneNotAvailable,
+	)
+}
+
 func SinkAddressable(configs *config.Env) func(sink *eventing.KafkaSink) {
 
 	return func(sink *eventing.KafkaSink) {
@@ -171,6 +183,9 @@ func SinkReceiverPod(namespace string, annotations map[string]string) runtime.Ob
 			Labels: map[string]string{
 				"app": base.SinkReceiverLabel,
 			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
 		},
 	}
 }


### PR DESCRIPTION
Part of https://github.com/knative-sandbox/eventing-kafka-broker/issues/160

Since we're splitting the installation of the control plane and the
data plane to allow installing the Broker or the KafkaSink, we need
to make sure that the respective data plane is running, so check
is at least one pod of the data plane is running and reflect that
in the status.
The check is performed using a lister so the information might be
stale, but this allows avoid performing an API call against the
API server.

## Proposed Changes

- Check if data plane pods are running