### PR TITLE
Custom Broker config for sacura job

### DIFF
--- a/test/pkg/config/sacura/101-broker.yaml
+++ b/test/pkg/config/sacura/101-broker.yaml
@@ -1,9 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-broker
+  namespace: sacura
+data:
+  default.topic.partitions: "10"
+  default.topic.replication.factor: "3"
+  bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"
+---
 apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:
   name: broker
   namespace: sacura
 spec:
+
+  config:
+    apiVersion: v1
+    kind: ConfigMap
+    name: config-broker
+
   delivery:
     retry: 3
     backoffPolicy: exponential


### PR DESCRIPTION
If a Kafka Broker crashes for whatever reason we use ephemeral
storage so the messages are lost, increasing the replication
factor to 3 reduces the probability of losing events.

## Proposed Changes

- Custom Broker config for sacura job

/area test
