### PR TITLE
Change auto topic create to be false

### DIFF
--- a/test/kafka/kafka-ephemeral-single.yaml
+++ b/test/kafka/kafka-ephemeral-single.yaml
@@ -28,6 +28,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      auto.create.topics.enable: false
     storage:
       type: ephemeral
   zookeeper:


### PR DESCRIPTION
Fixes #472

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Set auto.create.topics.enable to false

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
