### PR TITLE
Change release labels to kafka.eventing.knative.dev

### DIFF
--- a/control-plane/config/100-config-tracing.yaml
+++ b/control-plane/config/100-config-tracing.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-tracing
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
   annotations:

--- a/control-plane/config/100-kafka-broker-configmap.yaml
+++ b/control-plane/config/100-kafka-broker-configmap.yaml
@@ -19,6 +19,8 @@ kind: ConfigMap
 metadata:
   name: kafka-broker-config
   namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
 data:
   default.topic.partitions: "10"
   default.topic.replication.factor: "3"

--- a/control-plane/config/200-controller-cluster-role.yaml
+++ b/control-plane/config/200-controller-cluster-role.yaml
@@ -19,7 +19,7 @@ kind: ClusterRole
 metadata:
   name: kafka-controller
   labels:
-    contrib.eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - "*"

--- a/control-plane/config/200-controller-service-account.yaml
+++ b/control-plane/config/200-controller-service-account.yaml
@@ -20,4 +20,4 @@ metadata:
   name: kafka-controller
   namespace: knative-eventing
   labels:
-    contrib.eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel

--- a/control-plane/config/201-controller-cluster-role-binding.yaml
+++ b/control-plane/config/201-controller-cluster-role-binding.yaml
@@ -19,7 +19,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller
   labels:
-    contrib.eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -34,6 +34,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kafka-controller-addressable-resolver
+  labels:
+    kafka.eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-controller

--- a/control-plane/config/500-controller.yaml
+++ b/control-plane/config/500-controller.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -32,7 +32,7 @@ spec:
       name: kafka-controller
       labels:
         app: kafka-controller
-        eventing.knative.dev/release: devel
+        kafka.eventing.knative.dev/release: devel
     spec:
       securityContext:
         runAsNonRoot: true

--- a/control-plane/config/sink/100-kafka-sink.yaml
+++ b/control-plane/config/sink/100-kafka-sink.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     duck.knative.dev/addressable: "true"
     knative.dev/crd-install: "true"
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 spec:
   group: eventing.knative.dev
   names:

--- a/control-plane/config/sink/100-webhook-cluster-role.yaml
+++ b/control-plane/config/sink/100-webhook-cluster-role.yaml
@@ -19,7 +19,7 @@ kind: ClusterRole
 metadata:
   name: kafka-webhook-eventing
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 rules:
   # For watching logging configuration and getting certs.
   - apiGroups:
@@ -81,9 +81,3 @@ rules:
     resources:
       - "leases"
     verbs: *everything
-
-  # Necessary for conversion webhook. These are copied from the eventing (which are copied from serving)
-  # TODO: Do we really need all these permissions?
-  - apiGroups: [ "apiextensions.k8s.io" ]
-    resources: [ "customresourcedefinitions" ]
-    verbs: [ "get", "list", "create", "update", "delete", "patch", "watch" ]

--- a/control-plane/config/sink/100-webhook-service-account.yaml
+++ b/control-plane/config/sink/100-webhook-service-account.yaml
@@ -20,4 +20,4 @@ metadata:
   name: kafka-webhook-eventing
   namespace: knative-eventing
   labels:
-    contrib.eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel

--- a/control-plane/config/sink/200-addressable-resolver-cluster-role.yaml
+++ b/control-plane/config/sink/200-addressable-resolver-cluster-role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kafkasinks-addressable-resolver
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:

--- a/control-plane/config/sink/200-webhook-cluster-role-binding.yaml
+++ b/control-plane/config/sink/200-webhook-cluster-role-binding.yaml
@@ -19,7 +19,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-webhook-eventing
   labels:
-    contrib.eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-webhook-eventing

--- a/control-plane/config/sink/400-webhook-defaulting.yaml
+++ b/control-plane/config/sink/400-webhook-defaulting.yaml
@@ -17,7 +17,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:

--- a/control-plane/config/sink/400-webhook-secret.yaml
+++ b/control-plane/config/sink/400-webhook-secret.yaml
@@ -18,5 +18,5 @@ metadata:
   name: kafka-webhook-eventing-certs
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 # The data is populated at install time.

--- a/control-plane/config/sink/400-webhook-validation.yaml
+++ b/control-plane/config/sink/400-webhook-validation.yaml
@@ -17,7 +17,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.kafka.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:

--- a/control-plane/config/sink/500-webhook.yaml
+++ b/control-plane/config/sink/500-webhook.yaml
@@ -18,16 +18,18 @@ metadata:
   name: kafka-webhook-eventing
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app: kafka-webhook-eventing
+    kafka.eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
-    matchLabels: &labels
+    matchLabels:
       app: kafka-webhook-eventing
-      role: kafka-webhook-eventing
   template:
     metadata:
-      labels: *labels
+      labels:
+        app: kafka-webhook-eventing
+        kafka.eventing.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -107,15 +109,15 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    eventing.knative.dev/release: devel
-    role: kafka-webhook-eventing
   name: kafka-webhook-eventing
   namespace: knative-eventing
+  labels:
+    app: kafka-webhook-eventing
+    kafka.eventing.knative.dev/release: devel
 spec:
   ports:
     - name: https-webhook
       port: 443
       targetPort: 8443
   selector:
-    role: kafka-webhook-eventing
+    app: kafka-webhook-eventing

