### PR TITLE
Add more details in the status about ordered and unordered

### DIFF
--- a/control-plane/pkg/reconciler/trigger/trigger.go
+++ b/control-plane/pkg/reconciler/trigger/trigger.go
@@ -142,7 +142,9 @@ func (r *Reconciler) reconcileKind(ctx context.Context, trigger *eventing.Trigge
 	if err != nil {
 		return statusConditionManager.failedToResolveTriggerConfig(err)
 	}
-	statusConditionManager.subscriberResolved()
+	statusConditionManager.subscriberResolved(
+		fmt.Sprintf("Subscriber will receive events with the delivery order: %s", triggerConfig.DeliveryOrder.String()),
+	)
 
 	changed := coreconfig.AddOrUpdateEgressConfig(ct, brokerIndex, triggerConfig, triggerIndex)
 

--- a/control-plane/pkg/reconciler/trigger/trigger_lifecycle.go
+++ b/control-plane/pkg/reconciler/trigger/trigger_lifecycle.go
@@ -125,7 +125,7 @@ func (m *statusConditionManager) failedToUpdateDispatcherPodsAnnotation(err erro
 func (m *statusConditionManager) subscriberResolved(details string) {
 	m.Trigger.GetConditionSet().Manage(&m.Trigger.Status).MarkTrueWithReason(
 		eventing.TriggerConditionSubscriberResolved,
-		"SubscriberResolved",
+		string(eventing.TriggerConditionSubscriberResolved),
 		details,
 	)
 }

--- a/control-plane/pkg/reconciler/trigger/trigger_lifecycle.go
+++ b/control-plane/pkg/reconciler/trigger/trigger_lifecycle.go
@@ -122,6 +122,10 @@ func (m *statusConditionManager) failedToUpdateDispatcherPodsAnnotation(err erro
 	)
 }
 
-func (m *statusConditionManager) subscriberResolved() {
-	m.Trigger.Status.MarkSubscriberResolvedSucceeded()
+func (m *statusConditionManager) subscriberResolved(details string) {
+	m.Trigger.GetConditionSet().Manage(&m.Trigger.Status).MarkTrueWithReason(
+		eventing.TriggerConditionSubscriberResolved,
+		"SubscriberResolved",
+		details,
+	)
 }

--- a/control-plane/pkg/reconciler/trigger/trigger_test.go
+++ b/control-plane/pkg/reconciler/trigger/trigger_test.go
@@ -2192,7 +2192,7 @@ func withTriggerSubscriberResolvedSucceeded(deliveryOrder contract.DeliveryOrder
 	return func(t *eventing.Trigger) {
 		t.GetConditionSet().Manage(&t.Status).MarkTrueWithReason(
 			eventing.TriggerConditionSubscriberResolved,
-			"SubscriberResolved",
+			string(eventing.TriggerConditionSubscriberResolved),
 			fmt.Sprintf("Subscriber will receive events with the delivery order: %s", deliveryOrder.String()),
 		)
 	}

--- a/control-plane/pkg/reconciler/trigger/trigger_test.go
+++ b/control-plane/pkg/reconciler/trigger/trigger_test.go
@@ -148,7 +148,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 						withSubscriberURI,
 						reconcilertesting.WithTriggerDependencyReady(),
 						reconcilertesting.WithTriggerBrokerReady(),
-						reconcilertesting.WithTriggerSubscriberResolvedSucceeded(),
+						withTriggerSubscriberResolvedSucceeded(contract.DeliveryOrder_UNORDERED),
 					),
 				},
 			},
@@ -210,7 +210,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 						withSubscriberURI,
 						reconcilertesting.WithTriggerDependencyReady(),
 						reconcilertesting.WithTriggerBrokerReady(),
-						reconcilertesting.WithTriggerSubscriberResolvedSucceeded(),
+						withTriggerSubscriberResolvedSucceeded(contract.DeliveryOrder_ORDERED),
 						reconcilertesting.WithAnnotation(deliveryOrderAnnotation, deliveryOrderOrdered),
 					),
 				},
