### PR TITLE
Don't reconcile Triggers we don't own

### DIFF
--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -54,11 +54,13 @@ func NewBroker(options ...reconcilertesting.BrokerOption) runtime.Object {
 		BrokerName,
 		BrokerNamespace,
 		append(
-			options,
-			reconcilertesting.WithBrokerClass(kafka.BrokerClass),
-			func(broker *eventing.Broker) {
-				broker.UID = BrokerUUID
+			[]reconcilertesting.BrokerOption{
+				reconcilertesting.WithBrokerClass(kafka.BrokerClass),
+				func(broker *eventing.Broker) {
+					broker.UID = BrokerUUID
+				},
 			},
+			options...,
 		)...,
 	)
 }

--- a/control-plane/pkg/reconciler/trigger/trigger_test.go
+++ b/control-plane/pkg/reconciler/trigger/trigger_test.go
@@ -1090,6 +1090,31 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 				},
 			},
 		},
+		{
+			Name: "Don't reconcile trigger associated with a broker with a different broker class",
+			Objects: []runtime.Object{
+				newTrigger(),
+				NewBroker(func(b *eventing.Broker) {
+					b.Annotations = map[string]string{
+						eventing.BrokerClassAnnotationKey: "MTChannelBasedBroker",
+					}
+				}),
+			},
+			Key: testKey,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: newTrigger(
+						reconcilertesting.WithInitTriggerConditions,
+					),
+				},
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+		},
 	}
 
 	for i := range table {


### PR DESCRIPTION
This PR adds a check to verify that the Trigger we're reconciling
is associated with a Broker with the annotation
`eventing.knative.dev/broker.class` set to `Kafka`.

Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>

Fixes #211 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Don't reconcile Triggers we don't own