### PR TITLE
Patch HPA min replicas for eventing-webhook

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -69,6 +69,8 @@ function knative_eventing() {
     kubectl apply -f ${KNATIVE_EVENTING_RELEASE}
   fi
 
+  kubectl patch horizontalpodautoscalers.autoscaling -n knative-eventing eventing-webhook -p '{"spec": {"minReplicas": '${REPLICAS}'}}'
+
   # Publish test images.
   echo ">> Publishing test images from eventing"
   # We vendor test image code from eventing, in order to use ko to resolve them into Docker images, the


### PR DESCRIPTION
Eventing webhook HPA config sets MinReplicas to 1 and while chaosduck
kills the webhook we get 0 replicas available during E2E tests.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Patch HPA min replicas for eventing-webhook