### PR TITLE
Short circuit trigger reconciliation when broker not ready

### DIFF
--- a/control-plane/pkg/reconciler/trigger/trigger.go
+++ b/control-plane/pkg/reconciler/trigger/trigger.go
@@ -101,6 +101,11 @@ func (r *Reconciler) reconcileKind(ctx context.Context, trigger *eventing.Trigge
 
 	statusConditionManager.propagateBrokerCondition(broker)
 
+	if !broker.Status.IsReady() {
+		// Trigger will get re-queued once this broker is ready.
+		return nil
+	}
+
 	// Get data plane config map.
 	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx)
 	if err != nil {

--- a/control-plane/pkg/reconciler/trigger/trigger_test.go
+++ b/control-plane/pkg/reconciler/trigger/trigger_test.go
@@ -431,6 +431,31 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 			},
 		},
 		{
+			Name: "Broker not ready",
+			Objects: []runtime.Object{
+				newTrigger(),
+				NewBroker(
+					func(v *eventing.Broker) { v.Status.InitializeConditions() },
+					BrokerConfigNotParsed("wrong"),
+				),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			Key: testKey,
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: newTrigger(
+						reconcilertesting.WithInitTriggerConditions,
+						reconcilertesting.WithTriggerBrokerFailed("wrong", ""),
+					),
+				},
+			},
+		},
+		{
 			Name: "Broker deleted, no broker in config map",
 			Objects: []runtime.Object{
 				newTrigger(),


### PR DESCRIPTION
In https://github.com/knative-sandbox/eventing-kafka-broker/issues/720
I noticed that our error propagation isn't helpful for troubleshooting,
since when a broker is not ready, the error in the trigger ready
condition is overridden by "Broker not found in data plane map".

Fixes #720

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Short circuit trigger reconciler when broker not ready