### PR TITLE
Improved UnorderedOffsetManager

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/UnorderedOffsetManager.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/UnorderedOffsetManager.java
@@ -21,11 +21,10 @@ import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.SortedSet;
-import java.util.TreeSet;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,12 +39,7 @@ public final class UnorderedOffsetManager implements OffsetManager {
 
   private final KafkaConsumer<?, ?> consumer;
 
-  // This map contains the last acked message for every known TopicPartition
-  private final Map<TopicPartition, Long> lastAckedPerPartition;
-  // This map contains the set of messages waiting to be acked for every known TopicPartition
-  // The algorithm will commit the offset "o = set.last() + 1" when:
-  //   set.first() == lastAckedOffset + 1 && set.last() - set.first() == set.size() - 1
-  private final Map<TopicPartition, SortedSet<Long>> pendingAcksPerPartition;
+  private final Map<TopicPartition, OffsetTracker> offsetTrackers;
 
   private final Consumer<Integer> onCommit;
 
@@ -59,8 +53,7 @@ public final class UnorderedOffsetManager implements OffsetManager {
     Objects.requireNonNull(consumer, "provide consumer");
 
     this.consumer = consumer;
-    this.lastAckedPerPartition = new HashMap<>();
-    this.pendingAcksPerPartition = new HashMap<>();
+    this.offsetTrackers = new HashMap<>();
     this.onCommit = onCommit;
   }
 
@@ -76,7 +69,8 @@ public final class UnorderedOffsetManager implements OffsetManager {
     // Because recordReceived is guaranteed to be called in order,
     // we use it to set the last seen acked offset.
     // TODO If this assumption doesn't work, use this.consumer.committed(new TopicPartition(record.topic(), record.partition()))
-    this.lastAckedPerPartition.putIfAbsent(new TopicPartition(record.topic(), record.partition()), record.offset() - 1);
+    this.offsetTrackers.computeIfAbsent(new TopicPartition(record.topic(), record.partition()),
+      v -> new OffsetTracker(record.offset() - 1));
     return Future.succeededFuture();
   }
 
@@ -101,7 +95,8 @@ public final class UnorderedOffsetManager implements OffsetManager {
    */
   @Override
   public Future<Void> failedToSendToDLQ(final KafkaConsumerRecord<?, ?> record, final Throwable ex) {
-    mutateStateAndCheckAck(new TopicPartition(record.topic(), record.partition()), record.offset());
+    this.offsetTrackers.get(new TopicPartition(record.topic(), record.partition()))
+      .recordNewOffset(record.offset());
     return Future.succeededFuture();
   }
 
@@ -110,49 +105,36 @@ public final class UnorderedOffsetManager implements OffsetManager {
    */
   @Override
   public Future<Void> recordDiscarded(final KafkaConsumerRecord<?, ?> record) {
-    mutateStateAndCheckAck(new TopicPartition(record.topic(), record.partition()), record.offset());
+    this.offsetTrackers.get(new TopicPartition(record.topic(), record.partition()))
+      .recordNewOffset(record.offset());
     return Future.succeededFuture();
-  }
-
-  /**
-   * @return null if it shouldn't ack, otherwise the offset to ack - 1.
-   */
-  private Long mutateStateAndCheckAck(TopicPartition topicPartition, long offset) {
-    long lastAckedOffset = this.lastAckedPerPartition.get(topicPartition); // This is always non null
-    SortedSet<Long> partitionPendingAcks =
-      this.pendingAcksPerPartition.computeIfAbsent(topicPartition, v -> new TreeSet<>());
-    partitionPendingAcks.add(offset);
-
-    // Return the ack to commit if:
-    // * last acked offset is the same of the first pending ack in the set
-    // * the set contains every element in its range of values
-    return (partitionPendingAcks.first() == lastAckedOffset + 1 &&
-      partitionPendingAcks.last() - partitionPendingAcks.first() == partitionPendingAcks.size() - 1) ?
-      partitionPendingAcks.last() : null;
   }
 
   private Future<Void> commit(final KafkaConsumerRecord<?, ?> record) {
     TopicPartition topicPartition = new TopicPartition(record.topic(), record.partition());
-    Long toAck = mutateStateAndCheckAck(topicPartition, record.offset());
-    if (toAck != null) {
+    OffsetTracker tracker = this.offsetTrackers.get(topicPartition);
+    tracker.recordNewOffset(record.offset());
+
+    if (tracker.shouldCommit()) {
       // Reset the state
-      this.lastAckedPerPartition.put(topicPartition, toAck);
-      SortedSet<Long> messagesImGoingToAck = this.pendingAcksPerPartition.remove(topicPartition);
+      long newOffset = tracker.offsetToCommit();
+      long uncommittedSize = tracker.uncommittedSize();
+      tracker.reset(newOffset);
 
       // Execute the actual commit
       return consumer.commit(Map.of(
         topicPartition,
-        new OffsetAndMetadata(toAck + 1, ""))
+        new OffsetAndMetadata(newOffset, ""))
       )
         .onSuccess(ignored -> {
           if (onCommit != null) {
-            onCommit.accept(messagesImGoingToAck.size());
+            onCommit.accept((int) uncommittedSize);
           }
           logger.debug(
             "committed for topic partition {} {} offset {}",
             record.topic(),
             record.partition(),
-            toAck + 1
+            newOffset
           );
         })
         .onFailure(cause ->
@@ -160,12 +142,106 @@ public final class UnorderedOffsetManager implements OffsetManager {
             "failed to commit for topic partition {} {} offset {}",
             record.topic(),
             record.partition(),
-            toAck + 1,
+            newOffset,
             cause
           )
         ).mapEmpty();
     }
     return Future.succeededFuture();
+  }
+
+  /**
+   * This offset tracker keeps track of the committed records flipping a bit in the stored long.
+   */
+  private static class OffsetTracker {
+
+    private final static int ACKS_GARBAGE_SIZE_THRESHOLD = 128; // Meaning 8192 messages are on hold
+    private final static long[] POWS = new long[64];
+
+    static {
+      // Initialize POWS
+      for (int i = 0; i < 64; i++) {
+        long pow = 0;
+        for (int j = 0; j <= i; j++) {
+          pow |= 1L << j;
+        }
+        POWS[i] = pow;
+      }
+    }
+
+    private long lastAcked;
+    private long[] uncommitted;
+
+    private int greaterBlockIndex;
+    private int greaterBitIndexInGreaterBlock;
+
+    public OffsetTracker(long initialOffset) {
+      this.lastAcked = initialOffset;
+      this.uncommitted = new long[1];
+      this.greaterBlockIndex = -1;
+      this.greaterBitIndexInGreaterBlock = -1;
+    }
+
+    public void recordNewOffset(long offset) {
+      long diffWithLastCommittedOffset = offset - this.lastAcked - 1;
+      int blockIndex = blockIndex(diffWithLastCommittedOffset);
+      int bitIndex = (int) (diffWithLastCommittedOffset % 64); // That's obviously smaller than a long
+
+      checkAcksArraySize(blockIndex);
+
+      // Let's record this bit and update the greater indexes
+      this.uncommitted[blockIndex] |= 1L << bitIndex;
+      if (this.greaterBlockIndex < blockIndex) {
+        this.greaterBlockIndex = blockIndex;
+        this.greaterBitIndexInGreaterBlock = bitIndex;
+      } else if (this.greaterBlockIndex == blockIndex && this.greaterBitIndexInGreaterBlock < bitIndex) {
+        this.greaterBitIndexInGreaterBlock = bitIndex;
+      }
+    }
+
+    public boolean shouldCommit() {
+      // Let's check if we have all the bits to 1, except the last one
+      for (int b = 0; b < this.greaterBlockIndex; b++) {
+        if (this.uncommitted[b] != POWS[63]) {
+          return false;
+        }
+      }
+
+      return this.uncommitted[this.greaterBlockIndex] == POWS[this.greaterBitIndexInGreaterBlock];
+    }
+
+    public long uncommittedSize() {
+      return this.greaterBitIndexInGreaterBlock + 1 + (greaterBlockIndex * 64L);
+    }
+
+    public long offsetToCommit() {
+      return this.lastAcked + uncommittedSize() + 1;
+    }
+
+    public void reset(long committed) {
+      this.lastAcked = committed - 1;
+      this.greaterBlockIndex = -1;
+      this.greaterBitIndexInGreaterBlock = -1;
+
+      // Cleanup the acks array or overwrite it, depending on its size
+      if (this.uncommitted.length > ACKS_GARBAGE_SIZE_THRESHOLD) {
+        // No need to keep that big array
+        this.uncommitted = new long[1];
+      } else {
+        Arrays.fill(this.uncommitted, 0L);
+      }
+    }
+
+    private int blockIndex(long val) {
+      return (int) (val >> 6);
+    }
+
+    private void checkAcksArraySize(int blockIndex) {
+      if (this.uncommitted.length < blockIndex) {
+        this.uncommitted = Arrays.copyOf(this.uncommitted, (blockIndex + 1) * 2);
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

## Proposed Changes

- Modified a bit the benchmark from #640 to make sure we don't measure the record allocation time (which is quite expensive in longer benchmarks and dominated over the code under test), but now we record the `UnorderdOffsetManager` allocation (as noted in the JMH javadocs, it's better to avoid using `Level.Invocation` for the state when the bench length is short
- Rewrote the unordered offset manager to be more efficient

## Numbers

Master + https://github.com/knative-sandbox/eventing-kafka-broker/pull/648/commits/1df960a732bc5c76d74ada2fe50ee708606e193d:

```
Benchmark                                                Mode  Cnt       Score      Error  Units
UnorderedOffsetManagerBenchmark.benchmarkMixedABit      thrpt   10   23918,942 ± 1208,231  ops/s
UnorderedOffsetManagerBenchmark.benchmarkOrdered        thrpt   10       7,437 ±    0,130  ops/s
UnorderedOffsetManagerBenchmark.benchmarkRealisticCase  thrpt   10  150935,199 ± 3552,501  ops/s
UnorderedOffsetManagerBenchmark.benchmarkReverseOrder   thrpt   10       2,745 ±    0,103  ops/s
```

This PR:

```
Benchmark                                                Mode  Cnt       Score       Error  Units
UnorderedOffsetManagerBenchmark.benchmarkMixedABit      thrpt   10   61381,474 ±  1125,869  ops/s
UnorderedOffsetManagerBenchmark.benchmarkOrdered        thrpt   10       5,453 ±     0,026  ops/s
UnorderedOffsetManagerBenchmark.benchmarkRealisticCase  thrpt   10  481574,607 ± 16121,914  ops/s
UnorderedOffsetManagerBenchmark.benchmarkReverseOrder   thrpt   10       7,807 ±     0,145  ops/s
```

Note: the realistic benchmarks are `benchmarkMixedABit` and `benchmarkRealisticCase`, the other 2 are extreme cases where probably there are other factors dominating over the code under test