### PR TITLE
fix: Allow SASLMechanism to equal "PLAIN"

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KubernetesCredentials.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KubernetesCredentials.java
@@ -153,6 +153,7 @@ class KubernetesCredentials implements Credentials {
         return null;
       }
       this.SASLMechanism = switch (new String(Base64.getDecoder().decode(SASLMechanism))) {
+        case "PLAIN"         -> "PLAIN";
         case "SCRAM-SHA-256" -> "SCRAM-SHA-256";
         case "SCRAM-SHA-512" -> "SCRAM-SHA-512";
         default -> null;

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/security/KubernetesCredentialsTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/security/KubernetesCredentialsTest.java
@@ -32,13 +32,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class KubernetesCredentialsTest {
 
   @Test
-  public void getKubernetesCredentialsFromSecret() {
+  public void getKubernetesCredentialsFromSecretSaslPlain() {
+    getKubernetesCredentialsFromSecret("PLAIN");
+  }
 
+  @Test
+  public void getKubernetesCredentialsFromSecretSaslScram256() {
+    getKubernetesCredentialsFromSecret("SCRAM-SHA-256");
+  }
+
+  @Test
+  public void getKubernetesCredentialsFromSecretSaslScram512() {
+    getKubernetesCredentialsFromSecret("SCRAM-SHA-512");
+  }
+
+  private static void getKubernetesCredentialsFromSecret(final String saslMechanism) {
     final var data = Map.of(
       KubernetesCredentials.CA_CERTIFICATE_KEY, "CA_CERT",
       KubernetesCredentials.USER_CERTIFICATE_KEY, "USER_CERT",
       KubernetesCredentials.USER_KEY_KEY, "USER_KEY",
-      KubernetesCredentials.SASL_MECHANISM, "SCRAM-SHA-256",
+      KubernetesCredentials.SASL_MECHANISM, saslMechanism,
       KubernetesCredentials.SECURITY_PROTOCOL, SecurityProtocol.SASL_SSL.name,
       KubernetesCredentials.USERNAME_KEY, "USERNAME",
       KubernetesCredentials.PASSWORD_KEY, "PASSWORD"


### PR DESCRIPTION
Fixes #854

## Proposed Changes

- Consider "PLAIN" as a valid input in the `KubernetesCredentials` class

**Release Note**

```release-note
- :bug: Accept "PLAIN" as a valid `sasl.mechanism` secret value
```