### PR TITLE
Fix thread blocked issue

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerMessageHandler.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerMessageHandler.java
@@ -28,8 +28,11 @@ public class ResourcesReconcilerMessageHandler implements Handler<Message<Object
   public void handle(Message<Object> event) {
     DataPlaneContract.Contract contract = (DataPlaneContract.Contract) event.body();
     resourcesReconciler.reconcile(contract.getResourcesList())
-      .onSuccess(v -> logger.info("reconciled objects {}", keyValue("contract", contract)))
-      .onFailure(cause -> logger.error("failed to reconcile {}", keyValue("contract", contract), cause));
+      .onSuccess(
+        v -> logger.info("reconciled contract generation {}", keyValue("contractGeneration", contract.getGeneration())))
+      .onFailure(cause -> logger
+        .error("failed to reconcile contract generation {}", keyValue("contractGeneration", contract.getGeneration()),
+          cause));
   }
 
   public static MessageConsumer<Object> start(EventBus eventBus, ResourcesReconciler reconciler) {


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #371

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- `keyValue` converts the value using an internal jackson object mapper. Because the contract may be pretty large, this operation becomes very expensive, eventually leading to thread blocked issue.

