### PR TITLE
Remove config-logging volume and add server config for the sink

### DIFF
--- a/control-plane/config/500-controller.yaml
+++ b/control-plane/config/500-controller.yaml
@@ -53,10 +53,6 @@ spec:
         - name: controller
           image: ko://knative.dev/eventing-kafka-broker/control-plane/cmd/kafka-controller
           imagePullPolicy: IfNotPresent
-          volumeMounts:
-            - name: config-logging
-              mountPath: /etc/config-logging
-              readOnly: true
           env:
             - name: BROKER_DATA_PLANE_CONFIG_MAP_NAMESPACE
               value: knative-eventing
@@ -111,8 +107,4 @@ spec:
             allowPrivilegeEscalation: false
             privileged: false
             readOnlyRootFilesystem: true
-      volumes:
-        - name: config-logging
-          configMap:
-            name: config-logging
       restartPolicy: Always

--- a/data-plane/config/sink/100-config-kafka-sink-data-plane.yaml
+++ b/data-plane/config/sink/100-config-kafka-sink-data-plane.yaml
@@ -20,7 +20,7 @@ metadata:
   name: config-kafka-sink-data-plane
   namespace: knative-eventing
 data:
-  config-kafka-broker-producer.properties: |
+  config-kafka-sink-producer.properties: |
     acks=1
     buffer.memory=33554432
     # compression.type=snappy
@@ -49,3 +49,5 @@ data:
     retry.backoff.ms=100
     # transaction.timeout.ms=60000
     # transactional.id=null
+  config-kafka-sink-httpserver.properties: |
+    idleTimeout=0

--- a/data-plane/config/sink/template/500-receiver.yaml
+++ b/data-plane/config/sink/template/500-receiver.yaml
@@ -64,9 +64,9 @@ spec:
             - name: INGRESS_PORT
               value: "8080"
             - name: PRODUCER_CONFIG_FILE_PATH
-              value: /etc/config/config-kafka-broker-producer.properties
+              value: /etc/config/config-kafka-sink-producer.properties
             - name: HTTPSERVER_CONFIG_FILE_PATH
-              value: /etc/config/config-kafka-broker-httpserver.properties
+              value: /etc/config/config-kafka-sink-httpserver.properties
             - name: DATA_PLANE_CONFIG_FILE_PATH
               value: /etc/sinks/data
             - name: LIVENESS_PROBE_PATH


### PR DESCRIPTION
The `config-logging` volume mount isn't necessary.

Fixes #287 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove config-logging volume and add server config for the sink

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🧽 Update or clean up current behavior
Remove config-logging volume from the controller
```
