### PR TITLE
Remove strict flag

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -68,7 +68,7 @@ function knative_eventing() {
     popd || fail_test "Failed to set up Eventing"
   else
     echo ">> Install Knative Eventing from ${KNATIVE_EVENTING_RELEASE}"
-    kubectl apply --strict -f ${KNATIVE_EVENTING_RELEASE}
+    kubectl apply -f ${KNATIVE_EVENTING_RELEASE}
   fi
 
   # Publish test images.


### PR DESCRIPTION
- Release failed :sob: : https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-sandbox-eventing-kafka-broker-auto-release/1311005786016583680

```
>> Install Knative Eventing from https://storage.googleapis.com/knative-releases/eventing/previous/v0.18.0/eventing.yaml
Error: unknown flag: --strict
```

## Proposed Changes

- Remove strict flag
