### PR TITLE
Fix out of bounds in unordered offset manager

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/UnorderedOffsetManager.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/UnorderedOffsetManager.java
@@ -251,7 +251,7 @@ public final class UnorderedOffsetManager implements OffsetManager {
     }
 
     private void checkAcksArraySize(int blockIndex) {
-      if (this.uncommitted.length < blockIndex) {
+      if (blockIndex > this.uncommitted.length - 1) {
         // Let's make sure we create enough room for more unordered records
         this.uncommitted = Arrays.copyOf(this.uncommitted, (blockIndex + 1) * 2);
       }

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/UnorderedOffsetManagerTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/UnorderedOffsetManagerTest.java
@@ -51,6 +51,16 @@ public class UnorderedOffsetManagerTest extends AbstractOffsetManagerTest {
   }
 
   @Test
+  public void shouldNotCommitAndNotGoOutOfBounds() {
+    assertThatOffsetCommitted(List.of(new TopicPartition("aaa", 0)), offsetStrategy -> {
+      offsetStrategy.recordReceived(record("aaa", 0, 0));
+      offsetStrategy.successfullySentToSubscriber(record("aaa", 0, 64));
+      offsetStrategy.successfullySentToSubscriber(record("aaa", 0, 128));
+    })
+      .isEmpty();
+  }
+
+  @Test
   public void shouldCommitAfterSendingEventsOrderedOnTheSamePartitionWithInducedFailure() {
     assertThatOffsetCommittedWithFailures(List.of(new TopicPartition("aaa", 0)), (offsetStrategy, failureFlag) -> {
       offsetStrategy.recordReceived(record("aaa", 0, 0));


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fix #813

## Proposed Changes

- :bug: Fix out of bounds in unordered offset manager

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:bug: Fix out of bounds in unordered offset manager
```
