### PR TITLE
[data-plane]: Bump jmh.version from 1.27 to 1.29 in /data-plane

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,4 @@ updates:
       - "pierDipi"
     commit-message:
       prefix: "[data-plane]"
-    target-branch: "master"
+    target-branch: "main"

--- a/data-plane/benchmarks/pom.xml
+++ b/data-plane/benchmarks/pom.xml
@@ -32,7 +32,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jmh.version>1.28</jmh.version>
+    <jmh.version>1.29</jmh.version>
     <javac.target>15</javac.target>
     <uberjar.name>benchmarks</uberjar.name>
   </properties>


### PR DESCRIPTION
Bumps `jmh.version` from 1.27 to 1.29.

Updates `jmh-core` from 1.27 to 1.29

Updates `jmh-generator-annprocess` from 1.27 to 1.29