### PR TITLE
Remove WITH_KIND

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -56,8 +56,6 @@ jobs:
       GO111MODULE: off
       KO_DOCKER_REPO: kind.local
       REPLICAS: 1
-      WITH_KIND: true
-      SKIP_PUSH: true
       SYSTEM_NAMESPACE: knative-eventing
       # Use a semi-random cluster suffix, but somewhat predictable
       # so reruns don't just give us a completely new value.


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Followup of #749

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :broom: Removed `WITH_KIND` env when pushing data plane images. Now `KO_DOCKER_REPO = "kind.local"` is enough
