### PR TITLE
Remove replicas from our Deployments

### DIFF
--- a/control-plane/config/500-controller.yaml
+++ b/control-plane/config/500-controller.yaml
@@ -23,7 +23,6 @@ metadata:
     app: kafka-controller
     kafka.eventing.knative.dev/release: devel
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: kafka-controller

--- a/control-plane/config/sink/500-webhook.yaml
+++ b/control-plane/config/sink/500-webhook.yaml
@@ -21,7 +21,6 @@ metadata:
     app: kafka-webhook-eventing
     kafka.eventing.knative.dev/release: devel
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: kafka-webhook-eventing

--- a/data-plane/config/sink/template/500-receiver.yaml
+++ b/data-plane/config/sink/template/500-receiver.yaml
@@ -23,7 +23,6 @@ metadata:
     app: kafka-sink-receiver
     kafka.eventing.knative.dev/release: devel
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: kafka-sink-receiver

--- a/data-plane/config/template/500-dispatcher.yaml
+++ b/data-plane/config/template/500-dispatcher.yaml
@@ -23,7 +23,6 @@ metadata:
     app: kafka-broker-dispatcher
     kafka.eventing.knative.dev/release: devel
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: kafka-broker-dispatcher

--- a/data-plane/config/template/500-receiver.yaml
+++ b/data-plane/config/template/500-receiver.yaml
@@ -23,7 +23,6 @@ metadata:
     app: kafka-broker-receiver
     kafka.eventing.knative.dev/release: devel
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: kafka-broker-receiver


### PR DESCRIPTION
- There is no need to hard-code replicas since the default is 1.
- An upgrade won't force a scale down if a Deployment has been
scaled up.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove replicas from our Deployments