### PR TITLE
[release-0.22] Do not add a finalizer on triggers without a broker

### DIFF
--- a/control-plane/pkg/reconciler/trigger/controller.go
+++ b/control-plane/pkg/reconciler/trigger/controller.go
@@ -125,7 +125,7 @@ func filterTriggers(lister eventinglisters.BrokerLister) func(interface{}) bool 
 
 		broker, err := lister.Brokers(trigger.Namespace).Get(trigger.Spec.Broker)
 		if err != nil {
-			return true // TODO decide what to do on NotFound/Found
+			return false
 		}
 
 		value, ok := broker.GetAnnotations()[apiseventing.BrokerClassKey]

--- a/control-plane/pkg/reconciler/trigger/controller_test.go
+++ b/control-plane/pkg/reconciler/trigger/controller_test.go
@@ -54,5 +54,5 @@ func TestFilterTriggers(t *testing.T) {
 		},
 	})
 
-	assert.True(t, pass)
+	assert.False(t, pass)
 }


### PR DESCRIPTION
Fixes #863

_Note: I'm not backporting the E2E test since it uses new dependencies._

## Proposed Changes

- Do not add a finalizer on triggers without a broker

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Do not add a finalizer on triggers without a broker.
```

/kind bug