--- a/data-plane/config/100-config-kafka-broker-data-plane.yaml
+++ b/data-plane/config/100-config-kafka-broker-data-plane.yaml
@@ -19,6 +19,8 @@ kind: ConfigMap
 metadata:
   name: config-kafka-broker-data-plane
   namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
 data:
   config-kafka-broker-producer.properties: |
     key.serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/data-plane/config/100-config-logging.yaml
+++ b/data-plane/config/100-config-logging.yaml
@@ -19,6 +19,8 @@ kind: ConfigMap
 metadata:
   name: kafka-config-logging
   namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
 data:
   config.xml: |
     <configuration>

--- a/data-plane/config/sink/100-config-kafka-sink-data-plane.yaml
+++ b/data-plane/config/sink/100-config-kafka-sink-data-plane.yaml
@@ -19,6 +19,8 @@ kind: ConfigMap
 metadata:
   name: config-kafka-sink-data-plane
   namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
 data:
   config-kafka-sink-producer.properties: |
     key.serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/data-plane/config/sink/template/500-receiver.yaml
+++ b/data-plane/config/sink/template/500-receiver.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-sink-receiver
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -32,7 +32,7 @@ spec:
       name: kafka-sink-receiver
       labels:
         app: kafka-sink-receiver
-        eventing.knative.dev/release: devel
+        kafka.eventing.knative.dev/release: devel
     spec:
       securityContext:
         runAsNonRoot: true
@@ -146,6 +146,9 @@ kind: Service
 metadata:
   name: kafka-sink-ingress
   namespace: knative-eventing
+  labels:
+    app: kafka-sink-receiver
+    kafka.eventing.knative.dev/release: devel
 spec:
   selector:
     app: kafka-sink-receiver

--- a/data-plane/config/template/500-dispatcher.yaml
+++ b/data-plane/config/template/500-dispatcher.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-dispatcher
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -32,7 +32,7 @@ spec:
       name: kafka-broker-dispatcher
       labels:
         app: kafka-broker-dispatcher
-        eventing.knative.dev/release: devel
+        kafka.eventing.knative.dev/release: devel
     spec:
       securityContext:
         runAsNonRoot: true

--- a/data-plane/config/template/500-receiver.yaml
+++ b/data-plane/config/template/500-receiver.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-receiver
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -32,7 +32,7 @@ spec:
       name: kafka-broker-receiver
       labels:
         app: kafka-broker-receiver
-        eventing.knative.dev/release: devel
+        kafka.eventing.knative.dev/release: devel
     spec:
       securityContext:
         runAsNonRoot: true
@@ -147,6 +147,9 @@ kind: Service
 metadata:
   name: kafka-broker-ingress
   namespace: knative-eventing
+  labels:
+    app: kafka-broker-receiver
+    kafka.eventing.knative.dev/release: devel
 spec:
   selector:
     app: kafka-broker-receiver

--- a/hack/label.sh
+++ b/hack/label.sh
@@ -16,8 +16,8 @@
 
 # Update release labels if this is a tagged release
 if [[ -n "${TAG}" ]]; then
-  echo "Tagged release, updating release labels to eventing.knative.dev/release: \"${TAG}\""
-  export LABEL_YAML_CMD=(sed -e "s|eventing.knative.dev/release: devel|eventing.knative.dev/release: \"${TAG}\"|")
+  echo "Tagged release, updating release labels to kafka.eventing.knative.dev/release: \"${TAG}\""
+  export LABEL_YAML_CMD=(sed -e "s|kafka.eventing.knative.dev/release: devel|kafka.eventing.knative.dev/release: \"${TAG}\"|")
 else
   echo "Untagged release, will NOT update release labels"
   export LABEL_YAML_CMD=(cat)

--- a/test/config/100-config-logging.yaml
+++ b/test/config/100-config-logging.yaml
@@ -19,6 +19,8 @@ kind: ConfigMap
 metadata:
   name: kafka-config-logging
   namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
 data:
   config.xml: |
     <configuration>
@@ -41,7 +43,7 @@ metadata:
   name: config-logging
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
 data:

--- a/test/config/chaos/chaosduck.yaml
+++ b/test/config/chaos/chaosduck.yaml
@@ -18,7 +18,7 @@ metadata:
   name: chaosduck
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 
 ---
 kind: Role
@@ -27,7 +27,7 @@ metadata:
   name: chaosduck
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -43,7 +43,7 @@ metadata:
   name: chaosduck
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -60,7 +60,7 @@ metadata:
   name: chaosduck
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 spec:
   selector:
     matchLabels:

--- a/test/config/cm-watcher.yaml
+++ b/test/config/cm-watcher.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: test-kafka-broker-cm-watcher
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -30,7 +30,7 @@ spec:
       name: test-kafka-broker-cm-watcher
       labels:
         app: test-kafka-broker-cm-watcher
-        eventing.knative.dev/release: devel
+        kafka.eventing.knative.dev/release: devel
     spec:
       securityContext:
         runAsNonRoot: true

--- a/test/config/config-br-defaults.yaml
+++ b/test/config/config-br-defaults.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-br-defaults
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 data:
   default-br-config: |
     clusterDefault:


### PR DESCRIPTION
Fixes #468 

This was suggested by @matzew (https://knative.slack.com/archives/CR2141CGY/p1607526133257700) following the PR in `eventing-kafka` (https://github.com/knative-sandbox/eventing-kafka/pull/267)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Change release labels from `eventing.knative.dev` to `kafka.eventing.knative.dev`

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Change release labels from `eventing.knative.dev` to `kafka.eventing.knative.dev`.
```

/kind cleanup