### PR TITLE
Removed `java.compiler` from used jmods

### DIFF
--- a/data-plane/docker/generate_jdk.sh
+++ b/data-plane/docker/generate_jdk.sh
@@ -10,7 +10,7 @@ MODS=$(jdeps -q --print-module-deps --ignore-missing-deps "$1")
 echo "Computed mods = '$MODS'"
 
 # Remove compiler, sql, management modules
-MODS=$(echo $MODS | tr , '\n' | sed '/^java.compiler/d' | sed '/^java.sql/d' | sed '/^jdk.management/d' | sed -z 's/\n/,/g;s/,$/\n/')
+MODS=$(echo $MODS | tr , '\n' | sed '/^java.compiler/d' | sed '/^jdk.management/d' | sed -z 's/\n/,/g;s/,$/\n/')
 # Patch adding the dns
 MODS="$MODS,jdk.naming.dns"
 

--- a/data-plane/docker/generate_jdk.sh
+++ b/data-plane/docker/generate_jdk.sh
@@ -6,10 +6,11 @@ if [ $# -eq 0 ]
 fi
 
 echo "Computing mods for $1"
-MODS=$(jdeps -q --print-module-deps --ignore-missing-deps "$1" | sed -e 's/^[ \t]*//')
-
+MODS=$(jdeps -q --print-module-deps --ignore-missing-deps "$1")
 echo "Computed mods = '$MODS'"
 
+# Remove compiler, sql, management modules
+MODS=$(echo $MODS | tr , '\n' | sed '/^java.compiler/d' | sed '/^java.sql/d' | sed '/^jdk.management/d' | sed -z 's/\n/,/g;s/,$/\n/')
 # Patch adding the dns
 MODS="$MODS,jdk.naming.dns"
 

--- a/data-plane/docker/generate_jdk.sh
+++ b/data-plane/docker/generate_jdk.sh
@@ -10,7 +10,7 @@ MODS=$(jdeps -q --print-module-deps --ignore-missing-deps "$1")
 echo "Computed mods = '$MODS'"
 
 # Remove compiler, sql, management modules
-MODS=$(echo $MODS | tr , '\n' | sed '/^java.compiler/d' | sed '/^jdk.management/d' | sed -z 's/\n/,/g;s/,$/\n/')
+MODS=$(echo $MODS | tr , '\n' | sed '/^java.compiler/d' | sed -z 's/\n/,/g;s/,$/\n/')
 # Patch adding the dns
 MODS="$MODS,jdk.naming.dns"
 


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Followup of #265, part of #267

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Removed jmods we probably don't need
  * `java.compiler` contains the compiler types. It's brought in by Guava and Vert.x CLI feature. we don't use the Vert.x Cli feature, so we don't need this
