### PR TITLE
Log error on malformed event in response

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/http/IllegalResponseException.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/http/IllegalResponseException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.knative.eventing.kafka.broker.dispatcher.http;
+
+public class IllegalResponseException extends Exception {
+
+  public IllegalResponseException(String s) {
+    super(s);
+  }
+}


### PR DESCRIPTION
Fixes #194 

When a sink returns a non-event and a non-empty response there is no signal that
the event is malformed we just discard it, now we log the error.

## Proposed Changes

- Return a failed future when the response is a non-event and the response is non-empty.
