### PR TITLE
Reduce container images size

### DIFF
--- a/data-plane/config/sink/template/500-receiver.yaml
+++ b/data-plane/config/sink/template/500-receiver.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 999
+        runAsUser: 65532
       containers:
         - name: kafka-sink-receiver
           image: ${KNATIVE_KAFKA_SINK_RECEIVER_IMAGE}

--- a/data-plane/config/template/500-dispatcher.yaml
+++ b/data-plane/config/template/500-dispatcher.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 999
+        runAsUser: 65532
       containers:
         - name: kafka-broker-dispatcher
           image: ${KNATIVE_KAFKA_BROKER_DISPATCHER_IMAGE}

--- a/data-plane/config/template/500-receiver.yaml
+++ b/data-plane/config/template/500-receiver.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 999
+        runAsUser: 65532
       containers:
         - name: kafka-broker-receiver
           image: ${KNATIVE_KAFKA_BROKER_RECEIVER_IMAGE}

--- a/data-plane/docker/Dockerfile
+++ b/data-plane/docker/Dockerfile
@@ -20,7 +20,7 @@ FROM ${JAVA_IMAGE} as builder
 ARG APP_DIR
 ARG APP_JAR
 
-WORKDIR /app
+WORKDIR /build
 
 # https://github.com/AdoptOpenJDK/openjdk-docker/issues/260
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y binutils
@@ -42,24 +42,13 @@ COPY . .
 
 RUN ./mvnw package -pl=${APP_DIR} -am -DskipTests -Deditorconfig.skip --no-transfer-progress
 
-RUN ./generate_jdk.sh /app/${APP_DIR}/target/${APP_JAR}
+RUN ./generate_jdk.sh /build/${APP_DIR}/target/${APP_JAR}
+
+RUN cp /build/${APP_DIR}/target/${APP_JAR} /app/app.jar
 
 FROM ${BASE_IMAGE} as running
 
-ARG APP_DIR
-ARG APP_JAR
+COPY --from=builder /app /app
 
-# Create appuser and directories
-RUN groupadd -g 999 appuser && useradd -r -u 999 -g appuser appuser && \
-  mkdir /tmp/vertx-cache && chown -R appuser:appuser /tmp/vertx-cache && \
-  mkdir /app
-
-# Copy jar and jdk inside /app
-COPY --from=builder /app/jdk /app/jdk
-COPY --from=builder /app/${APP_DIR}/target/${APP_JAR} /app/app.jar
-RUN chown -R appuser:appuser /app
-
-# Set appuser and configure PATH
-USER appuser
-WORKDIR /app
+# Configure PATH
 ENV PATH="/app/jdk/bin:${PATH}"

--- a/test/data-plane/library.sh
+++ b/test/data-plane/library.sh
@@ -41,11 +41,10 @@ readonly receiver="${KNATIVE_KAFKA_BROKER_RECEIVER:-knative-kafka-broker-receive
 readonly dispatcher="${KNATIVE_KAFKA_BROKER_DISPATCHER:-knative-kafka-broker-dispatcher}"
 readonly sink="${KNATIVE_KAFKA_SINK_RECEIVER:-knative-kafka-sink-receiver}"
 
-# The BASE_IMAGE for the running image should be based on the same base of JAVA_IMAGE
-# because jlink generates a jdk linked to the libc available on the local machine
-# adoptopenjdk uses ubuntu:bionic as base
-readonly JAVA_IMAGE=docker.io/adoptopenjdk:14-jdk-hotspot
-readonly BASE_IMAGE=docker.io/ubuntu:bionic
+# The BASE_IMAGE must have system libraries (libc, zlib, etc) compatible with the JAVA_IMAGE because
+# Jlink generates a jdk linked to the same system libraries available on the base images.
+readonly BASE_IMAGE=gcr.io/distroless/java-debian10:base-nonroot    # Based on debian:buster
+readonly JAVA_IMAGE=docker.io/adoptopenjdk/openjdk14:debian         # Based on debian:buster
 
 readonly RECEIVER_JAR="receiver-1.0-SNAPSHOT.jar"
 readonly RECEIVER_DIRECTORY=receiver


### PR DESCRIPTION
This PR reduces the container image's sizes from `187MB` to `90MB +- 1MB`.

I worked with the [distroless community](https://github.com/GoogleContainerTools/distroless) to build non-root Java images,
the base image contains only system libraries (`glibc`, `zlib`, etc) and 
it runs as non-root, uid: `65532`.

- Base image size: ~30MB.
- Jar and the custom Java environment size: ~60MB.

Layers:
```
sha256:3041eb8028850a81494bb10b0843ae7a0822578bba3901b90dc63557f9437e9d   2 minutes ago       /bin/sh -c #(nop)  ENV PATH=/app/jdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin   0B                  
sha256:4ff88c0b75a38046f0c99c15333b31dd35de4b69328c981e368d2a92ded5cc20   2 minutes ago       /bin/sh -c #(nop) WORKDIR /app                                                                          0B                  
sha256:fa682947dcbf8b3ed768fe42c6f7e5660423385a69002145ac287d6e486c0fe8   2 minutes ago       /bin/sh -c #(nop) COPY dir:e92f937cea101df7dc902550b122be947360f8bec413e3b503f595dbedd5912e in /app     59.9MB              
sha256:a92e78c22ba509a04f3eb070f0b6978559d75fee91ad79b6f5e6fc5ab75bca6f   50 years ago        bazel build ...                                                                                         8.64MB              
<missing>                                                                 50 years ago        bazel build ...                                                                                         1.97MB              
<missing>                                                                 50 years ago        bazel build ...                                                                                         17.4MB              
<missing>                                                                 50 years ago        bazel build ...                                                                                         1.8MB               
```

Fixes #267 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Reduce container image sizes

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🧽 Improvements
The container image's sizes are ~90MB instead of ~287MB.
```

<!--
/cc matzew slinkydeveloper 
-->