### PR TITLE
Change dependabot target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,4 @@ updates:
       - "pierDipi"
     commit-message:
       prefix: "[data-plane]"
-    target-branch: "master"
+    target-branch: "main"


### PR DESCRIPTION
Dependabot was still targeting `master`

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Change dependabot target branch
