### PR TITLE
Handle ClosedWatchServiceEx and timeouts

### DIFF
--- a/data-plane/config/sink/template/500-receiver.yaml
+++ b/data-plane/config/sink/template/500-receiver.yaml
@@ -105,6 +105,9 @@ spec:
             # https://github.com/fabric8io/kubernetes-client/issues/2212
             - name: HTTP2_DISABLE
               value: "true"
+            # This should be set according to initial delay seconds
+            - name: WAIT_STARTUP_SECONDS
+              value: "8"
           command:
             - "java"
           args:
@@ -118,7 +121,7 @@ spec:
               port: 8080
               path: /healthz
               scheme: HTTP
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 1
@@ -128,7 +131,7 @@ spec:
               port: 8080
               path: /readyz
               scheme: HTTP
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 1

--- a/data-plane/config/template/500-dispatcher.yaml
+++ b/data-plane/config/template/500-dispatcher.yaml
@@ -94,6 +94,9 @@ spec:
             # https://github.com/fabric8io/kubernetes-client/issues/2212
             - name: HTTP2_DISABLE
               value: "true"
+            # This should be set according to initial delay seconds
+            - name: WAIT_STARTUP_SECONDS
+              value: "8"
           command:
             - "java"
           args:
@@ -107,7 +110,7 @@ spec:
               port: 9090
               path: /metrics
               scheme: HTTP
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 1
@@ -117,7 +120,7 @@ spec:
               port: 9090
               path: /metrics
               scheme: HTTP
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 1

--- a/data-plane/config/template/500-receiver.yaml
+++ b/data-plane/config/template/500-receiver.yaml
@@ -105,6 +105,9 @@ spec:
             # https://github.com/fabric8io/kubernetes-client/issues/2212
             - name: HTTP2_DISABLE
               value: "true"
+            # This should be set according to initial delay seconds
+            - name: WAIT_STARTUP_SECONDS
+              value: "8"
           command:
             - "java"
           args:
