### PR TITLE
Add Retry Config to EgressConfig during broker reconciliation

### DIFF
--- a/control-plane/config/500-controller.yaml
+++ b/control-plane/config/500-controller.yaml
@@ -86,6 +86,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: BROKER_DEFAULT_BACKOFF_DELAY
+              value: "PT1S"
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/control-plane/pkg/config/env_config.go
+++ b/control-plane/pkg/config/env_config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/kelseyhightower/envconfig"
+	"github.com/rickb777/date/period"
 )
 
 type Env struct {
@@ -29,6 +30,7 @@ type Env struct {
 	IngressName                 string `required:"true" split_words:"true"`
 	SystemNamespace             string `required:"true" split_words:"true"`
 	DataPlaneConfigFormat       string `required:"true" split_words:"true"`
+	DefaultBackoffDelay         string `required:"false" split_words:"true"`
 }
 
 func GetEnvConfig(prefix string) (*Env, error) {
@@ -38,9 +40,20 @@ func GetEnvConfig(prefix string) (*Env, error) {
 		return nil, fmt.Errorf("failed to process env config: %w", err)
 	}
 
+	if env.DefaultBackoffDelay != "" {
+		if isNotValidBackoffDelay(env.DefaultBackoffDelay) {
+			return nil, fmt.Errorf("invalid backoff delay: %s", env.DefaultBackoffDelay)
+		}
+	}
+
 	return env, nil
 }
 
 func (c *Env) DataPlaneConfigMapAsString() string {
 	return fmt.Sprintf("%s/%s", c.DataPlaneConfigMapNamespace, c.DataPlaneConfigMapName)
+}
+
+func isNotValidBackoffDelay(delay string) bool {
+	_, err := period.Parse(delay)
+	return err != nil
 }

--- a/control-plane/pkg/config/env_config_test.go
+++ b/control-plane/pkg/config/env_config_test.go
@@ -78,6 +78,22 @@ func TestGetEnvConfig(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "invalid backoff delay",
+			args: args{
+				prefix: "BROKER",
+			},
+			setEnv: func() {
+				_ = os.Setenv("BROKER_DATA_PLANE_CONFIG_MAP_NAMESPACE", "knative-eventing")
+				_ = os.Setenv("BROKER_DATA_PLANE_CONFIG_MAP_NAME", "kafka-brokers-triggers")
+				_ = os.Setenv("BROKER_GENERAL_CONFIG_MAP_NAME", "kafka-config")
+				_ = os.Setenv("BROKER_INGRESS_NAME", "kafka-broker-ingress")
+				_ = os.Setenv("BROKER_SYSTEM_NAMESPACE", "knative-eventing")
+				_ = os.Setenv("BROKER_DATA_PLANE_CONFIG_FORMAT", "json")
+				_ = os.Setenv("BROKER_DEFAULT_BACKOFF_DELAY", "PTT")
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/control-plane/pkg/core/config/utils.go
+++ b/control-plane/pkg/core/config/utils.go
@@ -19,6 +19,8 @@ package config
 import (
 	"fmt"
 
+	duck "knative.dev/eventing/pkg/apis/duck/v1"
+
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
 
 	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
@@ -38,4 +40,34 @@ func ContentModeFromString(mode string) contract.ContentMode {
 			[]string{eventing.ModeStructured, eventing.ModeBinary},
 		))
 	}
+}
+
+// BackoffPolicyFromString returns the BackoffPolicy from the given string.
+//
+// Default value is contract.BackoffPolicy_Exponential.
+func BackoffPolicyFromString(backoffPolicy *duck.BackoffPolicyType) contract.BackoffPolicy {
+	if backoffPolicy == nil {
+		return contract.BackoffPolicy_Exponential
+	}
+
+	bp := *backoffPolicy
+	switch bp {
+	case duck.BackoffPolicyLinear:
+		return contract.BackoffPolicy_Linear
+	case duck.BackoffPolicyExponential: // The linter complains for missing case in switch
+		return contract.BackoffPolicy_Exponential
+	default:
+		return contract.BackoffPolicy_Exponential
+	}
+}
+
+// BackoffDelayFromString returns the BackoffDelay from the given string.
+//
+// Default value is the specified defaultDelay.
+func BackoffDelayFromString(backoffDelay *string, defaultDelay string) string {
+	if backoffDelay == nil {
+		return defaultDelay
+	}
+
+	return *backoffDelay
 }

--- a/control-plane/pkg/core/config/utils_test.go
+++ b/control-plane/pkg/core/config/utils_test.go
@@ -19,6 +19,9 @@ package config
 import (
 	"testing"
 
+	"k8s.io/utils/pointer"
+	duck "knative.dev/eventing/pkg/apis/duck/v1"
+
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
 
 	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
@@ -52,6 +55,74 @@ func TestContentModeFromString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ContentModeFromString(tt.args.mode); got != tt.want {
 				t.Errorf("ContentModeFromString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBackoffPolicyFromString(t *testing.T) {
+	linerar := duck.BackoffPolicyLinear
+	exponential := duck.BackoffPolicyExponential
+	wrong := duck.BackoffPolicyType("default")
+	tests := []struct {
+		name          string
+		backoffPolicy *duck.BackoffPolicyType
+		want          contract.BackoffPolicy
+	}{
+		{
+			name:          "nil",
+			backoffPolicy: nil,
+			want:          contract.BackoffPolicy_Exponential,
+		},
+		{
+			name:          "exponential",
+			backoffPolicy: &exponential,
+			want:          contract.BackoffPolicy_Exponential,
+		},
+		{
+			name:          "linear",
+			backoffPolicy: &linerar,
+			want:          contract.BackoffPolicy_Linear,
+		},
+		{
+			name:          "default",
+			backoffPolicy: &wrong,
+			want:          contract.BackoffPolicy_Exponential,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BackoffPolicyFromString(tt.backoffPolicy); got != tt.want {
+				t.Errorf("BackoffPolicyFromString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBackoffDelayFromString(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		backoffDelay *string
+		defaultDelay string
+		want         string
+	}{
+		{
+			name:         "happy case",
+			backoffDelay: pointer.StringPtr("PT2S"),
+			defaultDelay: "PT1S",
+			want:         "PT2S",
+		},
+		{
+			name:         "default",
+			defaultDelay: "PT1S",
+			want:         "PT1S",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BackoffDelayFromString(tt.backoffDelay, tt.defaultDelay); got != tt.want {
+				t.Errorf("BackoffDelayFromString() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/control-plane/pkg/reconciler/testing/factory.go
+++ b/control-plane/pkg/reconciler/testing/factory.go
@@ -50,11 +50,12 @@ const (
 var DefaultConfigs = &broker.Configs{
 
 	Env: config.Env{
-		DataPlaneConfigMapName:      "kafka-broker-brokers-triggers",
 		DataPlaneConfigMapNamespace: "knative-eventing",
+		DataPlaneConfigMapName:      "kafka-broker-brokers-triggers",
 		IngressName:                 "kafka-broker-receiver",
 		SystemNamespace:             "knative-eventing",
 		DataPlaneConfigFormat:       base.Json,
+		DefaultBackoffDelay:         "PT1S",
 	},
 
 	BootstrapServers: "",

--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -80,16 +80,28 @@ func WithDelivery() func(*eventing.Broker) {
 	service := NewService()
 
 	return func(broker *eventing.Broker) {
-		broker.Spec.Delivery = &eventingduck.DeliverySpec{
-			DeadLetterSink: &duckv1.Destination{
-				Ref: &duckv1.KReference{
-					Kind:       service.Kind,
-					Namespace:  service.Namespace,
-					Name:       service.Name,
-					APIVersion: service.APIVersion,
-				},
+		if broker.Spec.Delivery == nil {
+			broker.Spec.Delivery = &eventingduck.DeliverySpec{}
+		}
+		broker.Spec.Delivery.DeadLetterSink = &duckv1.Destination{
+			Ref: &duckv1.KReference{
+				Kind:       service.Kind,
+				Namespace:  service.Namespace,
+				Name:       service.Name,
+				APIVersion: service.APIVersion,
 			},
 		}
+	}
+}
+
+func WithRetry(retry *int32, policy *eventingduck.BackoffPolicyType, delay *string) func(*eventing.Broker) {
+	return func(broker *eventing.Broker) {
+		if broker.Spec.Delivery == nil {
+			broker.Spec.Delivery = &eventingduck.DeliverySpec{}
+		}
+		broker.Spec.Delivery.Retry = retry
+		broker.Spec.Delivery.BackoffPolicy = policy
+		broker.Spec.Delivery.BackoffDelay = delay
 	}
 }
 

--- a/data-plane/config/template/500-dispatcher.yaml
+++ b/data-plane/config/template/500-dispatcher.yaml
@@ -87,6 +87,26 @@ spec:
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              port: 9090
+              path: /metrics
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              port: 9090
+              path: /metrics
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 1
           terminationMessagePolicy: FallbackToLogsOnError
           terminationMessagePath: /dev/temination-log
           securityContext:
@@ -101,7 +121,7 @@ spec:
           configMap:
             name: kafka-broker-brokers-triggers
         - name: cache
-          emptyDir: {}
+          emptyDir: { }
         - name: kafka-broker-config-logging
           configMap:
             name: kafka-config-logging

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/rickb777/date v1.13.0
 	github.com/stretchr/testify v1.6.0
 	go.uber.org/zap v1.15.0
 	google.golang.org/protobuf v1.25.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -281,6 +281,7 @@ github.com/prometheus/statsd_exporter/pkg/mapper/fsm
 # github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
 github.com/rcrowley/go-metrics
 # github.com/rickb777/date v1.13.0
+## explicit
 github.com/rickb777/date/period
 # github.com/rickb777/plural v1.2.1
 github.com/rickb777/plural


### PR DESCRIPTION
Part of #116

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add Retry Config to EgressConfig during broker reconciler

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🧽 Update or clean up current behavior
The control plane sends retry configurations to the data plane.
```