### PR TITLE
[release-0.20] Set auto offset reset to earliest 

### DIFF
--- a/data-plane/config/100-config-kafka-broker-data-plane.yaml
+++ b/data-plane/config/100-config-kafka-broker-data-plane.yaml
@@ -65,7 +65,7 @@ data:
     # ssl.truststore.location=
     # ssl.truststore.password=
     allow.auto.create.topics=true
-    auto.offset.reset=latest
+    auto.offset.reset=earliest
     client.dns.lookup=use_all_dns_ips
     connections.max.idle.ms=540000
     default.api.timeout.ms=60000


### PR DESCRIPTION
Part of https://github.com/knative-sandbox/eventing-kafka-broker/issues/556

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Consume topic from the earliest offset

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:bug: Consume topic from the earliest offset
```