### PR TITLE
Fix test timeout after 1h

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -157,7 +157,7 @@ jobs:
       - name: Run e2e Tests
         run: |
           # Run the tests tagged as e2e on the KinD cluster.
-          go test -race -count=1 -timeout=1h -short -tags=e2e \
+          go test -race -count=1 -timeout=2h -short -tags=e2e \
              ${{ matrix.test-suite }} ${{ matrix.extra-test-flags }}
 
       - name: Collect system diagnostics


### PR DESCRIPTION
In https://github.com/knative-sandbox/eventing-kafka-broker/pull/694/checks?check_run_id=2022472233
we got `panic: test timed out after 1h0m0s`

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Increase timeout for KinD e2e tests
