### PR TITLE
Automatically add area label to PRs

### DIFF
--- a/.github/workflows/OWNERS
+++ b/.github/workflows/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- area/test

--- a/control-plane/OWNERS
+++ b/control-plane/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- area/control-plane

--- a/data-plane/OWNERS
+++ b/data-plane/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- area/data-plane

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- area/test


### PR DESCRIPTION
This PR adds some OWNERS files telling to Prow to add labels
to PRs based on updated directories.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Automatically add area label to PRs

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```


<!--
**Docs**

:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
