### PR TITLE
Fix race condition when installing Kafka in CI

### DIFF
--- a/test/kafka/kafka_setup.sh
+++ b/test/kafka/kafka_setup.sh
@@ -25,10 +25,14 @@ sleep 5
 header "Applying Strimzi Cluster Operator file"
 cat $(dirname $0)/strimzi-cluster-operator.yaml | sed "s/cluster.local/${CLUSTER_SUFFIX}/g" | kubectl apply -n kafka -f -
 
-sleep 5
+sleep 10
 
-kubectl -n kafka apply -f $(dirname $0)/kafka-ephemeral.yaml
+kubectl -n kafka apply -f $(dirname $0)/kafka-ephemeral.yaml || kubectl -n kafka apply -f $(dirname $0)/kafka-ephemeral.yaml
+
+echo "Create TLS user"
 kubectl apply -n kafka -f $(dirname $0)/user-tls.yaml
+
+echo "Create SASL SCRUM 512 user"
 kubectl apply -n kafka -f $(dirname $0)/user-sasl-scram-512.yaml
 
 sleep 5


### PR DESCRIPTION
`error: unable to recognize "./test/kafka/kafka-ephemeral.yaml": no
matches for kind "Kafka" in version "kafka.strimzi.io/v1beta1"
ERROR: Failed to set up Kafka cluster`

https://github.com/knative-sandbox/eventing-kafka-broker/runs/2045620738?check_suite_focus=true