@@ -273,7 +273,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 						withSubscriberURI,
 						reconcilertesting.WithTriggerDependencyReady(),
 						reconcilertesting.WithTriggerBrokerReady(),
-						reconcilertesting.WithTriggerSubscriberResolvedSucceeded(),
+						withTriggerSubscriberResolvedSucceeded(contract.DeliveryOrder_UNORDERED),
 						reconcilertesting.WithAnnotation(deliveryOrderAnnotation, deliveryOrderUnordered),
 					),
 				},
@@ -342,7 +342,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 						withSubscriberURI,
 						reconcilertesting.WithTriggerDependencyReady(),
 						reconcilertesting.WithTriggerBrokerReady(),
-						reconcilertesting.WithTriggerSubscriberResolvedSucceeded(),
+						withTriggerSubscriberResolvedSucceeded(contract.DeliveryOrder_UNORDERED),
 					),
 				},
 			},
@@ -454,7 +454,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 						withSubscriberURI,
 						reconcilertesting.WithTriggerDependencyReady(),
 						reconcilertesting.WithTriggerBrokerReady(),
-						reconcilertesting.WithTriggerSubscriberResolvedSucceeded(),
+						withTriggerSubscriberResolvedSucceeded(contract.DeliveryOrder_UNORDERED),
 					),
 				},
 			},
@@ -751,7 +751,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 						withSubscriberURI,
 						reconcilertesting.WithTriggerDependencyReady(),
 						reconcilertesting.WithTriggerBrokerReady(),
-						reconcilertesting.WithTriggerSubscriberResolvedSucceeded(),
+						withTriggerSubscriberResolvedSucceeded(contract.DeliveryOrder_UNORDERED),
 					),
 				},
 			},
@@ -937,7 +937,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 						withSubscriberURI,
 						reconcilertesting.WithTriggerDependencyReady(),
 						reconcilertesting.WithTriggerBrokerReady(),
-						reconcilertesting.WithTriggerSubscriberResolvedSucceeded(),
+						withTriggerSubscriberResolvedSucceeded(contract.DeliveryOrder_UNORDERED),
 					),
 				},
 			},
@@ -1118,7 +1118,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 						withSubscriberURI,
 						reconcilertesting.WithTriggerDependencyReady(),
 						reconcilertesting.WithTriggerBrokerReady(),
-						reconcilertesting.WithTriggerSubscriberResolvedSucceeded(),
+						withTriggerSubscriberResolvedSucceeded(contract.DeliveryOrder_UNORDERED),
 					),
 				},
 			},
@@ -1363,7 +1363,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 						withSubscriberURI,
 						reconcilertesting.WithTriggerDependencyReady(),
 						reconcilertesting.WithTriggerBrokerReady(),
-						reconcilertesting.WithTriggerSubscriberResolvedSucceeded(),
+						withTriggerSubscriberResolvedSucceeded(contract.DeliveryOrder_UNORDERED),
 					),
 				},
 			},
@@ -2186,6 +2186,16 @@ func withSubscriberURI(trigger *eventing.Trigger) {
 		panic(err)
 	}
 	trigger.Status.SubscriberURI = u
+}
+
+func withTriggerSubscriberResolvedSucceeded(deliveryOrder contract.DeliveryOrder) func(*eventing.Trigger) {
+	return func(t *eventing.Trigger) {
+		t.GetConditionSet().Manage(&t.Status).MarkTrueWithReason(
+			eventing.TriggerConditionSubscriberResolved,
+			"SubscriberResolved",
+			fmt.Sprintf("Subscriber will receive events with the delivery order: %s", deliveryOrder.String()),
+		)
+	}
 }
 
 func patchFinalizers() clientgotesting.PatchActionImpl {


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #732

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :gift: Add some details in the existing subscriber resolved condition about the delivery order. I didn't added a new condition for it because it's quite complicated and requires several changes in eventing too

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- :gift: Add some details in the existing subscriber resolved condition about the delivery order.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
