### PR TITLE
Expose metrics defined by the spec in Prometheus format

### DIFF
--- a/data-plane/core/pom.xml
+++ b/data-plane/core/pom.xml
@@ -88,6 +88,11 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/MetricsOptionsProvider.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/MetricsOptionsProvider.java
@@ -28,11 +28,13 @@ public class MetricsOptionsProvider {
    * Get metrics options from the given metrics configurations.
    *
    * @param metricsConfigs metrics configurations.
+   * @param registry       registry name
    * @return metrics options
    */
-  public static MetricsOptions get(final BaseEnv metricsConfigs) {
+  public static MetricsOptions get(final BaseEnv metricsConfigs, final String registry) {
     return new MicrometerMetricsOptions()
       .setEnabled(true)
+      .setRegistryName(registry)
       .setPrometheusOptions(new VertxPrometheusOptions()
         .setEmbeddedServerOptions(new HttpServerOptions().setPort(metricsConfigs.getMetricsPort()))
         .setEmbeddedServerEndpoint(metricsConfigs.getMetricsPath())

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/metrics/MetricsOptionsProviderTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/metrics/MetricsOptionsProviderTest.java
@@ -17,15 +17,17 @@
 package dev.knative.eventing.kafka.broker.core.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import dev.knative.eventing.kafka.broker.core.utils.BaseEnv;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.Test;
 
 public class MetricsOptionsProviderTest {
 
   @Test
   public void get() {
-    final var metricsOptions = MetricsOptionsProvider.get(new BaseEnv(s -> "1"));
+    final var metricsOptions = MetricsOptionsProvider.get(new BaseEnv(s -> "1"), "name");
     assertThat(metricsOptions.isEnabled()).isTrue();
   }
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerRecordOffsetStrategyFactory.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerRecordOffsetStrategyFactory.java
@@ -19,6 +19,7 @@ package dev.knative.eventing.kafka.broker.dispatcher;
 import dev.knative.eventing.kafka.broker.core.Egress;
 import dev.knative.eventing.kafka.broker.core.Resource;
 import dev.knative.eventing.kafka.broker.dispatcher.strategy.UnorderedConsumerRecordOffsetStrategy;
+import io.micrometer.core.instrument.Counter;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 
 @FunctionalInterface
@@ -27,8 +28,8 @@ public interface ConsumerRecordOffsetStrategyFactory<K, V> {
   ConsumerRecordOffsetStrategy<K, V> get(final KafkaConsumer<K, V> consumer, final Resource resource,
                                          final Egress egress);
 
-  static <K, V> ConsumerRecordOffsetStrategyFactory<K, V> unordered() {
-    return (consumer, broker, trigger) -> new UnorderedConsumerRecordOffsetStrategy<>(consumer);
+  static <K, V> ConsumerRecordOffsetStrategyFactory<K, V> unordered(final Counter eventsSentCounter) {
+    return (consumer, broker, trigger) -> new UnorderedConsumerRecordOffsetStrategy<>(consumer, eventsSentCounter);
   }
 
 }

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerVerticleFactoryTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerVerticleFactoryTest.java
@@ -23,6 +23,7 @@ import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CL
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import dev.knative.eventing.kafka.broker.core.Egress;
@@ -33,6 +34,7 @@ import dev.knative.eventing.kafka.broker.dispatcher.ConsumerRecordOffsetStrategy
 import io.cloudevents.CloudEvent;
 import io.cloudevents.kafka.CloudEventDeserializer;
 import io.cloudevents.kafka.CloudEventSerializer;
+import io.micrometer.core.instrument.Counter;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
@@ -64,7 +66,7 @@ public class HttpConsumerVerticleFactoryTest {
       .setProperty(VALUE_SERIALIZER_CLASS_CONFIG, CloudEventSerializer.class.getName());
 
     final var verticleFactory = new HttpConsumerVerticleFactory(
-      ConsumerRecordOffsetStrategyFactory.unordered(),
+      ConsumerRecordOffsetStrategyFactory.unordered(mock(Counter.class)),
       consumerProperties,
       WebClient.create(vertx),
       vertx,
@@ -151,7 +153,7 @@ public class HttpConsumerVerticleFactoryTest {
       .setProperty(VALUE_SERIALIZER_CLASS_CONFIG, CloudEventSerializer.class.getName());
 
     final var verticleFactory = new HttpConsumerVerticleFactory(
-      ConsumerRecordOffsetStrategyFactory.unordered(),
+      ConsumerRecordOffsetStrategyFactory.unordered(mock(Counter.class)),
       consumerProperties,
       WebClient.create(vertx),
       vertx,

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/integration/UnorderedConsumerTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/integration/UnorderedConsumerTest.java
@@ -19,6 +19,7 @@ package dev.knative.eventing.kafka.broker.dispatcher.integration;
 import static dev.knative.eventing.kafka.broker.core.file.FileWatcherTest.write;
 import static dev.knative.eventing.kafka.broker.core.testing.utils.CoreObjects.contract;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import dev.knative.eventing.kafka.broker.core.ObjectsCreator;
@@ -31,6 +32,7 @@ import io.cloudevents.CloudEvent;
 import io.cloudevents.core.message.MessageReader;
 import io.cloudevents.core.v1.CloudEventBuilder;
 import io.cloudevents.http.vertx.VertxMessageFactory;
+import io.micrometer.core.instrument.Counter;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
@@ -69,7 +71,7 @@ public class UnorderedConsumerTest {
       client,
       vertx,
       producerConfigs,
-      ConsumerRecordOffsetStrategyFactory.unordered()
+      ConsumerRecordOffsetStrategyFactory.unordered(mock(Counter.class))
     );
 
     final var event = new CloudEventBuilder()

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/Main.java
@@ -27,6 +27,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.kafka.client.producer.KafkaProducer;
+import io.vertx.micrometer.backends.BackendRegistries;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystems;
@@ -37,6 +38,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Main {
+
+  // Micrometer employs a naming convention that separates lowercase words with a '.' (dot) character.
+  // Different monitoring systems have different recommendations regarding naming convention, and some naming
+  // conventions may be incompatible for one system and not another.
+  // Each Micrometer implementation for a monitoring system comes with a naming convention that transforms lowercase
+  // dot notation names to the monitoring system’s recommended naming convention.
+  // Additionally, this naming convention implementation sanitizes metric names and tags of special characters that
+  // are disallowed by the monitoring system.
+  public static final String HTTP_REQUESTS_MALFORMED_COUNT = "http.requests.malformed"; // prometheus format --> http_requests_malformed_total
+  public static final String HTTP_REQUESTS_PRODUCE_COUNT = "http.requests.produce";     // prometheus format --> http_requests_produce_total
+  public static final String METRICS_REGISTRY_NAME = "metrics";
 
   private static final Logger logger = LoggerFactory.getLogger(Main.class);
 
@@ -60,15 +72,22 @@ public class Main {
     logger.info("Starting Receiver {}", keyValue("env", env));
 
     final var vertx = Vertx.vertx(
-      new VertxOptions().setMetricsOptions(MetricsOptionsProvider.get(env))
+      new VertxOptions().setMetricsOptions(MetricsOptionsProvider.get(env, METRICS_REGISTRY_NAME))
     );
+
+    final var metricsRegistry = BackendRegistries.getNow(METRICS_REGISTRY_NAME);
+
+    final var badRequestCounter = metricsRegistry.counter(HTTP_REQUESTS_MALFORMED_COUNT);
+    final var produceEventsCounter = metricsRegistry.counter(HTTP_REQUESTS_PRODUCE_COUNT);
 
     producerConfigs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, CloudEventSerializer.class);
     producerConfigs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     final var handler = new RequestHandler<>(
       producerConfigs,
       new CloudEventRequestToRecordMapper(),
-      properties -> KafkaProducer.create(vertx, properties)
+      properties -> KafkaProducer.create(vertx, properties),
+      badRequestCounter,
+      produceEventsCounter
     );
 
     final var httpServerOptions = new HttpServerOptions(

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/RequestHandlerTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/RequestHandlerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import dev.knative.eventing.kafka.broker.core.ResourceWrapper;
+import io.micrometer.core.instrument.Counter;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -88,8 +89,9 @@ public class RequestHandlerTest {
     final var handler = new RequestHandler<>(
       new Properties(),
       mapper,
-      properties -> producer
-    );
+      properties -> producer,
+      mock(Counter.class),
+      mock(Counter.class));
 
     final var countDown = new CountDownLatch(1);
 
@@ -121,8 +123,9 @@ public class RequestHandlerTest {
     final var handler = new RequestHandler<Object, Object>(
       new Properties(),
       mapper,
-      properties -> producer
-    );
+      properties -> producer,
+      mock(Counter.class),
+      mock(Counter.class));
 
     final var countDown = new CountDownLatch(1);
     handler.reconcile(Map.of(resource, new HashSet<>()))
@@ -172,8 +175,9 @@ public class RequestHandlerTest {
           recreated.set(true);
         }
         return mock(KafkaProducer.class);
-      }
-    );
+      },
+      mock(Counter.class),
+      mock(Counter.class));
 
     final var checkpoint = context.checkpoint();
 
@@ -219,8 +223,9 @@ public class RequestHandlerTest {
           context.failNow(new IllegalStateException("producer should be recreated"));
         }
         return mock(KafkaProducer.class);
-      }
-    );
+      },
+      mock(Counter.class),
+      mock(Counter.class));
 
     final var checkpoint = context.checkpoint();
 


### PR DESCRIPTION
This PR exposes the following metrics:
1. http_events_sent_total
2. http_requests_produce_total
3. http_requests_malformed_total

All of the above metrics are counters.

(1) is incremented when the dispatcher commits the offset to Kafka.
(2) is incremented when the receiver sends successfully the message to Kafka.
(3) is incremented when the receiver receives a malformed event.

Signed-off-by Pierangelo Di Pilato <pierangelodipilato@gmail.com>

Fixes #227

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Expose metrics defined by the spec in Prometheus format

## Prometheus Dashboard

![image](https://user-images.githubusercontent.com/33736985/94724008-e42c1900-0359-11eb-8c70-ce91b630e45c.png)

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🎁 Add new feature
The receiver component exposes:
  - http_requests_produce_total - Number of accepted produce requests (200-level responses)
  - http_requests_malformed_total - Number of malformed produce requests (400-level responses)
The dispatcher component exposes:
  - http_events_sent_total - Number of events delivered
```