### PR TITLE
Skip ConfigMap update when there are no changes

### DIFF
--- a/control-plane/pkg/reconciler/trigger/trigger_test.go
+++ b/control-plane/pkg/reconciler/trigger/trigger_test.go
@@ -507,31 +507,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 			WantPatches: []clientgotesting.PatchActionImpl{
 				patchFinalizers(),
 			},
-			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
-					Resources: []*contract.Resource{
-						{
-							Uid:     BrokerUUID,
-							Topics:  []string{BrokerTopic()},
-							Ingress: &contract.Ingress{IngressType: &contract.Ingress_Path{Path: receiver.Path(BrokerNamespace, BrokerName)}},
-							Egresses: []*contract.Egress{
-								{
-									Destination:   ServiceURL,
-									ConsumerGroup: TriggerUUID,
-									Uid:           TriggerUUID,
-									Filter: &contract.Filter{Attributes: map[string]string{
-										"type": "type1",
-									}},
-								},
-							},
-						},
-					},
-					Generation: 1,
-				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
-					base.VolumeGenerationAnnotationKey: "1",
-				}),
-			},
+			WantUpdates: []clientgotesting.UpdateActionImpl{},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
 				{
 					Object: newTrigger(
@@ -980,6 +956,9 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 									Destination:   ServiceURL,
 									ConsumerGroup: TriggerUUID,
 									Uid:           TriggerUUID,
+									Filter: &contract.Filter{Attributes: map[string]string{
+										"source": "source2",
+									}},
 								},
 								{
 									Destination:   "http://example.com/3",


### PR DESCRIPTION
During E2E tests there are a lot of no-op reconciliation
since chaosduck kills the leader pod and every time
a new replica starts we trigger a global resync that 
most of the time doesn't actually change the ConfigMap.

For example, the ConfigMap diff looks like this:

```
  	"""
  	{
- 	  "generation": "1",
+ 	  "generation": "2",
  	  "resources": [
  	    {
  	... // 15 identical lines
  	"""
  )
```

This leads to an unnecessary reconciliation loop on the data plane
and increase update conflicts of the ConfigMap.

## Proposed Changes

- Skip ConfigMap update when there are no changes

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:broom: Update or clean up current behavior
Skip ConfigMap update when there are no changes
```

/kind cleanup