### PR TITLE
Avoid logging the entire resource

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerDeployerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerDeployerVerticle.java
@@ -90,8 +90,8 @@ public final class ConsumerDeployerVerticle extends AbstractVerticle implements 
         .onSuccess(deploymentId -> {
           this.deployedDispatchers.put(egress.getUid(), deploymentId);
           logger.info("Verticle deployed {} {} {}",
-            keyValue("egress", egress),
-            keyValue("resource", resource),
+            keyValue("egress.uid", egress.getUid()),
+            keyValue("resource.uid", resource.getUid()),
             keyValue("deploymentId", deploymentId)
           );
         })
@@ -106,8 +106,8 @@ public final class ConsumerDeployerVerticle extends AbstractVerticle implements 
         .mapEmpty();
     } catch (Exception e) {
       logger.error("potential control-plane bug: failed to get verticle {} {}",
-        keyValue("egress", egress),
-        keyValue("resource", resource),
+        keyValue("egress.uid", egress.getUid()),
+        keyValue("resource.uid", resource.getUid()),
         e
       );
       return Future.failedFuture(new IllegalStateException("Potential control-plane bug: failed to get verticle", e));
@@ -129,13 +129,13 @@ public final class ConsumerDeployerVerticle extends AbstractVerticle implements 
     return vertx.undeploy(this.deployedDispatchers.remove(egress.getUid()))
       .onSuccess(v -> logger.info(
         "Removed egress {} {}",
-        keyValue("egress", egress),
-        keyValue("resource", resource)
+        keyValue("egress.uid", egress.getUid()),
+        keyValue("resource.uid", resource.getUid())
       ))
       .onFailure(cause -> logger.error(
         "failed to un-deploy verticle {} {}",
-        keyValue("egress", egress),
-        keyValue("resource", resource),
+        keyValue("egress.uid", egress.getUid()),
+        keyValue("resource.uid", resource.getUid()),
         cause
       ));
   }


### PR DESCRIPTION
Logging the entire resource might block the event loop thread.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Avoid logging the entire resource

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

<!--
**Release Note**

:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

/assign slinkydeveloper 