### PR TITLE
Fix TimeoutException and DnsNameResolverTimeoutException

### DIFF
--- a/data-plane/config/template/500-dispatcher.yaml
+++ b/data-plane/config/template/500-dispatcher.yaml
@@ -139,3 +139,6 @@ spec:
           configMap:
             name: config-tracing
       restartPolicy: Always
+      dnsConfig:
+        options:
+          - name: single-request-reopen


### PR DESCRIPTION
Fixes #537

During E2E tests there are a couple of TimeoutException due to 
DNS name resolver timeout:
```
io.vertx.circuitbreaker.TimeoutException: operation timeout
```
The root cause of the issue is https://github.com/netty/netty/issues/8880, 
and the solution is to add [`single-request-reopen` as a DNS config](https://github.com/netty/netty/issues/8880#issuecomment-558411219).

What does `single-request-reopen` do?

From https://man7.org/linux/man-pages/man5/resolv.conf.5.html
```
              single-request (since glibc 2.10)
                     Sets RES_SNGLKUP in _res.options.  By default,
                     glibc performs IPv4 and IPv6 lookups in parallel
                     since version 2.9.  Some appliance DNS servers
                     cannot handle these queries properly and make the
                     requests time out.  This option disables the
                     behavior and makes glibc perform the IPv6 and IPv4
                     requests sequentially (at the cost of some slowdown
                     of the resolving process).
              single-request-reopen (since glibc 2.9)
                     Sets RES_SNGLKUPREOP in _res.options.  The resolver
                     uses the same socket for the A and AAAA requests.
                     Some hardware mistakenly sends back only one reply.
                     When that happens the client system will sit and
                     wait for the second reply.  Turning this option on
                     changes this behavior so that if two requests from
                     the same port are not handled correctly it will
                     close the socket and open a new one before sending
                     the second request.
```

Other issues suggesting the usage of this configuration:
- https://github.com/kubernetes/kubernetes/issues/62628
- https://github.com/Azure/AKS/issues/667

## Proposed Changes

- Add `single-request-reopen` as DNS config

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Fix TimeoutException and DnsNameResolverTimeoutException.
```

/kind bug