### PR TITLE
Drop hack and test from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,3 @@
 * @knative-sandbox/eventing-writers
 * @knative-sandbox/eventing-kafka-broker-approvers
 
-# hack and test are owned by productivity
-/hack/* @knative-sandbox/productivity-wg-leads
-/test/* @knative-sandbox/productivity-wg-leads


### PR DESCRIPTION
With this setting, we will need approval from
productivity for every new test, which can
easily become a bottleneck.

## Proposed Changes

- Drop hack and test from CODEOWNERS
