### PR TITLE
Create one producer per properties in receiver

### DIFF
--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/RequestMapper.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/RequestMapper.java
@@ -223,6 +223,7 @@ public class RequestMapper<K, V> implements Handler<HttpServerRequest>, IngressR
     private int refs;
 
     ReferenceCounter(final T value) {
+      Objects.requireNonNull(value);
       this.value = value;
       this.refs = 0;
     }


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #328

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Now we create one producer per config