### PR TITLE
Add Global resync handlers

### DIFF
--- a/control-plane/pkg/reconciler/broker/controller.go
+++ b/control-plane/pkg/reconciler/broker/controller.go
@@ -104,7 +104,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher, configs *Conf
 		Handler:    controller.HandleAll(impl.Enqueue),
 	})
 
-	globalResync := func(obj interface{}) {
+	globalResync := func(_ interface{}) {
 		impl.GlobalResync(brokerInformer.Informer())
 	}
 

--- a/control-plane/pkg/reconciler/broker/controller.go
+++ b/control-plane/pkg/reconciler/broker/controller.go
@@ -110,7 +110,11 @@ func NewController(ctx context.Context, watcher configmap.Watcher, configs *Conf
 
 	configmapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterWithNameAndNamespace(configs.DataPlaneConfigMapNamespace, configs.DataPlaneConfigMapName),
-		Handler:    controller.HandleAll(globalResync),
+		Handler: cache.ResourceEventHandlerFuncs{
+			DeleteFunc: func(obj interface{}) {
+				globalResync(obj)
+			},
+		},
 	})
 
 	cm, err := reconciler.KubeClient.CoreV1().ConfigMaps(configs.SystemNamespace).Get(ctx, configs.GeneralConfigMapName, metav1.GetOptions{})

--- a/control-plane/pkg/reconciler/broker/controller.go
+++ b/control-plane/pkg/reconciler/broker/controller.go
@@ -111,6 +111,9 @@ func NewController(ctx context.Context, watcher configmap.Watcher, configs *Conf
 	configmapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterWithNameAndNamespace(configs.DataPlaneConfigMapNamespace, configs.DataPlaneConfigMapName),
 		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				globalResync(obj)
+			},
 			DeleteFunc: func(obj interface{}) {
 				globalResync(obj)
 			},

--- a/control-plane/pkg/reconciler/sink/controller.go
+++ b/control-plane/pkg/reconciler/sink/controller.go
@@ -73,7 +73,7 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 
 	sinkInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
-	globalResync := func(obj interface{}) {
+	globalResync := func(_ interface{}) {
 		impl.GlobalResync(sinkInformer.Informer())
 	}
 

--- a/control-plane/pkg/reconciler/sink/controller.go
+++ b/control-plane/pkg/reconciler/sink/controller.go
@@ -79,7 +79,11 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 
 	configmapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterWithNameAndNamespace(configs.DataPlaneConfigMapNamespace, configs.DataPlaneConfigMapName),
-		Handler:    controller.HandleAll(globalResync),
+		Handler: cache.ResourceEventHandlerFuncs{
+			DeleteFunc: func(obj interface{}) {
+				globalResync(obj)
+			},
+		},
 	})
 
 	return impl

--- a/control-plane/pkg/reconciler/sink/controller.go
+++ b/control-plane/pkg/reconciler/sink/controller.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"go.uber.org/zap"
+	"k8s.io/client-go/tools/cache"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap"
 	podinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod"
@@ -41,6 +42,8 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 
 	logger := logging.FromContext(ctx)
 
+	configmapInformer := configmapinformer.Get(ctx)
+
 	reconciler := &Reconciler{
 		Reconciler: &base.Reconciler{
 			KubeClient:                  kubeclient.Get(ctx),
@@ -51,7 +54,7 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 			SystemNamespace:             configs.SystemNamespace,
 			ReceiverLabel:               base.SinkReceiverLabel,
 		},
-		ConfigMapLister: configmapinformer.Get(ctx).Lister(),
+		ConfigMapLister: configmapInformer.Lister(),
 		ClusterAdmin:    sarama.NewClusterAdmin,
 		Configs:         configs,
 	}
@@ -69,6 +72,15 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 	sinkInformer := sinkinformer.Get(ctx)
 
 	sinkInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+
+	globalResync := func(obj interface{}) {
+		impl.GlobalResync(sinkInformer.Informer())
+	}
+
+	configmapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithNameAndNamespace(configs.DataPlaneConfigMapNamespace, configs.DataPlaneConfigMapName),
+		Handler:    controller.HandleAll(globalResync),
+	})
 
 	return impl
 }

