### PR TITLE
Upload Codecov Java report

### DIFF
--- a/.github/workflows/knative-java-test.yaml
+++ b/.github/workflows/knative-java-test.yaml
@@ -60,4 +60,4 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./data-plane/target/jacoco/jacoco.xml
-          flags: unittests
+          flags: java-unittests

--- a/.github/workflows/knative-java-test.yaml
+++ b/.github/workflows/knative-java-test.yaml
@@ -1,0 +1,63 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is automagically synced here from github.com/knative-sandbox/.github
+# repo by knobots: https://github.com/mattmoor/knobots and will be overwritten.
+
+name: Test
+
+on:
+
+  push:
+    branches: [ 'master' ]
+
+  pull_request:
+    branches: [ 'master', 'release-*' ]
+
+jobs:
+
+  test:
+    name: Java Unit Tests
+    strategy:
+      matrix:
+        java-version: [ 14 ]
+        platform: [ ubuntu-latest ]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java-version }}
+
+      - name: Check for .codecov.yaml
+        id: codecov-enabled
+        uses: andstor/file-existence-action@v1
+        with:
+          files: .codecov.yaml
+
+      - if: steps.codecov-enabled.outputs.files_exists == 'true'
+        name: Java Test
+        run: mvn verify --file data-plane/pom.xml --no-transfer-progress
+
+      - if: steps.codecov-enabled.outputs.files_exists == 'true'
+        name: Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./data-plane/target/jacoco/jacoco.xml
+          flags: unittests


### PR DESCRIPTION
It's different from https://github.com/knative-sandbox/eventing-kafka-broker/pull/199 since in this one we upload reports in two different actions independently with two different flags.

## Proposed Changes

- Upload Codecov Java report