### PR TITLE
Add more unit tests for Kafka reconciler package

### DIFF
--- a/control-plane/pkg/reconciler/kafka/admin_test.go
+++ b/control-plane/pkg/reconciler/kafka/admin_test.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka
+
+import (
+	"io"
+	"testing"
+
+	"github.com/Shopify/sarama"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/security"
+)
+
+func TestGetClusterAdmin(t *testing.T) {
+
+	tests := []struct {
+		name             string
+		adminFunc        NewClusterAdminFunc
+		bootstrapServers []string
+		secOptions       security.ConfigOption
+		wantErr          bool
+	}{
+		{
+			name:             "security options error",
+			adminFunc:        func(addrs []string, config *sarama.Config) (sarama.ClusterAdmin, error) { return nil, nil },
+			bootstrapServers: []string{"bs:9092"},
+			secOptions:       func(config *sarama.Config) error { return io.EOF },
+			wantErr:          true,
+		},
+		{
+			name:             "admin func error",
+			adminFunc:        func(addrs []string, config *sarama.Config) (sarama.ClusterAdmin, error) { return nil, io.EOF },
+			bootstrapServers: []string{"bs:9092"},
+			secOptions:       func(config *sarama.Config) error { return nil },
+			wantErr:          true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := GetClusterAdmin(tt.adminFunc, tt.bootstrapServers, tt.secOptions)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetClusterAdmin() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/control-plane/pkg/reconciler/kafka/topic.go
+++ b/control-plane/pkg/reconciler/kafka/topic.go
@@ -43,7 +43,18 @@ func BootstrapServersCommaSeparated(bootstrapServers []string) string {
 }
 
 func BootstrapServersArray(bootstrapServers string) []string {
-	return strings.Split(bootstrapServers, ",")
+	bss := strings.Split(bootstrapServers, ",")
+
+	j := len(bss)
+	for i := 0; i < j; i++ {
+		bss[i] = strings.TrimSpace(bss[i])
+		if bss[i] == "" {
+			j--
+			bss[i] = bss[j]
+			i--
+		}
+	}
+	return bss[:j]
 }
 
 // Topic returns a topic name given a topic prefix and a generic object.

--- a/control-plane/pkg/reconciler/kafka/topic_test.go
+++ b/control-plane/pkg/reconciler/kafka/topic_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
@@ -437,4 +438,13 @@ func TestNewClusterAdminFuncIsTopicPresentCloseClusterAdmin(t *testing.T) {
 	assert.Nil(t, err, "IsTopicPresentAndValid() error = %v, wantErr %v", err, false)
 	assert.True(t, got, "IsTopicPresentAndValid() got = %v, want %v", got, true)
 	assert.True(t, ca.ExpectedClose, "expected call to Close() on ClusterAdmin")
+}
+
+func TestBootstrapServersArray(t *testing.T) {
+	bss := BootstrapServersArray("bs:9091, bs:9000,,bs:9002,")
+
+	require.Contains(t, bss, "bs:9091")
+	require.Contains(t, bss, "bs:9000")
+	require.Contains(t, bss, "bs:9002")
+	require.Len(t, bss, 3)
 }


### PR DESCRIPTION
- Add more unit tests for Kafka reconciler package
- Handle trailing commas and spaces when extracting bootstrap servers