### PR TITLE
Add Maven cache in GH Actions

### DIFF
--- a/.github/workflows/knative-java-test.yaml
+++ b/.github/workflows/knative-java-test.yaml
@@ -45,6 +45,13 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
 
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
       - name: Check for .codecov.yaml
         id: codecov-enabled
         uses: andstor/file-existence-action@v1
@@ -53,7 +60,7 @@ jobs:
 
       - if: steps.codecov-enabled.outputs.files_exists == 'true'
         name: Java Test
-        run: mvn verify --file data-plane/pom.xml --no-transfer-progress
+        run: mvn verify -B -U --file data-plane/pom.xml --no-transfer-progress
 
       - if: steps.codecov-enabled.outputs.files_exists == 'true'
         name: Codecov

--- a/.github/workflows/knative-profile-data-plane.yaml
+++ b/.github/workflows/knative-profile-data-plane.yaml
@@ -55,6 +55,13 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
 
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v2
         with:

--- a/data-plane/profiler/run.sh
+++ b/data-plane/profiler/run.sh
@@ -47,7 +47,7 @@ echo "Async profiler URL: ${ASYNC_PROFILER_URL}"
 echo "Kafka URL: ${KAFKA_URL}"
 
 # Build the data plane.
-cd "${PROJECT_ROOT_DIR}" && ./mvnw package -DskipTests -Dlicense.skip -Deditorconfig.skip --no-transfer-progress && cd - || exit 1
+cd "${PROJECT_ROOT_DIR}" && ./mvnw package -DskipTests -Dlicense.skip -Deditorconfig.skip -B -U --no-transfer-progress && cd - || exit 1
 
 # Download async profiler.
 rm async-profiler


### PR DESCRIPTION
Cached dependencies allow reducing workflow run time.

ref: https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies

## Proposed Changes

- Add Maven cache in GH Actions
