### PR TITLE
Bump Go from 1.14 to 1.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/eventing-kafka-broker
 
-go 1.14
+go 1.15
 
 require (
 	github.com/Shopify/sarama v1.27.0


### PR DESCRIPTION
## Proposed Changes
 
- Bump Go from 1.14 to 1.15
- Run `./hack/update-codegen.sh`