### PR TITLE
[WIP] Debug NPE onDeleteEgress

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerImpl.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerImpl.java
@@ -41,11 +41,13 @@ public class ResourcesReconcilerImpl implements ResourcesReconciler {
   private final Map<String, DataPlaneContract.Egress> cachedEgresses;
 
   private ResourcesReconcilerImpl(
-    IngressReconcilerListener ingressReconcilerListener,
-    EgressReconcilerListener egressReconcilerListener) {
+    final IngressReconcilerListener ingressReconcilerListener,
+    final EgressReconcilerListener egressReconcilerListener) {
+
     if (ingressReconcilerListener == null && egressReconcilerListener == null) {
       throw new NullPointerException("You need to specify at least one listener");
     }
+
     this.ingressReconcilerListener = ingressReconcilerListener;
     this.egressReconcilerListener = egressReconcilerListener;
 
@@ -54,8 +56,8 @@ public class ResourcesReconcilerImpl implements ResourcesReconciler {
   }
 
   @Override
-  public Future<Void> reconcile(
-    Collection<DataPlaneContract.Resource> newResources) {
+  public Future<Void> reconcile(final Collection<DataPlaneContract.Resource> newResources) {
+
     final Map<String, DataPlaneContract.Resource> newResourcesMap = new HashMap<>(
       newResources
         .stream()
@@ -200,6 +202,8 @@ public class ResourcesReconcilerImpl implements ResourcesReconciler {
     if (r1 == null || r2 == null) {
       return false;
     }
+
+
     return Objects.equals(r1.getUid(), r2.getUid())
       && Objects.equals(r1.getTopicsList(), r2.getTopicsList())
       && Objects.equals(r1.getBootstrapServers(), r2.getBootstrapServers())
@@ -228,6 +232,7 @@ public class ResourcesReconcilerImpl implements ResourcesReconciler {
   }
 
   public static class Builder {
+
     private IngressReconcilerListener ingressReconcilerListener;
     private EgressReconcilerListener egressReconcilerListener;
 

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerImpl.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerImpl.java
@@ -203,7 +203,6 @@ public class ResourcesReconcilerImpl implements ResourcesReconciler {
       return false;
     }
 
-
     return Objects.equals(r1.getUid(), r2.getUid())
       && Objects.equals(r1.getTopicsList(), r2.getTopicsList())
       && Objects.equals(r1.getBootstrapServers(), r2.getBootstrapServers())

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerMessageHandler.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerMessageHandler.java
@@ -34,23 +34,24 @@ public class ResourcesReconcilerMessageHandler implements Handler<Message<Object
 
   private final ResourcesReconciler resourcesReconciler;
 
-  public ResourcesReconcilerMessageHandler(
-    ResourcesReconciler resourcesReconciler) {
+  public ResourcesReconcilerMessageHandler(final ResourcesReconciler resourcesReconciler) {
     this.resourcesReconciler = resourcesReconciler;
   }
 
   @Override
-  public void handle(Message<Object> event) {
+  public void handle(final Message<Object> event) {
     DataPlaneContract.Contract contract = (DataPlaneContract.Contract) event.body();
     resourcesReconciler.reconcile(contract.getResourcesList())
-      .onSuccess(
-        v -> logger.info("reconciled contract generation {}", keyValue("contractGeneration", contract.getGeneration())))
-      .onFailure(cause -> logger
-        .error("failed to reconcile contract generation {}", keyValue("contractGeneration", contract.getGeneration()),
-          cause));
+      .onSuccess(v -> logger.info("reconciled contract generation {}",
+        keyValue("contractGeneration", contract.getGeneration())
+      ))
+      .onFailure(cause -> logger.error("failed to reconcile contract generation {}",
+        keyValue("contractGeneration", contract.getGeneration()),
+        cause
+      ));
   }
 
-  public static MessageConsumer<Object> start(EventBus eventBus, ResourcesReconciler reconciler) {
+  public static MessageConsumer<Object> start(final EventBus eventBus, final ResourcesReconciler reconciler) {
     return eventBus.localConsumer(ADDRESS, new ResourcesReconcilerMessageHandler(reconciler));
   }
 }

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourceReconcilerTestRunner.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourceReconcilerTestRunner.java
@@ -20,9 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 public class ResourceReconcilerTestRunner {
 
@@ -31,15 +29,17 @@ public class ResourceReconcilerTestRunner {
     private final Collection<DataPlaneContract.Resource> resources;
     private final ResourceReconcilerTestRunner runner;
 
-    private final Set<String> newIngresses = new HashSet<>();
-    private final Set<String> updatedIngresses = new HashSet<>();
-    private final Set<String> deletedIngresses = new HashSet<>();
-    private final Set<String> newEgresses = new HashSet<>();
-    private final Set<String> updatedEgresses = new HashSet<>();
-    private final Set<String> deletedEgresses = new HashSet<>();
+    private final List<String> newIngresses = new ArrayList<>();
+    private final List<String> updatedIngresses = new ArrayList<>();
+    private final List<String> deletedIngresses = new ArrayList<>();
+    private final List<String> newEgresses = new ArrayList<>();
+    private final List<String> updatedEgresses = new ArrayList<>();
+    private final List<String> deletedEgresses = new ArrayList<>();
 
-    public ReconcileStep(Collection<DataPlaneContract.Resource> resources,
-                         ResourceReconcilerTestRunner runner) {
+    public ReconcileStep(
+      final Collection<DataPlaneContract.Resource> resources,
+      final ResourceReconcilerTestRunner runner) {
+
       this.resources = resources;
       this.runner = runner;
     }

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerMessageHandlerTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerMessageHandlerTest.java
@@ -38,16 +38,15 @@ public class ResourcesReconcilerMessageHandlerTest {
     DataPlaneContract.Contract expected = CoreObjects.contract();
 
     ResourcesReconcilerMessageHandler.start(vertx.eventBus(), contract -> {
-      testContext.verify(() ->
-        assertThat(contract)
-          .isEqualTo(expected.getResourcesList())
+      testContext.verify(() -> {
+          assertThat(contract).isEqualTo(expected.getResourcesList());
+          testContext.completeNow();
+        }
       );
-      testContext.completeNow();
       return Future.succeededFuture();
     });
 
     ContractPublisher publisher = new ContractPublisher(vertx.eventBus(), ResourcesReconcilerMessageHandler.ADDRESS);
     publisher.accept(expected);
   }
-
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerDeployerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerDeployerVerticle.java
@@ -133,12 +133,14 @@ public final class ConsumerDeployerVerticle extends AbstractVerticle implements 
   public Future<Void> onDeleteEgress(final DataPlaneContract.Resource resource, final DataPlaneContract.Egress egress) {
     final var deploymentID = this.deployedDispatchers.remove(egress.getUid());
     if (deploymentID == null) {
-      return Future.failedFuture(String.format(
-        "Verticle not found onDeleteEgress for resource resource.uid=%s egress.uid=%s",
-        resource.getUid(),
-        egress.getUid()
-      ));
+      logger.warn(
+        "Verticle not found onDeleteEgress for resource {} {}",
+        keyValue("resource.uid", resource.getUid()),
+        keyValue("egress.uid", egress.getUid())
+      );
+      return Future.succeededFuture();
     }
+
     return vertx.undeploy(deploymentID)
       .onSuccess(v -> logger.info(
         "Removed egress {} {}",

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -23,7 +23,7 @@ if ! ${SKIP_INITIALIZE}; then
 fi
 
 if ! ${LOCAL_DEVELOPMENT}; then
-  scale_controlplane kafka-controller kafka-webhook-eventing eventing-webhook eventing-controller
+  scale_controlplane kafka-controller kafka-webhook-eventing eventing-webhook eventing-controller kafka-broker-receiver kafka-broker-dispatcher kafka-sink-receiver
 fi
 
 if ! ${LOCAL_DEVELOPMENT}; then

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -23,7 +23,7 @@ if ! ${SKIP_INITIALIZE}; then
 fi
 
 if ! ${LOCAL_DEVELOPMENT}; then
-  scale_controlplane kafka-controller kafka-webhook-eventing eventing-webhook eventing-controller kafka-broker-receiver kafka-broker-dispatcher kafka-sink-receiver
+  scale_controlplane kafka-controller kafka-webhook-eventing eventing-webhook eventing-controller
 fi
 
 if ! ${LOCAL_DEVELOPMENT}; then

--- a/test/pkg/config/100-config-logging.yaml
+++ b/test/pkg/config/100-config-logging.yaml
@@ -25,9 +25,6 @@ data:
       <appender name="jsonConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
       </appender>
-      <logger name="dev.knative" level="DEBUG">
-        <appender-ref ref="jsonConsoleAppender" />
-      </logger>
       <root level="INFO">
         <appender-ref ref="jsonConsoleAppender"/>
       </root>


### PR DESCRIPTION
- Example: https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative-sandbox_eventing-kafka-broker/435/pull-knative-sandbox-eventing-kafka-broker-integration-tests/1334822094491357184

- [CM generation logs](https://00f74ba44bfe97549491d5eca746196a1e7b123c39-apidata.googleusercontent.com/download/storage/v1/b/knative-prow/o/pr-logs%2Fpull%2Fknative-sandbox_eventing-kafka-broker%2F435%2Fpull-knative-sandbox-eventing-kafka-broker-integration-tests%2F1334822094491357184%2Fartifacts%2Ff4710b2d-3623-11eb-ba47-8635a115e761%2Fknative-eventing-logs%2Fknative-eventing%2Fkafka-broker-dispatcher-775dcdd99-ss8w4-kafka-broker-dispatcher.log?jk=AFshE3WUfluOCl1y1bkzppqHawgo5pe8jWaYrpGxGF5cU4aACrqz4WxuTP_E005o_VPeuy-LUaMnG-tiLgx_KZrWki9mmlHi2lVKpQVf9fPB0R9j9DZ7u1ltW0yUOMl_saHaU_mugLXoTONjRZi6bFRTtbPcmNII7IzcAYxxJShouLkFWOq5V1TWty078mCptDiq07pvQlGqvNFXrQHdJCQKnY3McGxFr9PKY5QOCSLDkd0MimAA8uEiUdSLvDtFZUXoC7qrdWXPzLnWUPGk6BnJ9rY3AYbJEq6inDxsCBzGtXGskBWxBvFSsV_4uaH-xjrH5L5QIcIt_7Efxr32-kiDVygeLhUFJvYSC46309uX9UPCVgtOLPZVDCt3fNtUFGUpLeC71KChLmb7zJPW3OwvCaeKKFAg4Rjv6SK6SLgrnZyY23RTWIeG0gHUWPgpJps-xaHGASMoTRG4XprNOF8ZNB0bhcC1OOPRk7hUdaMYRkVu5SvOclxyZdS3l0F_aARfReS0aIXuEoIp3435lqOarvHTcJdcBsgvosc3WN5rPJig5ttBh_d4vfoSL6ek2_LVtczXoS7-3SacMlcPAKEEfiQdfoRxABy-DEAy5hYCdCA5Rqs_Reg7j15M5ya2MfPUSLOS82_dQp_RbcoiCYui28-C4egs6mGibBk5Igi7w93qUymk3TnY58gDxFNqQvoju6QvuAJS94R9Ik6_KFcoN7HRre-C_G7RRnDEu0h38xAWk-ZofMr-mLjMGvyMDc9n5vBuV6KtYBtQ-WmuWUrBNvl-yI_rtpK3Defc3sYux0-aAULJ5DiUcHi5nJ9Vh25CrqUVGIj_3f81T9vh8HjxIeVHtKTKj86oKhZ7JhmpBGwolz1wPMqzAiYQsY0lwE5p1JnEKg4wXYmkKVzdP-gUdtYM0386nOsH1JZAcBgTgCbOQsYJJzALc2d73EtBYcMpMVmKY3yG6s_yyE_vOwrFFSG3Ywul2K0h6WXUpYZ0O6dG2gflKmeaIi8FYudRh-3uKZ9eWkIrXyldSpn8SM0DOaH2q5nTQi06LfYATCXIFHhaHe_4iXAVnMgjVJ8tdMQWM8xkx9afBntmRppjLp5v8gqrvdr1SATiOoFPD-Kue46bNQKUdDdbinn_rbKdU4owzl1L5Izsp5Loyvnl_Z-4ZNB_WVdUogbZhyVYoPMTE_XmuFifSax7x8_Jik2mMx_yZd9uxlCpNOh1I89g7SXdI7gpoDi3ocnXJGXl5-Rt4GILEbWQ5bRgp52fKA&isca=1) 

---

```
{"@timestamp":"2020-12-04T12:00:22.006Z","@version":"1","message":"failed to reconcile contract generation contractGeneration=589","logger_name":"dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler","thread_name":"vert.x-eventloop-thread-0","level":"ERROR","level_value":40000,"stack_trace":"java.lang.NullPointerException: null\n\tat java.base/java.util.concurrent.ConcurrentHashMap.get(Unknown Source)\n\tat io.vertx.core.impl.DeploymentManager.undeployVerticle(DeploymentManager.java:77)\n\tat io.vertx.core.impl.VertxImpl.lambda$undeploy$17(VertxImpl.java:708)\n\tat io.vertx.core.impl.future.ComposeTransformation.onSuccess(ComposeTransformation.java:38)\n\tat io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:61)\n\tat io.vertx.core.impl.future.SucceededFuture.addListener(SucceededFuture.java:82)\n\tat io.vertx.core.impl.future.FutureBase.compose(FutureBase.java:104)\n\tat io.vertx.core.impl.future.SucceededFuture.compose(SucceededFuture.java:27)\n\tat io.vertx.core.Future.compose(Future.java:199)\n\tat io.vertx.core.impl.VertxImpl.undeploy(VertxImpl.java:708)\n\tat dev.knative.eventing.kafka.broker.dispatcher.ConsumerDeployerVerticle.onDeleteEgress(ConsumerDeployerVerticle.java:129)\n\tat dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerImpl.reconcile(ResourcesReconcilerImpl.java:123)\n\tat dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler.handle(ResourcesReconcilerMessageHandler.java:45)\n\tat dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler.handle(ResourcesReconcilerMessageHandler.java:29)\n\tat io.vertx.core.impl.EventLoopContext.emit(EventLoopContext.java:52)\n\tat io.vertx.core.impl.DuplicatedContext.emit(DuplicatedContext.java:194)\n\tat io.vertx.core.eventbus.impl.MessageConsumerImpl.dispatch(MessageConsumerImpl.java:177)\n\tat io.vertx.core.eventbus.impl.HandlerRegistration$InboundDeliveryContext.next(HandlerRegistration.java:157)\n\tat io.vertx.core.eventbus.impl.HandlerRegistration$InboundDeliveryContext.dispatch(HandlerRegistration.java:128)\n\tat io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:107)\n\tat io.vertx.core.eventbus.impl.HandlerRegistration.dispatch(HandlerRegistration.java:104)\n\tat io.vertx.core.eventbus.impl.MessageConsumerImpl.deliver(MessageConsumerImpl.java:183)\n\tat io.vertx.core.eventbus.impl.MessageConsumerImpl.doReceive(MessageConsumerImpl.java:168)\n\tat io.vertx.core.eventbus.impl.HandlerRegistration.lambda$receive$0(HandlerRegistration.java:54)\n\tat io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)\n\tat io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)\n\tat io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500)\n\tat io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)\n\tat io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)\n\tat io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)\n\tat java.base/java.lang.Thread.run(Unknown Source)\n","contractGeneration":589}
```

```
{"@timestamp":"2020-12-04T12:00:23.033Z","@version":"1","message":"failed to reconcile contract generation contractGeneration=590","logger_name":"dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler","thread_name":"vert.x-eventloop-thread-0","level":"ERROR","level_value":40000,"stack_trace":"java.lang.NullPointerException: null\n\tat java.base/java.util.concurrent.ConcurrentHashMap.get(Unknown Source)\n\tat io.vertx.core.impl.DeploymentManager.undeployVerticle(DeploymentManager.java:77)\n\tat io.vertx.core.impl.VertxImpl.lambda$undeploy$17(VertxImpl.java:708)\n\tat io.vertx.core.impl.future.ComposeTransformation.onSuccess(ComposeTransformation.java:38)\n\tat io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:61)\n\tat io.vertx.core.impl.future.SucceededFuture.addListener(SucceededFuture.java:82)\n\tat io.vertx.core.impl.future.FutureBase.compose(FutureBase.java:104)\n\tat io.vertx.core.impl.future.SucceededFuture.compose(SucceededFuture.java:27)\n\tat io.vertx.core.Future.compose(Future.java:199)\n\tat io.vertx.core.impl.VertxImpl.undeploy(VertxImpl.java:708)\n\tat dev.knative.eventing.kafka.broker.dispatcher.ConsumerDeployerVerticle.onDeleteEgress(ConsumerDeployerVerticle.java:129)\n\tat dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerImpl.reconcile(ResourcesReconcilerImpl.java:157)\n\tat dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler.handle(ResourcesReconcilerMessageHandler.java:45)\n\tat dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler.handle(ResourcesReconcilerMessageHandler.java:29)\n\tat io.vertx.core.impl.EventLoopContext.emit(EventLoopContext.java:52)\n\tat io.vertx.core.impl.DuplicatedContext.emit(DuplicatedContext.java:194)\n\tat io.vertx.core.eventbus.impl.MessageConsumerImpl.dispatch(MessageConsumerImpl.java:177)\n\tat io.vertx.core.eventbus.impl.HandlerRegistration$InboundDeliveryContext.next(HandlerRegistration.java:157)\n\tat io.vertx.core.eventbus.impl.HandlerRegistration$InboundDeliveryContext.dispatch(HandlerRegistration.java:128)\n\tat io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:107)\n\tat io.vertx.core.eventbus.impl.HandlerRegistration.dispatch(HandlerRegistration.java:104)\n\tat io.vertx.core.eventbus.impl.MessageConsumerImpl.deliver(MessageConsumerImpl.java:183)\n\tat io.vertx.core.eventbus.impl.MessageConsumerImpl.doReceive(MessageConsumerImpl.java:168)\n\tat io.vertx.core.eventbus.impl.HandlerRegistration.lambda$receive$0(HandlerRegistration.java:54)\n\tat io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)\n\tat io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)\n\tat io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500)\n\tat io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)\n\tat io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)\n\tat io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)\n\tat java.base/java.lang.Thread.run(Unknown Source)\n","contractGeneration":590}
```

```
{"@timestamp":"2020-12-04T12:01:09.560Z","@version":"1","message":"failed to reconcile contract generation contractGeneration=649","logger_name":"dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler","thread_name":"vert.x-eventloop-thread-0","level":"ERROR","level_value":40000,"stack_trace":"java.lang.NullPointerException: null\n\tat java.base/java.util.concurrent.ConcurrentHashMap.get(Unknown Source)\n\tat io.vertx.core.impl.DeploymentManager.undeployVerticle(DeploymentManager.java:77)\n\tat io.vertx.core.impl.VertxImpl.lambda$undeploy$17(VertxImpl.java:708)\n\tat io.vertx.core.impl.future.ComposeTransformation.onSuccess(ComposeTransformation.java:38)\n\tat io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:61)\n\tat io.vertx.core.impl.future.SucceededFuture.addListener(SucceededFuture.java:82)\n\tat io.vertx.core.impl.future.FutureBase.compose(FutureBase.java:104)\n\tat io.vertx.core.impl.future.SucceededFuture.compose(SucceededFuture.java:27)\n\tat io.vertx.core.Future.compose(Future.java:199)\n\tat io.vertx.core.impl.VertxImpl.undeploy(VertxImpl.java:708)\n\tat dev.knative.eventing.kafka.broker.dispatcher.ConsumerDeployerVerticle.onDeleteEgress(ConsumerDeployerVerticle.java:129)\n\tat dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerImpl.reconcile(ResourcesReconcilerImpl.java:123)\n\tat dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler.handle(ResourcesReconcilerMessageHandler.java:45)\n\tat dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler.handle(ResourcesReconcilerMessageHandler.java:29)\n\tat io.vertx.core.impl.EventLoopContext.emit(EventLoopContext.java:52)\n\tat io.vertx.core.impl.DuplicatedContext.emit(DuplicatedContext.java:194)\n\tat io.vertx.core.eventbus.impl.MessageConsumerImpl.dispatch(MessageConsumerImpl.java:177)\n\tat io.vertx.core.eventbus.impl.HandlerRegistration$InboundDeliveryContext.next(HandlerRegistration.java:157)\n\tat io.vertx.core.eventbus.impl.HandlerRegistration$InboundDeliveryContext.dispatch(HandlerRegistration.java:128)\n\tat io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:107)\n\tat io.vertx.core.eventbus.impl.HandlerRegistration.dispatch(HandlerRegistration.java:104)\n\tat io.vertx.core.eventbus.impl.MessageConsumerImpl.deliver(MessageConsumerImpl.java:183)\n\tat io.vertx.core.eventbus.impl.MessageConsumerImpl.doReceive(MessageConsumerImpl.java:168)\n\tat io.vertx.core.eventbus.impl.HandlerRegistration.lambda$receive$0(HandlerRegistration.java:54)\n\tat io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)\n\tat io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)\n\tat io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500)\n\tat io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)\n\tat io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)\n\tat io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)\n\tat java.base/java.lang.Thread.run(Unknown Source)\n","contractGeneration":649}
```
Contract generation correlation:
```
{"level":"debug","ts":"2020-12-04T12:00:21.143Z","logger":"kafka-broker-cm-watcher","caller":"base/reconciler.go:143","msg":"Unmarshalling configmap","format":"json"}
2020/12/04 12:00:21   (
  	"""
  	{
- 	  "generation":  "588",
+ 	  "generation":  "589",
  	  "resources":  [
  	    {
  	... // 444 identical lines
  	      },
  	      "egresses":  [
- 	        {
- 	          "consumerGroup":  "5fe216c0-e563-433e-9f8c-7ab0ae273656",
- 	          "destination":  "http://logger-pod.test-broker-v1-beta1-control-plane-3-zh9bn.svc.cluster.local/",
- 	          "filter":  {
- 	            "attributes":  {
- 	              "source":  "",
- 	              "type":  "logger"
- 	            }
- 	          },
- 	          "uid":  "5fe216c0-e563-433e-9f8c-7ab0ae273656"
- 	        },
  	        {
  	          "consumerGroup":  "c7453ecb-0e64-473c-a293-0b0b4a53f121",
  	... // 13 identical lines
  	"""
  )
```

```
{"level":"debug","ts":"2020-12-04T12:00:22.162Z","logger":"kafka-broker-cm-watcher","caller":"base/reconciler.go:143","msg":"Unmarshalling configmap","format":"json"}
2020/12/04 12:00:22   strings.Join({
  	"{",
- 	`  "generation":  "589",`,
+ 	`  "generation":  "590",`,
  	`  "resources":  [`,
  	"    {",
  	... // 442 identical lines
  	`      "ingress":  {`,
  	`        "path":  "/test-broker-v1-beta1-control-plane-3-zh9bn/br"`,
- 	"      },",
- 	`      "egresses":  [`,
- 	"        {",
- 	`          "consumerGroup":  "c7453ecb-0e64-473c-a293-0b0b4a53f121",`,
- 	`          "destination":  "http://logger-pod.test-broker-v1-beta1-control-plane-3-zh9bn.svc.cluster.local/",`,
- 	`          "filter":  {`,
- 	`            "attributes":  {`,
- 	`              "source":  "",`,
- 	`              "type":  "logger"`,
- 	"            }",
- 	"          },",
- 	`          "uid":  "c7453ecb-0e64-473c-a293-0b0b4a53f121"`,
- 	"        }",
- 	"      ]",
+ 	"      }",
  	"    }",
  	"  ]",
  	"}",
  }, "\n")
```

```
{"level":"debug","ts":"2020-12-04T12:01:08.707Z","logger":"kafka-broker-cm-watcher","caller":"base/reconciler.go:143","msg":"Unmarshalling configmap","format":"json"}
2020/12/04 12:01:08   (
  	"""
  	{
- 	  "generation":  "648",
+ 	  "generation":  "649",
  	  "resources":  [
  	    {
  	... // 294 identical lines
  	      },
  	      "egresses":  [
- 	        {
- 	          "consumerGroup":  "a87d27c3-8235-4f32-a986-9d56a202371c",
- 	          "destination":  "http://logger-pod.test-broker-v1-beta1-control-plane-4-jw2hb.svc.cluster.local/",
- 	          "filter":  {
- 	            "attributes":  {
- 	              "source":  "",
- 	              "type":  "logger"
- 	            }
- 	          },
- 	          "uid":  "a87d27c3-8235-4f32-a986-9d56a202371c"
- 	        },
  	        {
  	          "consumerGroup":  "d7689bed-c54b-4e51-a5c8-c57d52fa8b71",
  	... // 13 identical lines
  	"""
  )
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

/cc pierDipi