### PR TITLE
[data-plane]: Bump vertx.version from 4.0.2 to 4.0.3 in /data-plane

### DIFF
--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -42,7 +42,7 @@
     <mycila.license.plugin.version>4.0.rc2</mycila.license.plugin.version>
 
     <!-- dependencies version -->
-    <vertx.version>4.0.2</vertx.version>
+    <vertx.version>4.0.3</vertx.version>
     <cloudevents.sdk.version>2.0.0</cloudevents.sdk.version>
     <micrometer.version>1.6.4</micrometer.version>
     <opentelemetry.version>0.15.0</opentelemetry.version>


### PR DESCRIPTION
Bumps `vertx.version` from 4.0.2 to 4.0.3.

Updates `vertx-stack-depchain` from 4.0.2 to 4.0.3

Updates `vertx-junit5` from 4.0.2 to 4.0.3