### PR TITLE
Non-blocking data plane components

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerVerticle.java
@@ -18,10 +18,13 @@ package dev.knative.eventing.kafka.broker.dispatcher;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * ConsumerVerticle is responsible for manging the consumer lifecycle.
@@ -31,29 +34,30 @@ import java.util.Set;
  */
 public final class ConsumerVerticle<K, V> extends AbstractVerticle {
 
-  private final KafkaConsumer<K, V> consumer;
+  private final Function<Vertx, KafkaConsumer<K, V>> consumerFactory;
+  private KafkaConsumer<K, V> consumer;
   private final Set<String> topics;
-  private final Handler<KafkaConsumerRecord<K, V>> recordHandler;
+  private final BiFunction<Vertx, KafkaConsumer<K, V>, Handler<KafkaConsumerRecord<K, V>>> recordHandler;
 
   /**
    * All args constructor.
    *
-   * @param consumer      Kafka consumer.
-   * @param topics        topic to consume.
-   * @param recordHandler handler of consumed Kafka records.
+   * @param consumerFactory Kafka consumer.
+   * @param topics          topic to consume.
+   * @param recordHandler   handler of consumed Kafka records.
    */
   public ConsumerVerticle(
-    final KafkaConsumer<K, V> consumer,
+    final Function<Vertx, KafkaConsumer<K, V>> consumerFactory,
     final Set<String> topics,
-    final Handler<KafkaConsumerRecord<K, V>> recordHandler) {
+    final BiFunction<Vertx, KafkaConsumer<K, V>, Handler<KafkaConsumerRecord<K, V>>> recordHandler) {
 
-    Objects.requireNonNull(consumer, "provide consumer");
+    Objects.requireNonNull(consumerFactory, "provide consumerFactory");
     Objects.requireNonNull(topics, "provide topic");
-    Objects.requireNonNull(recordHandler, "provide record handler");
+    Objects.requireNonNull(recordHandler, "provide recordHandler");
 
-    this.recordHandler = recordHandler;
-    this.consumer = consumer;
     this.topics = topics;
+    this.recordHandler = recordHandler;
+    this.consumerFactory = consumerFactory;
   }
 
   /**
@@ -61,7 +65,8 @@ public final class ConsumerVerticle<K, V> extends AbstractVerticle {
    */
   @Override
   public void start(Promise<Void> startPromise) {
-    consumer.handler(recordHandler);
+    this.consumer = consumerFactory.apply(vertx);
+    consumer.handler(recordHandler.apply(vertx, this.consumer));
     consumer.exceptionHandler(startPromise::tryFail);
     consumer.subscribe(topics, startPromise);
   }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerVerticle.java
@@ -42,21 +42,21 @@ public final class ConsumerVerticle<K, V> extends AbstractVerticle {
   /**
    * All args constructor.
    *
-   * @param consumerFactory Kafka consumer.
-   * @param topics          topic to consume.
-   * @param recordHandler   handler of consumed Kafka records.
+   * @param consumerFactory      Kafka consumer.
+   * @param topics               topic to consume.
+   * @param recordHandlerFactory record handler factory.
    */
   public ConsumerVerticle(
     final Function<Vertx, KafkaConsumer<K, V>> consumerFactory,
     final Set<String> topics,
-    final BiFunction<Vertx, KafkaConsumer<K, V>, Handler<KafkaConsumerRecord<K, V>>> recordHandler) {
+    final BiFunction<Vertx, KafkaConsumer<K, V>, Handler<KafkaConsumerRecord<K, V>>> recordHandlerFactory) {
 
     Objects.requireNonNull(consumerFactory, "provide consumerFactory");
     Objects.requireNonNull(topics, "provide topic");
-    Objects.requireNonNull(recordHandler, "provide recordHandler");
+    Objects.requireNonNull(recordHandlerFactory, "provide recordHandlerFactory");
 
     this.topics = topics;
-    this.recordHandler = recordHandler;
+    this.recordHandler = recordHandlerFactory;
     this.consumerFactory = consumerFactory;
   }
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/Main.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/Main.java
@@ -36,7 +36,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.tracing.TracingOptions;
 import io.vertx.core.tracing.TracingPolicy;
-import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.micrometer.backends.BackendRegistries;
 import java.io.File;
@@ -119,8 +118,7 @@ public class Main {
       final var consumerVerticleFactory = new HttpConsumerVerticleFactory(
         consumerRecordOffsetStrategyFactory,
         consumerConfig,
-        WebClient.create(vertx, clientOptions),
-        vertx,
+        clientOptions,
         producerConfig
       );
 

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerVerticleFactoryTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerVerticleFactoryTest.java
@@ -33,7 +33,7 @@ import io.cloudevents.kafka.CloudEventDeserializer;
 import io.cloudevents.kafka.CloudEventSerializer;
 import io.micrometer.core.instrument.Counter;
 import io.vertx.core.Vertx;
-import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.junit5.VertxExtension;
 import java.util.Properties;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -60,8 +60,7 @@ public class HttpConsumerVerticleFactoryTest {
     final var verticleFactory = new HttpConsumerVerticleFactory(
       ConsumerRecordOffsetStrategyFactory.unordered(mock(Counter.class)),
       consumerProperties,
-      WebClient.create(vertx),
-      vertx,
+      new WebClientOptions(),
       producerConfigs
     );
 
@@ -88,7 +87,7 @@ public class HttpConsumerVerticleFactoryTest {
   }
 
   @Test
-  public void shouldNotThrowIllegalArgumentExceptionIfNotDLQ(final Vertx vertx) {
+  public void shouldNotThrowIllegalArgumentExceptionIfNotDLQ() {
 
     final var consumerProperties = new Properties();
     consumerProperties.setProperty(BOOTSTRAP_SERVERS_CONFIG, "0.0.0.0:9092");
@@ -103,8 +102,7 @@ public class HttpConsumerVerticleFactoryTest {
     final var verticleFactory = new HttpConsumerVerticleFactory(
       ConsumerRecordOffsetStrategyFactory.unordered(mock(Counter.class)),
       consumerProperties,
-      WebClient.create(vertx),
-      vertx,
+      new WebClientOptions(),
       producerConfigs
     );
 

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/integration/ConsumerVerticleFactoryMock.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/integration/ConsumerVerticleFactoryMock.java
@@ -16,6 +16,8 @@
 package dev.knative.eventing.kafka.broker.dispatcher.integration;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
+import dev.knative.eventing.kafka.broker.contract.DataPlaneContract.Egress;
+import dev.knative.eventing.kafka.broker.contract.DataPlaneContract.Resource;
 import dev.knative.eventing.kafka.broker.dispatcher.ConsumerRecordOffsetStrategyFactory;
 import dev.knative.eventing.kafka.broker.dispatcher.http.HttpConsumerVerticleFactory;
 import io.cloudevents.CloudEvent;
@@ -56,25 +58,24 @@ public class ConsumerVerticleFactoryMock extends HttpConsumerVerticleFactory {
   }
 
   @Override
-  protected Function<Vertx, KafkaProducer<String, CloudEvent>> createProducer(
-    final DataPlaneContract.Resource resource,
-    final DataPlaneContract.Egress egress) {
+  protected KafkaProducer<String, CloudEvent> createProducer(
+    final Vertx vertx,
+    final Resource resource,
+    final Egress egress) {
 
-    return vertx -> {
-      final var producer = new MockProducer<>(
-        true,
-        new StringSerializer(),
-        new CloudEventSerializer()
-      );
+    final var producer = new MockProducer<>(
+      true,
+      new StringSerializer(),
+      new CloudEventSerializer()
+    );
 
-      mockProducer.put(egress.getConsumerGroup(), producer);
+    mockProducer.put(egress.getConsumerGroup(), producer);
 
-      return KafkaProducer.create(vertx, producer);
-    };
+    return KafkaProducer.create(vertx, producer);
   }
 
   @Override
-  protected Function<Vertx, KafkaConsumer<String, CloudEvent>> createConsumer(
+  protected Function<Vertx, KafkaConsumer<String, CloudEvent>> createConsumerFactory(
     final DataPlaneContract.Resource resource,
     final DataPlaneContract.Egress egress) {
     return vertx -> {

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/integration/UnorderedConsumerTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/integration/UnorderedConsumerTest.java
@@ -35,7 +35,6 @@ import io.cloudevents.core.v1.CloudEventBuilder;
 import io.cloudevents.http.vertx.VertxMessageFactory;
 import io.micrometer.core.instrument.Counter;
 import io.vertx.core.Vertx;
-import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.io.IOException;
@@ -68,12 +67,9 @@ public class UnorderedConsumerTest {
 
     final var producerConfigs = new Properties();
     final var consumerConfigs = new Properties();
-    final var client = WebClient.create(vertx);
 
     final var consumerVerticleFactoryMock = new ConsumerVerticleFactoryMock(
       consumerConfigs,
-      client,
-      vertx,
       producerConfigs,
       ConsumerRecordOffsetStrategyFactory.unordered(mock(Counter.class))
     );

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/Main.java
@@ -105,7 +105,7 @@ public class Main {
       producerConfigs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
       producerConfigs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, CloudEventSerializer.class);
 
-      final Function<Vertx, RequestMapper<String, CloudEvent>> handler = v -> new RequestMapper<>(
+      final Function<Vertx, RequestMapper<String, CloudEvent>> handlerFactory = v -> new RequestMapper<>(
         producerConfigs,
         new CloudEventRequestToRecordMapper(v),
         properties -> KafkaProducer.create(v, properties),
@@ -121,7 +121,7 @@ public class Main {
 
       final var verticle = new ReceiverVerticle(
         httpServerOptions,
-        handler,
+        handlerFactory,
         h -> new SimpleProbeHandlerDecorator(
           env.getLivenessProbePath(),
           env.getReadinessProbePath(),

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/Main.java
@@ -27,6 +27,7 @@ import dev.knative.eventing.kafka.broker.core.tracing.Tracing;
 import dev.knative.eventing.kafka.broker.core.tracing.TracingConfig;
 import dev.knative.eventing.kafka.broker.core.utils.Configurations;
 import dev.knative.eventing.kafka.broker.core.utils.Shutdown;
+import io.cloudevents.CloudEvent;
 import io.cloudevents.kafka.CloudEventSerializer;
 import io.opentelemetry.api.OpenTelemetry;
 import io.vertx.core.Vertx;
@@ -41,6 +42,7 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import net.logstash.logback.encoder.LogstashEncoder;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -103,10 +105,10 @@ public class Main {
       producerConfigs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
       producerConfigs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, CloudEventSerializer.class);
 
-      final var handler = new RequestMapper<>(
+      final Function<Vertx, RequestMapper<String, CloudEvent>> handler = v -> new RequestMapper<>(
         producerConfigs,
-        new CloudEventRequestToRecordMapper(vertx),
-        properties -> KafkaProducer.create(vertx, properties),
+        new CloudEventRequestToRecordMapper(v),
+        properties -> KafkaProducer.create(v, properties),
         badRequestCounter,
         produceEventsCounter
       );

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/ReceiverVerticle.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/ReceiverVerticle.java
@@ -50,7 +50,7 @@ public class ReceiverVerticle extends AbstractVerticle {
   public ReceiverVerticle(
     final HttpServerOptions httpServerOptions,
     final Function<Vertx, RequestMapper<String, CloudEvent>> requestHandlerFactory,
-    Function<Handler<HttpServerRequest>, Handler<HttpServerRequest>>... handlerDecoratorFactories) {
+    final Function<Handler<HttpServerRequest>, Handler<HttpServerRequest>>... handlerDecoratorFactories) {
     Objects.requireNonNull(httpServerOptions, "provide http server options");
     Objects.requireNonNull(requestHandlerFactory, "provide request handler");
 

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/ReceiverVerticle.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/ReceiverVerticle.java
@@ -22,59 +22,62 @@ import io.vertx.core.AbstractVerticle;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.impl.ContextInternal;
 import java.util.Objects;
 import java.util.function.Function;
 
 public class ReceiverVerticle extends AbstractVerticle {
 
   private final HttpServerOptions httpServerOptions;
-  private final RequestMapper<String, CloudEvent> requestMapper;
-  private final Handler<HttpServerRequest> requestHandler;
 
   private HttpServer server;
   private MessageConsumer<Object> messageConsumer;
+  private final Function<Vertx, RequestMapper<String, CloudEvent>> requestHandlerFactory;
+  private final Function<Handler<HttpServerRequest>, Handler<HttpServerRequest>>[] handlerDecoratorFactories;
 
   /**
    * Create a new HttpVerticle.
    *
-   * @param httpServerOptions server options.
-   * @param requestMapper     request handler.
+   * @param httpServerOptions         server options.
+   * @param requestHandlerFactory     request handler factory.
+   * @param handlerDecoratorFactories request handler decorators functions
    */
   @SafeVarargs
   public ReceiverVerticle(
     final HttpServerOptions httpServerOptions,
-    final RequestMapper<String, CloudEvent> requestMapper,
+    final Function<Vertx, RequestMapper<String, CloudEvent>> requestHandlerFactory,
     Function<Handler<HttpServerRequest>, Handler<HttpServerRequest>>... handlerDecoratorFactories) {
     Objects.requireNonNull(httpServerOptions, "provide http server options");
-    Objects.requireNonNull(requestMapper, "provide request handler");
+    Objects.requireNonNull(requestHandlerFactory, "provide request handler");
 
     this.httpServerOptions = httpServerOptions;
-    this.requestMapper = requestMapper;
-
-    Handler<HttpServerRequest> requestHandler = requestMapper;
-    for (var decFactory : handlerDecoratorFactories) {
-      requestHandler = decFactory.apply(requestHandler);
-    }
-    this.requestHandler = requestHandler;
+    this.requestHandlerFactory = requestHandlerFactory;
+    this.handlerDecoratorFactories = handlerDecoratorFactories;
   }
 
   @Override
   public void start(final Promise<Void> startPromise) {
+    final var requestMapper = this.requestHandlerFactory.apply(vertx);
+
     this.messageConsumer = ResourcesReconcilerMessageHandler.start(
       vertx.eventBus(),
       ResourcesReconcilerImpl
         .builder()
-        .watchIngress(this.requestMapper)
+        .watchIngress(requestMapper)
         .build()
     );
     this.server = vertx.createHttpServer(httpServerOptions);
 
-    this.server.requestHandler(this.requestHandler)
+    Handler<HttpServerRequest> requestHandler = requestMapper;
+    for (final var handlerDecoratorFactory : this.handlerDecoratorFactories) {
+      requestHandler = handlerDecoratorFactory.apply(requestHandler);
+    }
+
+    this.server.requestHandler(requestHandler)
       .exceptionHandler(startPromise::tryFail)
       .listen(httpServerOptions.getPort(), httpServerOptions.getHost())
       .<Void>mapEmpty()

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/ReceiverVerticleTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/ReceiverVerticleTest.java
@@ -99,7 +99,7 @@ public class ReceiverVerticleTest {
     httpServerOptions.setHost("localhost");
     final var verticle = new ReceiverVerticle(
       httpServerOptions,
-      handler
+      v -> handler
     );
     vertx.deployVerticle(verticle, testContext.succeeding(ar -> testContext.completeNow()));
   }

--- a/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/DataPlaneTest.java
+++ b/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/DataPlaneTest.java
@@ -58,6 +58,7 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.AfterAll;
@@ -313,10 +314,10 @@ public class DataPlaneTest {
     final Vertx vertx,
     final VertxTestContext context) throws InterruptedException {
 
-    final var handler = new RequestMapper<>(
+    final Function<Vertx, RequestMapper<String, CloudEvent>> handler = v -> new RequestMapper<>(
       producerConfigs(),
-      new CloudEventRequestToRecordMapper(vertx),
-      properties -> KafkaProducer.create(vertx, properties),
+      new CloudEventRequestToRecordMapper(v),
+      properties -> KafkaProducer.create(v, properties),
       mock(Counter.class),
       mock(Counter.class)
     );

--- a/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/DataPlaneTest.java
+++ b/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/DataPlaneTest.java
@@ -314,7 +314,7 @@ public class DataPlaneTest {
     final Vertx vertx,
     final VertxTestContext context) throws InterruptedException {
 
-    final Function<Vertx, RequestMapper<String, CloudEvent>> handler = v -> new RequestMapper<>(
+    final Function<Vertx, RequestMapper<String, CloudEvent>> handlerFactory = v -> new RequestMapper<>(
       producerConfigs(),
       new CloudEventRequestToRecordMapper(v),
       properties -> KafkaProducer.create(v, properties),
@@ -325,7 +325,7 @@ public class DataPlaneTest {
     final var httpServerOptions = new HttpServerOptions();
     httpServerOptions.setPort(INGRESS_PORT);
 
-    final var verticle = new ReceiverVerticle(httpServerOptions, handler);
+    final var verticle = new ReceiverVerticle(httpServerOptions, handlerFactory);
 
     final CountDownLatch latch = new CountDownLatch(1);
     vertx.deployVerticle(verticle, context.succeeding(h -> latch.countDown()));

--- a/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/DataPlaneTest.java
+++ b/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/DataPlaneTest.java
@@ -46,6 +46,7 @@ import io.micrometer.core.instrument.Counter;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -292,8 +293,7 @@ public class DataPlaneTest {
     final var consumerVerticleFactory = new HttpConsumerVerticleFactory(
       consumerRecordOffsetStrategyFactory,
       consumerConfigs,
-      WebClient.create(vertx),
-      vertx,
+      new WebClientOptions(),
       producerConfigs
     );
 


### PR DESCRIPTION
Sharing a `WebClient` across multiple verticles is discouraged by
Vertx, see https://vertx.io/docs/vertx-core/java/#_httpclient_usage.
That section talks about the HTTP Client, the `WebClient` isn't different.

> When used in a Verticle, the Verticle should use its own client instance.

Main changes are around when objects are built and in which Vertx context.

## Proposed Changes

- Dispatcher non-blocking
- Receiver non-blocking

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- :broom: Update or clean up current behavior
The data plane is completely non-blocking.
```

/kind enhancement