--- a/control-plane/pkg/reconciler/sink/controller.go
+++ b/control-plane/pkg/reconciler/sink/controller.go
@@ -80,6 +80,9 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 	configmapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterWithNameAndNamespace(configs.DataPlaneConfigMapNamespace, configs.DataPlaneConfigMapName),
 		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				globalResync(obj)
+			},
 			DeleteFunc: func(obj interface{}) {
 				globalResync(obj)
 			},

--- a/control-plane/pkg/reconciler/trigger/controller.go
+++ b/control-plane/pkg/reconciler/trigger/controller.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap"
 	podinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -52,6 +53,7 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 
 	logger := logging.FromContext(ctx).Desugar()
 
+	configmapInformer := configmapinformer.Get(ctx)
 	brokerInformer := brokerinformer.Get(ctx)
 	triggerInformer := triggerinformer.Get(ctx)
 	triggerLister := triggerInformer.Lister()
@@ -91,6 +93,15 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 	brokerInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: kafka.BrokerClassFilter(),
 		Handler:    enqueueTriggers(logger, triggerLister, impl.Enqueue),
+	})
+
+	globalResync := func(obj interface{}) {
+		impl.GlobalResync(triggerInformer.Informer())
+	}
+
+	configmapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithNameAndNamespace(configs.DataPlaneConfigMapNamespace, configs.DataPlaneConfigMapName),
+		Handler:    controller.HandleAll(globalResync),
 	})
 
 	return impl

--- a/control-plane/pkg/reconciler/trigger/controller.go
+++ b/control-plane/pkg/reconciler/trigger/controller.go
@@ -101,7 +101,11 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 
 	configmapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterWithNameAndNamespace(configs.DataPlaneConfigMapNamespace, configs.DataPlaneConfigMapName),
-		Handler:    controller.HandleAll(globalResync),
+		Handler: cache.ResourceEventHandlerFuncs{
+			DeleteFunc: func(obj interface{}) {
+				globalResync(obj)
+			},
+		},
 	})
 
 	return impl

--- a/control-plane/pkg/reconciler/trigger/controller.go
+++ b/control-plane/pkg/reconciler/trigger/controller.go
@@ -102,6 +102,9 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 	configmapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterWithNameAndNamespace(configs.DataPlaneConfigMapNamespace, configs.DataPlaneConfigMapName),
 		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				globalResync(obj)
+			},
 			DeleteFunc: func(obj interface{}) {
 				globalResync(obj)
 			},

--- a/control-plane/pkg/reconciler/trigger/controller.go
+++ b/control-plane/pkg/reconciler/trigger/controller.go
@@ -95,7 +95,7 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 		Handler:    enqueueTriggers(logger, triggerLister, impl.Enqueue),
 	})
 
-	globalResync := func(obj interface{}) {
+	globalResync := func(_ interface{}) {
 		impl.GlobalResync(triggerInformer.Informer())
 	}
 

--- a/control-plane/pkg/reconciler/trigger/controller_test.go
+++ b/control-plane/pkg/reconciler/trigger/controller_test.go
@@ -29,6 +29,7 @@ import (
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -46,4 +46,6 @@ if ! ${LOCAL_DEVELOPMENT}; then
   go_test_e2e -tags=sacura -timeout=20m ./test/... || fail_test "Sacura tests failed"
 fi
 
+go_test_e2e -tags=deletecm ./test/... || fail_test "Integration tests failed"
+
 success

--- a/test/e2e/broker_trigger_sink_test.go
+++ b/test/e2e/broker_trigger_sink_test.go
@@ -133,6 +133,6 @@ func TestBrokerV1TriggersV1SinkV1Alpha1(t *testing.T) {
 		idsTrigger2 := addressable.Send(t, brokerAddressable, setTypeMutator("trigger2"))
 
 		// Read events from the topic.
-		verify(t, client, eventingv1alpha1.ModeStructured, kss.Topic, append(idsTrigger1, idsTrigger2...))
+		sink.Verify(t, client, eventingv1alpha1.ModeStructured, kss.Topic, append(idsTrigger1, idsTrigger2...))
 	})
 }

