### PR TITLE
Retry executing DP builds to avoid conn reset errors

### DIFF
--- a/test/data-plane/library.sh
+++ b/test/data-plane/library.sh
@@ -170,15 +170,21 @@ function k8s() {
 
 function data_plane_unit_tests() {
 
-  docker build \
-    --file ${DATA_PLANE_DIR}/docker/test/Dockerfile \
-    --build-arg JAVA_IMAGE=${JAVA_IMAGE} \
-    --tag tests ${DATA_PLANE_DIR}
+  java_ut || java_ut || fail_test "Data plane unit tests failed"
 
   echo "Copy test reports in ${ARTIFACTS}"
   docker cp "$(docker create --rm tests)":/reports "${ARTIFACTS}" || fail_test "Failed to copy test reports in ${ARTIFACTS}"
 
   cd ${ARTIFACTS}/reports && find * -maxdepth 0 -exec mv {} ../junit_{} \; && cd - && rm -r ${ARTIFACTS}/reports
+
+  return $?
+}
+
+function java_ut() {
+  docker build \
+    --file ${DATA_PLANE_DIR}/docker/test/Dockerfile \
+    --build-arg JAVA_IMAGE=${JAVA_IMAGE} \
+    --tag tests ${DATA_PLANE_DIR}
 
   return $?
 }

--- a/test/data-plane/library.sh
+++ b/test/data-plane/library.sh
@@ -145,9 +145,9 @@ function data_plane_build_push() {
 
   export KNATIVE_KAFKA_SINK_RECEIVER_IMAGE="${KO_DOCKER_REPO}"/"${sink}":"${uuid}"
 
-  receiver_build_push || fail_test "failed to build receiver"
-  dispatcher_build_push || fail_test "failed to build dispatcher"
-  sink_build_push || fail_test "failed to build sink"
+  receiver_build_push || receiver_build_push || fail_test "failed to build receiver"
+  dispatcher_build_push || dispatcher_build_push || fail_test "failed to build dispatcher"
+  sink_build_push || sink_build_push || fail_test "failed to build sink"
 }
 
 function k8s() {


### PR DESCRIPTION
We get a lot of connection reset errors during maven builds, like
```
[ERROR] Failed to execute goal on project receiver: Could not resolve dependencies for project dev.knative.eventing.kafka.broker:receiver:jar:1.0-SNAPSHOT: Failed to collect dependencies at io.vertx:vertx-web-client:jar:4.0.0.CR1: Failed to read artifact descriptor for io.vertx:vertx-web-client:jar:4.0.0.CR1: Could not transfer artifact io.vertx:vertx-web-client:pom:4.0.0.CR1 from/to central (https://repo.maven.apache.org/maven2): Transfer failed for https://repo.maven.apache.org/maven2/io/vertx/vertx-web-client/4.0.0.CR1/vertx-web-client-4.0.0.CR1.pom: Connection reset -> [Help 1]
```
and this makes our test grid red and it's difficult to see what's actually failing.

## Proposed Changes

- Retry executing DP unit tests to avoid conn reset errors