@@ -118,7 +121,7 @@ spec:
               port: 8080
               path: /healthz
               scheme: HTTP
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 1
@@ -128,7 +131,7 @@ spec:
               port: 8080
               path: /readyz
               scheme: HTTP
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 1

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/BaseEnv.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/BaseEnv.java
@@ -15,9 +15,9 @@
  */
 package dev.knative.eventing.kafka.broker.core.utils;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
 
 public class BaseEnv {
 
@@ -31,6 +31,8 @@ public class BaseEnv {
 
   public static final String CONFIG_TRACING_PATH = "CONFIG_TRACING_PATH";
 
+  public static final String WAIT_STARTUP_SECONDS = "WAIT_STARTUP_SECONDS";
+
   private final String producerConfigFilePath;
   private final String dataPlaneConfigFilePath;
 
@@ -41,6 +43,8 @@ public class BaseEnv {
 
   private final String configTracingPath;
 
+  private final int waitStartupSeconds;
+
   public BaseEnv(Function<String, String> envProvider) {
     this.metricsPath = requireNonNull(envProvider.apply(METRICS_PATH));
     this.metricsPort = Integer.parseInt(requireNonNull(envProvider.apply(METRICS_PORT)));
@@ -49,6 +53,7 @@ public class BaseEnv {
     this.producerConfigFilePath = requireNonNull(envProvider.apply(PRODUCER_CONFIG_FILE_PATH));
     this.dataPlaneConfigFilePath = requireNonNull(envProvider.apply(DATA_PLANE_CONFIG_FILE_PATH));
     this.configTracingPath = requireNonNull(envProvider.apply(CONFIG_TRACING_PATH));
+    this.waitStartupSeconds = Integer.parseInt(envProvider.apply(WAIT_STARTUP_SECONDS));
   }
 
   public String getProducerConfigFilePath() {
@@ -77,6 +82,10 @@ public class BaseEnv {
 
   public String getConfigTracingPath() {
     return configTracingPath;
+  }
+
+  public int getWaitStartupSeconds() {
+    return waitStartupSeconds;
   }
 
   @Override

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/Shutdown.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/Shutdown.java
@@ -16,10 +16,11 @@
 package dev.knative.eventing.kafka.broker.core.utils;
 
 import io.vertx.core.Vertx;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class Shutdown {
 
@@ -27,6 +28,7 @@ public class Shutdown {
 
   public static Runnable run(final Vertx vertx, final AutoCloseable... closeables) {
     return () -> {
+      logger.info("Executing shutdown");
       for (AutoCloseable closeable : closeables) {
         try {
           closeable.close();
@@ -40,6 +42,7 @@ public class Shutdown {
 
   public static Runnable closeSync(final Vertx vertx) {
     return () -> {
+      logger.info("Closing Vert.x");
       final var wait = new CountDownLatch(1);
       vertx.close(ignore -> wait.countDown());
       try {

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/utils/BaseEnvTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/utils/BaseEnvTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 
 public class BaseEnvTest {
 
-
   private static final Function<String, String> provider = s -> switch (s) {
     case "PRODUCER_CONFIG_FILE_PATH" -> "/tmp/config";
     case "DATA_PLANE_CONFIG_FILE_PATH" -> "/tmp/config-data";
@@ -31,6 +30,7 @@ public class BaseEnvTest {
     case "METRICS_PUBLISH_QUANTILES" -> "TRUE";
     case "CONFIG_TRACING_PATH" -> "/etc/tracing";
     case "METRICS_JVM_ENABLED" -> "false";
+    case "WAIT_STARTUP_SECONDS" -> "1";
     default -> throw new IllegalArgumentException("unknown " + s);
   };
 

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/ReceiverEnvTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/ReceiverEnvTest.java
@@ -15,10 +15,10 @@
  */
 package dev.knative.eventing.kafka.broker.receiver;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import dev.knative.eventing.kafka.broker.core.utils.BaseEnv;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ReceiverEnvTest {
 
@@ -30,6 +30,7 @@ class ReceiverEnvTest {
   private static final String HTTPSERVER_CONFIG_FILE_PATH = "/etc/http-server-config";
   private static final String TRACING_CONFIG_PATH = "/etc/tracing";
   private static final String METRICS_JVM_ENABLED = "true";
+  public static final int WAIT_STARTUP_SECONDS = 8;
 
   @Test
   public void create() {
@@ -46,6 +47,7 @@ class ReceiverEnvTest {
         case BaseEnv.METRICS_PUBLISH_QUANTILES -> "TRUE";
         case BaseEnv.CONFIG_TRACING_PATH -> TRACING_CONFIG_PATH;
         case BaseEnv.METRICS_JVM_ENABLED -> METRICS_JVM_ENABLED;
+        case BaseEnv.WAIT_STARTUP_SECONDS -> Integer.valueOf(WAIT_STARTUP_SECONDS).toString();
         default -> throw new IllegalArgumentException(key);
       }
     );
@@ -58,6 +60,7 @@ class ReceiverEnvTest {
     assertThat(env.getHttpServerConfigFilePath()).isEqualTo(HTTPSERVER_CONFIG_FILE_PATH);
     assertThat(env.getConfigTracingPath()).isEqualTo(TRACING_CONFIG_PATH);
     assertThat(env.isMetricsJvmEnabled()).isEqualTo(Boolean.valueOf(METRICS_JVM_ENABLED));
+    assertThat(env.getWaitStartupSeconds()).isEqualTo(WAIT_STARTUP_SECONDS);
 
     // Check toString is overridden
     assertThat(env.toString()).doesNotContain("@");


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
```
{"@timestamp":"2021-02-10T09:43:50.408Z","@version":"1","message":"Failed during filesystem watch","logger_name":"dev.knative.eventing.kafka.broker.dispatcher.Main","thread_name":"main","level":"ERROR","level_value":40000,"stack_trace":"java.nio.file.ClosedWatchServiceException: null\n\tat java.base/sun.nio.fs.AbstractWatchService.checkOpen(Unknown Source)\n\tat java.base/sun.nio.fs.AbstractWatchService.checkKey(Unknown Source)\n\tat java.base/sun.nio.fs.AbstractWatchService.take(Unknown Source)\n\tat dev.knative.eventing.kafka.broker.core.file.FileWatcher.watch(FileWatcher.java:104)\n\tat dev.knative.eventing.kafka.broker.dispatcher.Main.main(Main.java:153)\n"}
```


## Proposed Changes

- Handle ClosedWatchServiceEx and timeouts

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Reduce error logging noise on clean shutdown.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