--- a/test/e2e/delete_cm_test.go
+++ b/test/e2e/delete_cm_test.go
@@ -1,0 +1,178 @@
+// +build deletecm
+
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	. "github.com/cloudevents/sdk-go/v2/test"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	eventing "knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/eventing/test/lib/recordevents"
+	"knative.dev/eventing/test/lib/resources"
+	"knative.dev/pkg/system"
+
+	eventingv1alpha1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
+	eventingv1alpha1clientset "knative.dev/eventing-kafka-broker/control-plane/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
+	"knative.dev/eventing-kafka-broker/test/pkg/addressable"
+	kafkatest "knative.dev/eventing-kafka-broker/test/pkg/kafka"
+	"knative.dev/eventing-kafka-broker/test/pkg/sink"
+)
+
+func TestDeleteBrokerCM(t *testing.T) {
+
+	const (
+		triggerName = "trigger"
+		brokerName  = "broker"
+		subscriber  = "subscriber"
+		senderName  = "sender"
+
+		configMapName = "kafka-broker-brokers-triggers"
+
+		eventType   = "type1"
+		eventSource = "source1"
+	)
+
+	eventId := uuid.New().String()
+
+	ctx := context.Background()
+
+	client := testlib.Setup(t, true)
+	defer testlib.TearDown(client)
+
+	client.CreateBrokerV1OrFail(
+		brokerName,
+		resources.WithBrokerClassForBrokerV1(kafka.BrokerClass),
+	)
+
+	eventTracker, _ := recordevents.StartEventRecordOrFail(ctx, client, subscriber)
+
+	client.CreateTriggerOrFailV1Beta1(
+		triggerName,
+		resources.WithBrokerV1Beta1(brokerName),
+		resources.WithSubscriberServiceRefForTriggerV1Beta1(subscriber),
+		func(trigger *eventing.Trigger) {
+			trigger.Spec.Filter = &eventing.TriggerFilter{
+				Attributes: map[string]string{
+					"source": eventSource,
+				},
+			}
+		},
+	)
+
+	client.WaitForAllTestResourcesReadyOrFail(ctx)
+
+	t.Logf("Sending events to %s/%s", client.Namespace, brokerName)
+
+	eventToSend := cloudevents.NewEvent()
+	eventToSend.SetID(eventId)
+	eventToSend.SetType(eventType)
+	eventToSend.SetSource(eventSource)
+
+	client.SendEventToAddressable(
+		ctx,
+		senderName+"matching",
+		brokerName,
+		testlib.BrokerTypeMeta,
+		eventToSend,
+	)
+
+	eventTracker.AssertAtLeast(1, recordevents.MatchEvent(HasId(eventId)))
+
+	t.Logf("Deleting ConfigMap %s", configMapName)
+
+	err := client.Kube.CoreV1().ConfigMaps(system.Namespace()).Delete(ctx, configMapName, metav1.DeleteOptions{})
+	assert.Nil(t, err)
+
+	client.WaitForAllTestResourcesReadyOrFail(ctx)
+
+	eventId = uuid.New().String()
+	eventToSend.SetID(eventId)
+
+	client.SendEventToAddressable(
+		ctx,
+		senderName+"matching-2",
+		brokerName,
+		testlib.BrokerTypeMeta,
+		eventToSend,
+	)
+
+	eventTracker.AssertAtLeast(1, recordevents.MatchEvent(HasId(eventId)))
+}
+
+func TestDeleteSinkCM(t *testing.T) {
+
+	const (
+		configMapName = "kafka-sink-sinks"
+	)
+
+	ctx := context.Background()
+
+	client := testlib.Setup(t, false)
+	defer testlib.TearDown(client)
+
+	clientSet, err := eventingv1alpha1clientset.NewForConfig(client.Config)
+	assert.Nil(t, err)
+
+	// Create a KafkaSink with the following spec.
+
+	kss := eventingv1alpha1.KafkaSinkSpec{
+		Topic:             "kafka-sink-" + client.Namespace,
+		NumPartitions:     pointer.Int32Ptr(10),
+		ReplicationFactor: func(rf int16) *int16 { return &rf }(1),
+		BootstrapServers:  kafkatest.BootstrapServersArr,
+	}
+
+	createFunc := sink.CreatorV1Alpha1(clientSet, kss)
+
+	kafkaSink, err := createFunc(types.NamespacedName{
+		Namespace: client.Namespace,
+		Name:      "kafka-sink",
+	})
+	assert.Nil(t, err)
+
+	client.WaitForResourceReadyOrFail(kafkaSink.Name, &kafkaSink.TypeMeta)
+
+	// Send events to the KafkaSink.
+	ids := addressable.Send(t, kafkaSink)
+
+	// Read events from the topic.
+	verify(t, client, eventingv1alpha1.ModeStructured, kss.Topic, ids)
+
+	t.Logf("Deleting ConfigMap %s", configMapName)
+
+	err = client.Kube.CoreV1().ConfigMaps(system.Namespace()).Delete(ctx, configMapName, metav1.DeleteOptions{})
+	assert.Nil(t, err)
+
+	client.WaitForResourceReadyOrFail(kafkaSink.Name, &kafkaSink.TypeMeta)
+
+	// Send events to the KafkaSink.
+	ids = addressable.Send(t, kafkaSink)
+
+	// Read events from the topic.
+	verify(t, client, eventingv1alpha1.ModeStructured, kss.Topic, ids)
+}

