### PR TITLE
Change logging during e2e tests

### DIFF
--- a/test/pkg/config/100-config-logging.yaml
+++ b/test/pkg/config/100-config-logging.yaml
@@ -25,7 +25,10 @@ data:
       <appender name="jsonConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
       </appender>
-      <root level="DEBUG">
+      <logger name="dev.knative" level="DEBUG">
+        <appender-ref ref="jsonConsoleAppender" />
+      </logger>
+      <root level="INFO">
         <appender-ref ref="jsonConsoleAppender"/>
       </root>
     </configuration>


### PR DESCRIPTION
There are a lot of log lines coming from Kafka clients, that
are unnecessary. This PR sets the logging level for our
loggers to `DEBUG` and keep all others to `INFO`.

## Proposed Changes

- Change logging during e2e tests