### PR TITLE
Use registry URL to reference container images

### DIFF
--- a/proto/hack/generate_proto
+++ b/proto/hack/generate_proto
@@ -10,7 +10,7 @@ CONTROL_PLANE_OUTPUT_DIR=./
 mkdir -p $DATA_PLANE_OUTPUT_DIR
 mkdir -p $CONTROL_PLANE_OUTPUT_DIR
 
-docker run --rm -v "${PWD}":"${PWD}" --security-opt label:disable -w "${PWD}" thethingsindustries/protoc:latest \
+docker run --rm -v "${PWD}":"${PWD}" --security-opt label:disable -w "${PWD}" docker.io/thethingsindustries/protoc:latest \
   --proto_path="${PWD}" \
   --java_out=$DATA_PLANE_OUTPUT_DIR \
   --go_out=$CONTROL_PLANE_OUTPUT_DIR \

--- a/test/data-plane/library.sh
+++ b/test/data-plane/library.sh
@@ -41,7 +41,7 @@ readonly receiver="${KNATIVE_KAFKA_BROKER_RECEIVER:-knative-kafka-broker-receive
 readonly dispatcher="${KNATIVE_KAFKA_BROKER_DISPATCHER:-knative-kafka-broker-dispatcher}"
 readonly sink="${KNATIVE_KAFKA_SINK_RECEIVER:-knative-kafka-sink-receiver}"
 
-readonly JAVA_IMAGE=adoptopenjdk:14-jre-hotspot
+readonly JAVA_IMAGE=docker.io/adoptopenjdk:14-jre-hotspot
 
 readonly RECEIVER_JAR="receiver-1.0-SNAPSHOT.jar"
 readonly RECEIVER_DIRECTORY=receiver


### PR DESCRIPTION
- Motivation: https://www.redhat.com/en/blog/be-careful-when-pulling-images-short-name

Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use registry URL to reference container images

