### PR TITLE
Fix imports in release script

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -19,8 +19,8 @@ set -o nounset
 set -o pipefail
 
 source $(dirname $0)/../vendor/knative.dev/hack/release.sh
-source $(dirname $0)/../test/data-plane/library.sh
-source $(dirname $0)/../test/control-plane/library.sh
+source $(dirname $0)/data-plane.sh
+source $(dirname $0)/control-plane.sh
 
 export EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT="eventing-kafka-controller.yaml"
 export EVENTING_KAFKA_BROKER_ARTIFACT="eventing-kafka-broker.yaml"


### PR DESCRIPTION
Nightly release failed with:
`./hack/release.sh: line 22: ./hack/../test/data-plane/library.sh: No such file or directory`

Ref: https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-sandbox-eventing-kafka-broker-nightly-release/1340595282286481408

## Proposed Changes

- Fix imports in release script
