### PR TITLE
Fix link to Kafka download page

### DIFF
--- a/data-plane/profiler/run.sh
+++ b/data-plane/profiler/run.sh
@@ -39,7 +39,7 @@ echo "Profiling event ${EVENT}"
 PROJECT_ROOT_DIR=$(dirname $0)/..
 RESOURCES_DIR="$(dirname $0)"/resources
 ASYNC_PROFILER_URL="https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.0-b1/async-profiler-2.0-b1-linux-x64.tar.gz"
-KAFKA_URL="https://downloads.apache.org/kafka/2.6.0/kafka_2.12-2.6.0.tgz"
+KAFKA_URL="https://archive.apache.org/dist/kafka/2.6.0/kafka_2.13-2.6.0.tgz"
 
 echo "Project root dir: ${PROJECT_ROOT_DIR}"
 echo "Resource dir: ${RESOURCES_DIR}"


### PR DESCRIPTION
As per title, profiling CI job was trying to download Kafka from an
old page, archive links should be much more stable.
