### PR TITLE
Add producer interceptor PartitionKeyExtensionInterceptor

### DIFF
--- a/data-plane/config/broker/100-config-kafka-broker-data-plane.yaml
+++ b/data-plane/config/broker/100-config-kafka-broker-data-plane.yaml
@@ -40,7 +40,6 @@ data:
     receive.buffer.bytes=-1
     request.timeout.ms=30000
     enable.idempotence=false
-    # interceptor.classes=""
     max.in.flight.requests.per.connection=5
     metadata.max.age.ms=300000
     # metric.reporters=""

--- a/data-plane/config/sink/100-config-kafka-sink-data-plane.yaml
+++ b/data-plane/config/sink/100-config-kafka-sink-data-plane.yaml
@@ -40,7 +40,6 @@ data:
     receive.buffer.bytes=-1
     request.timeout.ms=30000
     enable.idempotence=false
-    # interceptor.classes=""
     max.in.flight.requests.per.connection=5
     metadata.max.age.ms=300000
     # metric.reporters=""

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/Main.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/Main.java
@@ -29,12 +29,19 @@ import dev.knative.eventing.kafka.broker.core.utils.Shutdown;
 import dev.knative.eventing.kafka.broker.dispatcher.http.HttpConsumerVerticleFactory;
 import io.cloudevents.kafka.CloudEventDeserializer;
 import io.cloudevents.kafka.CloudEventSerializer;
+import io.cloudevents.kafka.PartitionKeyExtensionInterceptor;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.tracing.TracingOptions;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.ext.web.client.WebClientOptions;
+import net.logstash.logback.encoder.LogstashEncoder;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.ClosedWatchServiceException;
@@ -42,11 +49,6 @@ import java.nio.file.FileSystems;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import net.logstash.logback.encoder.LogstashEncoder;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static dev.knative.eventing.kafka.broker.core.utils.Logging.keyValue;
 
@@ -102,6 +104,7 @@ public class Main {
 
       final var producerConfig = Configurations.getProperties(env.getProducerConfigFilePath());
       producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, CloudEventSerializer.class.getName());
+      producerConfig.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, PartitionKeyExtensionInterceptor.class.getName());
       final var consumerConfig = Configurations.getProperties(env.getConsumerConfigFilePath());
       consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, CloudEventDeserializer.class.getName());
       final var webClientConfig = Configurations.getPropertiesAsJson(env.getWebClientConfigFilePath());

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerVerticleFactory.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerVerticleFactory.java
@@ -34,7 +34,6 @@ import dev.knative.eventing.kafka.broker.dispatcher.consumer.impl.OrderedOffsetM
 import dev.knative.eventing.kafka.broker.dispatcher.consumer.impl.UnorderedConsumerVerticle;
 import dev.knative.eventing.kafka.broker.dispatcher.consumer.impl.UnorderedOffsetManager;
 import io.cloudevents.CloudEvent;
-import io.cloudevents.kafka.PartitionKeyExtensionInterceptor;
 import io.micrometer.core.instrument.Counter;
 import io.vertx.circuitbreaker.CircuitBreaker;
 import io.vertx.circuitbreaker.CircuitBreakerOptions;
@@ -128,7 +127,6 @@ public class HttpConsumerVerticleFactory implements ConsumerVerticleFactory {
 
     final var producerConfigs = new HashMap<>(this.producerConfigs);
     producerConfigs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, resource.getBootstrapServers());
-    producerConfigs.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, PartitionKeyExtensionInterceptor.class.getName());
 
     final DeliveryOrder deliveryOrder = DeliveryOrder.fromContract(egress.getDeliveryOrder());
 

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/Main.java
@@ -27,6 +27,7 @@ import dev.knative.eventing.kafka.broker.core.tracing.TracingConfig;
 import dev.knative.eventing.kafka.broker.core.utils.Configurations;
 import dev.knative.eventing.kafka.broker.core.utils.Shutdown;
 import io.cloudevents.kafka.CloudEventSerializer;
+import io.cloudevents.kafka.PartitionKeyExtensionInterceptor;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
@@ -111,6 +112,7 @@ public class Main {
 
       producerConfigs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
       producerConfigs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, CloudEventSerializer.class);
+      producerConfigs.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, PartitionKeyExtensionInterceptor.class.getName());
 
       final Function<Vertx, RequestMapper> handlerFactory = v -> new RequestMapper(
         v,


### PR DESCRIPTION
As reported in slack, we don't set this interceptor.

## Proposed Changes

- Set PartitionKey interceptor to PartitionKeyExtensionInterceptor

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Add producer interceptor `io.cloudevents.kafka.PartitionKeyExtensionInterceptor` to provide ordered delivery based on the partitioning extension of the CloudEvents spec.
```

/kind bug
