### PR TITLE
Set anti-affinity for receiver deployment

### DIFF
--- a/data-plane/config/sink/template/500-receiver.yaml
+++ b/data-plane/config/sink/template/500-receiver.yaml
@@ -37,6 +37,16 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: kafka-sink-receiver
+                topologyKey: kubernetes.io/hostname
+              weight: 100
       containers:
         - name: kafka-sink-receiver
           image: ${KNATIVE_KAFKA_SINK_RECEIVER_IMAGE}

--- a/data-plane/config/template/500-receiver.yaml
+++ b/data-plane/config/template/500-receiver.yaml
@@ -37,6 +37,16 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: kafka-broker-receiver
+                topologyKey: kubernetes.io/hostname
+              weight: 100
       containers:
         - name: kafka-broker-receiver
           image: ${KNATIVE_KAFKA_BROKER_RECEIVER_IMAGE}


### PR DESCRIPTION
Signed-off-by: Arghya Sadhu <arghya88@gmail.com>

Fixes #482

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Set anti-affinity for receiver deployment


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Receivers now specify anti-affinity so that replicas will not be colocated
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
