### PR TITLE
Stop testing on k8s version 1.17

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -21,7 +21,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - v1.17.11
           - v1.18.8
           - v1.19.4
           - v1.20.0
@@ -39,9 +38,6 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0
         include:
-          - k8s-version: v1.17.11
-            kind-version: v0.9.0
-            kind-image-sha: sha256:5240a7a2c34bf241afb54ac05669f8a46661912eab05705d660971eeb12f6555
           - k8s-version: v1.18.8
             kind-version: v0.9.0
             kind-image-sha: sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb


### PR DESCRIPTION
Kubernetes's minimum version is 1.18.

Fixes #778

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Stop testing on k8s version 1.17

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Kubernetes's minimum version is 1.18.
```
