### PR TITLE
[data-plane]: Bump protobuf.version from 3.15.3 to 3.15.8 in /data-plane

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,4 @@ updates:
       - "pierDipi"
     commit-message:
       prefix: "[data-plane]"
-    target-branch: "master"
+    target-branch: "main"

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -47,7 +47,7 @@
     <micrometer.version>1.6.4</micrometer.version>
     <opentelemetry.version>0.15.0</opentelemetry.version>
     <jackson.version>2.12.2</jackson.version>
-    <protobuf.version>3.15.4</protobuf.version>
+    <protobuf.version>3.15.8</protobuf.version>
     <slf4j.version>1.7.30</slf4j.version>
     <ch.qos.logback.version>1.2.3</ch.qos.logback.version>
     <net.logstash.logback.encoder.version>6.6</net.logstash.logback.encoder.version>


### PR DESCRIPTION
Bumps `protobuf.version` from 3.15.3 to 3.15.8.
Updates `protobuf-java` from 3.15.3 to 3.15.8