### PR TITLE
Project pod name as env var in our deployments

### DIFF
--- a/control-plane/config/500-controller.yaml
+++ b/control-plane/config/500-controller.yaml
@@ -96,6 +96,10 @@ spec:
               value: config-observability
             - name: METRICS_DOMAIN
               value: knative.dev/eventing
+           - name: POD_NAME
+             valueFrom:
+               fieldRef:
+                 fieldPath: metadata.name
           ports:
             - containerPort: 9090
               name: metrics

--- a/control-plane/config/500-controller.yaml
+++ b/control-plane/config/500-controller.yaml
@@ -96,10 +96,10 @@ spec:
               value: config-observability
             - name: METRICS_DOMAIN
               value: knative.dev/eventing
-           - name: POD_NAME
-             valueFrom:
-               fieldRef:
-                 fieldPath: metadata.name
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           ports:
             - containerPort: 9090
               name: metrics

--- a/control-plane/config/sink/500-webhook.yaml
+++ b/control-plane/config/sink/500-webhook.yaml
@@ -71,6 +71,10 @@ spec:
               value: kafka-webhook-eventing
             - name: WEBHOOK_PORT
               value: "8443"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
 
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Fixes https://github.com/knative-sandbox/eventing-kafka-broker/issues/192

- https://github.com/knative/pkg/pull/1714

## Proposed Changes

- Project pod name as env var in our deployments