--- a/test/e2e/kafka_sink_test.go
+++ b/test/e2e/kafka_sink_test.go
@@ -19,7 +19,6 @@
 package e2e
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,7 +66,7 @@ func TestKafkaSinkV1Alpha1DefaultContentMode(t *testing.T) {
 		ids := addressable.Send(t, kafkaSink)
 
 		// Read events from the topic.
-		verify(t, client, eventingv1alpha1.ModeStructured, kss.Topic, ids)
+		sink.Verify(t, client, eventingv1alpha1.ModeStructured, kss.Topic, ids)
 	})
 }
 
@@ -104,7 +103,7 @@ func TestKafkaSinkV1Alpha1StructuredContentMode(t *testing.T) {
 		ids := addressable.Send(t, kafkaSink)
 
 		// Read events from the topic.
-		verify(t, client, eventingv1alpha1.ModeStructured, kss.Topic, ids)
+		sink.Verify(t, client, eventingv1alpha1.ModeStructured, kss.Topic, ids)
 	})
 }
 
@@ -141,25 +140,6 @@ func TestKafkaSinkV1Alpha1BinaryContentMode(t *testing.T) {
 		ids := addressable.Send(t, kafkaSink)
 
 		// Read events from the topic.
-		verify(t, client, eventingv1alpha1.ModeBinary, kss.Topic, ids)
+		sink.Verify(t, client, eventingv1alpha1.ModeBinary, kss.Topic, ids)
 	})
-}
-
-func verify(t *testing.T, client *testlib.Client, mode, topic string, ids []string) {
-
-	err := kafkatest.VerifyMessagesInTopic(
-		client.Kube,
-		client.Tracker,
-		types.NamespacedName{
-			Namespace: client.Namespace,
-			Name:      "verify-messages",
-		},
-		&kafkatest.ConsumerConfig{
-			BootstrapServers: kafkatest.BootstrapServers,
-			Topic:            topic,
-			IDS:              strings.Join(ids, ","),
-			ContentMode:      mode,
-		},
-	)
-	assert.Nil(t, err, "failed to verify messages in topic: %v - (see pod logs)", err)
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,4 +1,4 @@
-// +build e2e
+// +build e2e deletecm
 
 /*
  * Copyright 2020 The Knative Authors

--- a/test/pkg/sink/verify.go
+++ b/test/pkg/sink/verify.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sink
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/storage/names"
+	testlib "knative.dev/eventing/test/lib"
+
+	kafkatest "knative.dev/eventing-kafka-broker/test/pkg/kafka"
+)
+
+func Verify(t *testing.T, client *testlib.Client, mode, topic string, ids []string) {
+
+	err := kafkatest.VerifyMessagesInTopic(
+		client.Kube,
+		client.Tracker,
+		types.NamespacedName{
+			Namespace: client.Namespace,
+			Name:      names.SimpleNameGenerator.GenerateName("verify-messages"),
+		},
+		&kafkatest.ConsumerConfig{
+			BootstrapServers: kafkatest.BootstrapServers,
+			Topic:            topic,
+			IDS:              strings.Join(ids, ","),
+			ContentMode:      mode,
+		},
+	)
+	assert.Nil(t, err, "failed to verify messages in topic: %v - (see pod logs)", err)
+}


### PR DESCRIPTION
If our data plane ConfigMap is removed, the control plane won't
be able to recover, so adding a handler so that we resync everything
once that happens.

## Proposed Changes

- Add Global resync handlers

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:bug: Fix bug
Controllers resync state when managed resources change.
```

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

/kind bug