### PR TITLE
Improve SSL support

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/Credentials.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/Credentials.java
@@ -30,7 +30,7 @@ public interface Credentials {
    *
    * @return true if client auth should be skipped otherwise false
    */
-  boolean skipUser();
+  boolean skipClientAuth();
 
   /**
    * @return user certificate.

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/Credentials.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/Credentials.java
@@ -26,6 +26,13 @@ public interface Credentials {
   String caCertificates();
 
   /**
+   * Skip client auth.
+   *
+   * @return true if client auth should be skipped otherwise false
+   */
+  boolean skipUser();
+
+  /**
    * @return user certificate.
    */
   String userCertificate();

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/CredentialsValidator.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/CredentialsValidator.java
@@ -35,7 +35,7 @@ class CredentialsValidator {
     }
 
     if (is(SecurityProtocol.SSL, securityProtocol)) {
-      if (credentials.skipUser()) {
+      if (credentials.skipClientAuth()) {
         return null;
       }
       if (anyBlank(credentials.userCertificate(), credentials.userKey())) {

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/CredentialsValidator.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/CredentialsValidator.java
@@ -35,7 +35,10 @@ class CredentialsValidator {
     }
 
     if (is(SecurityProtocol.SSL, securityProtocol)) {
-      if (anyBlank(credentials.userCertificate(), credentials.userKey(), credentials.caCertificates())) {
+      if (credentials.skipUser()) {
+        return null;
+      }
+      if (anyBlank(credentials.userCertificate(), credentials.userKey())) {
         return "Security protocol " + securityProtocol.name + ": invalid user certificate or user key or CA certificates";
       }
       return null;
@@ -53,9 +56,6 @@ class CredentialsValidator {
     }
 
     if (is(SecurityProtocol.SASL_SSL, securityProtocol)) {
-      if (anyBlank(credentials.caCertificates())) {
-        return "Security protocol " + securityProtocol.name + ": invalid truststore";
-      }
       if (isInvalidSASLMechanism(SASLMechanism)) {
         return "Security protocol " + securityProtocol.name + ": invalid SASL mechanism, expected SCRAM-SHA-256 or SCRAM-SHA-512 got " + SASLMechanism;
       }

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KafkaClientsAuth.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KafkaClientsAuth.java
@@ -16,15 +16,16 @@
 
 package dev.knative.eventing.kafka.broker.core.security;
 
-import java.util.Map;
-import java.util.Properties;
-import java.util.function.BiConsumer;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
 import org.apache.kafka.common.security.scram.ScramLoginModule;
 import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.BiConsumer;
 
 public class KafkaClientsAuth {
 
@@ -78,13 +79,17 @@ public class KafkaClientsAuth {
   }
 
   private static void ssl(final BiConsumer<String, String> propertiesSetter, final Credentials credentials) {
-    propertiesSetter.accept(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
-    propertiesSetter.accept(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, credentials.caCertificates());
-    final var keystore = credentials.userCertificate();
-    if (keystore != null) {
-      propertiesSetter.accept(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, credentials.userCertificate());
-      propertiesSetter.accept(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, credentials.userKey());
+    final var caCert = credentials.caCertificates();
+    if (caCert != null) {
+      propertiesSetter.accept(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+      propertiesSetter.accept(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, caCert);
+    }
+    final var userCert = credentials.userCertificate();
+    final var userKey = credentials.userKey();
+    if (userCert != null && userKey != null) {
       propertiesSetter.accept(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+      propertiesSetter.accept(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, userCert);
+      propertiesSetter.accept(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, userKey);
     }
   }
 }

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KubernetesCredentials.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KubernetesCredentials.java
@@ -17,10 +17,11 @@
 package dev.knative.eventing.kafka.broker.core.security;
 
 import io.fabric8.kubernetes.api.model.Secret;
-import java.util.Base64;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Base64;
 
 import static dev.knative.eventing.kafka.broker.core.utils.Logging.keyValue;
 
@@ -32,6 +33,7 @@ class KubernetesCredentials implements Credentials {
 
   static final String USER_CERTIFICATE_KEY = "user.crt";
   static final String USER_KEY_KEY = "user.key";
+  static final String USER_SKIP_KEY = "user.skip";
 
   static final String USERNAME_KEY = "user";
   static final String PASSWORD_KEY = "password";
@@ -44,6 +46,7 @@ class KubernetesCredentials implements Credentials {
   private String caCertificates;
   private String userCertificate;
   private String userKey;
+  private Boolean skipUser;
   private SecurityProtocol securityProtocol;
   private String SASLMechanism;
   private String SASLUsername;
@@ -66,6 +69,26 @@ class KubernetesCredentials implements Credentials {
       this.caCertificates = new String(Base64.getDecoder().decode(truststore));
     }
     return this.caCertificates;
+  }
+
+  @Override
+  public boolean skipUser() {
+    if (secret == null || secret.getData() == null) {
+      return false;
+    }
+    if (skipUser == null) {
+      final var skip = secret.getData().get(USER_SKIP_KEY);
+      if (skip == null) {
+        this.skipUser = false;
+      } else {
+        try {
+          this.skipUser = Boolean.parseBoolean(skip);
+        } catch (final Exception ex) {
+          this.skipUser = false;
+        }
+      }
+    }
+    return this.skipUser;
   }
 
   @Override

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KubernetesCredentials.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KubernetesCredentials.java
@@ -72,7 +72,7 @@ class KubernetesCredentials implements Credentials {
   }
 
   @Override
-  public boolean skipUser() {
+  public boolean skipClientAuth() {
     if (secret == null || secret.getData() == null) {
       return false;
     }

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/PlaintextCredentials.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/PlaintextCredentials.java
@@ -26,7 +26,7 @@ public class PlaintextCredentials implements Credentials {
   }
 
   @Override
-  public boolean skipUser() {
+  public boolean skipClientAuth() {
     return true;
   }
 

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/PlaintextCredentials.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/PlaintextCredentials.java
@@ -26,6 +26,11 @@ public class PlaintextCredentials implements Credentials {
   }
 
   @Override
+  public boolean skipUser() {
+    return true;
+  }
+
+  @Override
   public String userCertificate() {
     return null;
   }

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/security/CredentialsValidatorTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/security/CredentialsValidatorTest.java
@@ -87,7 +87,7 @@ public class CredentialsValidatorTest {
     final var credential = mock(Credentials.class);
 
     when(credential.securityProtocol()).thenReturn(SecurityProtocol.SSL);
-    when(credential.skipUser()).thenReturn(true);
+    when(credential.skipClientAuth()).thenReturn(true);
     when(credential.userCertificate()).thenReturn("  ");
     when(credential.userKey()).thenReturn("  ");
     when(credential.caCertificates()).thenReturn(null);

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/security/CredentialsValidatorTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/security/CredentialsValidatorTest.java
@@ -71,16 +71,30 @@ public class CredentialsValidatorTest {
   }
 
   @Test
-  public void securityProtocolSslInvalidNoCACert() {
+  public void securityProtocolSslNoCACert() {
     final var credential = mock(Credentials.class);
 
     when(credential.securityProtocol()).thenReturn(SecurityProtocol.SSL);
     when(credential.userCertificate()).thenReturn("xyz");
     when(credential.userKey()).thenReturn("my-key");
-    when(credential.caCertificates()).thenReturn("   ");
+    when(credential.caCertificates()).thenReturn(null);
 
-    assertThat(CredentialsValidator.validate(credential)).isNotEmpty();
+    assertThat(CredentialsValidator.validate(credential)).isNull();
   }
+
+  @Test
+  public void securityProtocolSslNoCACertNoClientAuth() {
+    final var credential = mock(Credentials.class);
+
+    when(credential.securityProtocol()).thenReturn(SecurityProtocol.SSL);
+    when(credential.skipUser()).thenReturn(true);
+    when(credential.userCertificate()).thenReturn("  ");
+    when(credential.userKey()).thenReturn("  ");
+    when(credential.caCertificates()).thenReturn(null);
+
+    assertThat(CredentialsValidator.validate(credential)).isNull();
+  }
+
 
   @Test
   public void securityProtocolSaslPlaintextScramSha256Valid() {
@@ -195,17 +209,16 @@ public class CredentialsValidatorTest {
   }
 
   @Test
-  public void securityProtocolSaslSslScramSha51NoTruststoreInValid() {
+  public void securityProtocolSaslSslScramSha51EmptyCaCert() {
     final var credential = mock(Credentials.class);
 
     when(credential.securityProtocol()).thenReturn(SecurityProtocol.SASL_SSL);
-    when(credential.userCertificate()).thenReturn("abc");
     when(credential.caCertificates()).thenReturn("   ");
     when(credential.SASLMechanism()).thenReturn("SCRAM-SHA-512");
     when(credential.SASLUsername()).thenReturn("bbb");
     when(credential.SASLPassword()).thenReturn("ccc");
 
-    assertThat(CredentialsValidator.validate(credential)).isNotEmpty();
+    assertThat(CredentialsValidator.validate(credential)).isNull();
   }
 
   @Test
@@ -250,28 +263,29 @@ public class CredentialsValidatorTest {
   }
 
   @Test
-  public void securityProtocolSaslSslScramSha256NoTruststoreInValid() {
+  public void securityProtocolSaslSslScramSha256NoCaCert() {
     final var credential = mock(Credentials.class);
 
     when(credential.securityProtocol()).thenReturn(SecurityProtocol.SASL_SSL);
-    when(credential.caCertificates()).thenReturn("   ");
+    when(credential.caCertificates()).thenReturn(null);
     when(credential.SASLMechanism()).thenReturn("SCRAM-SHA-512");
     when(credential.SASLUsername()).thenReturn("bbb");
     when(credential.SASLPassword()).thenReturn("ccc");
 
-    assertThat(CredentialsValidator.validate(credential)).isNotEmpty();
+    assertThat(CredentialsValidator.validate(credential)).isNull();
   }
 
   @Test
-  public void securityProtocolSaslSslScramSha256NoCACertInValid() {
+  public void securityProtocolSaslSslScramSha256EmptyCACert() {
     final var credential = mock(Credentials.class);
 
     when(credential.securityProtocol()).thenReturn(SecurityProtocol.SASL_SSL);
+    when(credential.caCertificates()).thenReturn("  ");
     when(credential.SASLMechanism()).thenReturn("SCRAM-SHA-512");
     when(credential.SASLUsername()).thenReturn("bbb");
     when(credential.SASLPassword()).thenReturn("ccc");
 
-    assertThat(CredentialsValidator.validate(credential)).isNotEmpty();
+    assertThat(CredentialsValidator.validate(credential)).isNull();
   }
 
   @Test


### PR DESCRIPTION
When `protocol=SSL` or `protocol=SASL_SSL` CA certificates aren't
required since users might want to use system's root CA set.

When `protocol=SSL` client auth might or might not be required
on the broker side. 
Users can use `user.skip: true` to disable client authentication
checks.

Note: I thought to use `user.skip` since we use `user.crt` and
`user.key` for providing client key pair.

Fixes #605

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Improve SSL support

**Docs**

- https://github.com/knative/docs/issues/3202
