### PR TITLE
Add Webhook RBAC configuration

### DIFF
--- a/control-plane/config/sink/100-webhook-cluster-role.yaml
+++ b/control-plane/config/sink/100-webhook-cluster-role.yaml
@@ -1,0 +1,89 @@
+---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kafka-webhook-eventing
+  labels:
+    eventing.knative.dev/release: devel
+rules:
+  # For watching logging configuration and getting certs.
+  - apiGroups:
+      - ""
+    resources:
+      - "configmaps"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+
+  # For manipulating certs into secrets.
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+      - "namespaces"
+    verbs:
+      - "get"
+      - "create"
+      - "update"
+      - "list"
+      - "watch"
+      - "patch"
+
+  # For getting our Deployment so we can decorate with ownerref.
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+    verbs:
+      - "get"
+
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments/finalizers"
+    verbs:
+      - update
+
+  # For actually registering our webhook.
+  - apiGroups:
+      - "admissionregistration.k8s.io"
+    resources:
+      - "mutatingwebhookconfigurations"
+      - "validatingwebhookconfigurations"
+    verbs: &everything
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+
+  # For leader election
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - "leases"
+    verbs: *everything
+
+  # Necessary for conversion webhook. These are copied from the eventing (which are copied from serving)
+  # TODO: Do we really need all these permissions?
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: [ "customresourcedefinitions" ]
+    verbs: [ "get", "list", "create", "update", "delete", "patch", "watch" ]

--- a/control-plane/config/sink/100-webhook-service-account.yaml
+++ b/control-plane/config/sink/100-webhook-service-account.yaml
@@ -1,0 +1,23 @@
+---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kafka-webhook-eventing
+  namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: devel

--- a/control-plane/config/sink/200-webhook-cluster-role-binding.yaml
+++ b/control-plane/config/sink/200-webhook-cluster-role-binding.yaml
@@ -1,0 +1,31 @@
+---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kafka-webhook-eventing
+  labels:
+    contrib.eventing.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: kafka-webhook-eventing
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: kafka-webhook-eventing
+  apiGroup: rbac.authorization.k8s.io
+

--- a/control-plane/config/sink/500-webhook.yaml
+++ b/control-plane/config/sink/500-webhook.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: eventing-kafka-webhook
+  name: kafka-webhook-eventing
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
@@ -23,8 +23,8 @@ spec:
   replicas: 1
   selector:
     matchLabels: &labels
-      app: eventing-kafka-webhook
-      role: eventing-kafka-webhook
+      app: kafka-webhook-eventing
+      role: kafka-webhook-eventing
   template:
     metadata:
       labels: *labels
@@ -36,16 +36,16 @@ spec:
             - podAffinityTerm:
                 labelSelector:
                   matchLabels:
-                    app: eventing-kafka-webhook
+                    app: kafka-webhook-eventing
                 topologyKey: kubernetes.io/hostname
               weight: 100
 
-      serviceAccountName: eventing-kafka-webhook
+      serviceAccountName: kafka-webhook-eventing
       securityContext:
         runAsNonRoot: true
 
       containers:
-        - name: eventing-kafka-webhook
+        - name: kafka-webhook-eventing
           terminationMessagePolicy: FallbackToLogsOnError
 
           image: ko://knative.dev/eventing-kafka-broker/control-plane/cmd/webhook-kafka
@@ -68,7 +68,7 @@ spec:
             - name: METRICS_DOMAIN
               value: knative.dev/eventing
             - name: WEBHOOK_NAME
-              value: eventing-kafka-webhook
+              value: kafka-webhook-eventing
             - name: WEBHOOK_PORT
               value: "8443"
 
@@ -103,8 +103,8 @@ kind: Service
 metadata:
   labels:
     eventing.knative.dev/release: devel
-    role: eventing-kafka-webhook
-  name: eventing-kafka-webhook
+    role: kafka-webhook-eventing
+  name: kafka-webhook-eventing
   namespace: knative-eventing
 spec:
   ports:
@@ -112,4 +112,4 @@ spec:
       port: 443
       targetPort: 8443
   selector:
-    role: eventing-kafka-webhook
+    role: kafka-webhook-eventing


### PR DESCRIPTION
The Webhook deployment doesn't become ready since the
service account doesn't exist.

This PR adds a service account `kafka-webhook-eventing`
and assign it to the webhook deployment.

The name has the suffix `-eventing` to distinguish it from
the `eventing-contrib` webhook which is called `kafka-webhook`,
so that users can use both without problems.

## Proposed Changes

- Add Webhook RBAC configuration