### PR TITLE
Add gomod dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,15 @@
 
 version: 2
 updates:
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/data-plane" # Location of package manifests
+  - package-ecosystem: "gomod"
+    vendor: true
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "master"
+
+  - package-ecosystem: "maven"
+    directory: "/data-plane"
     schedule:
       interval: "daily"
     assignees:


### PR DESCRIPTION
Now, Dependabot supports go mod vendor
https://github.blog/changelog/2020-10-19-dependabot-go-mod-tidy-and-vendor-support/.

## Proposed Changes

- Add gomod dependabot configuration
