### PR TITLE
Run on K8s 1.20.0 and bump 1.19 to 1.19.4

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -23,7 +23,8 @@ jobs:
         k8s-version:
           - v1.17.11
           - v1.18.8
-          - v1.19.1
+          - v1.19.4
+          - v1.20.0
 
         test-suite:
           - ./test/e2e
@@ -38,9 +39,12 @@ jobs:
           - k8s-version: v1.18.8
             kind-version: v0.9.0
             kind-image-sha: sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb
-          - k8s-version: v1.19.1
+          - k8s-version: v1.19.4
             kind-version: v0.9.0
-            kind-image-sha: sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
+            kind-image-sha: sha256:796d09e217d93bed01ecf8502633e48fd806fe42f9d02fdd468b81cd4e3bd40b
+          - k8s-version: v1.20.0
+            kind-version: v0.9.0
+            kind-image-sha: sha256:b40ecf8bcb188f6a0d0f5d406089c48588b75edc112c6f635d26be5de1c89040
 
           # Add the flags we use for each of these test suites.
           - test-suite: ./test/e2e


### PR DESCRIPTION
Fixes #535

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Run on K8s 1.20.0 and bump 1.19 to 1.19.4

```release-note
Support Kubernetes 1.20.
```
