### PR TITLE
Playing with Subscriptions API filters

### DIFF
--- a/data-plane/THIRD-PARTY.txt
+++ b/data-plane/THIRD-PARTY.txt
@@ -1,5 +1,5 @@
 
-Lists of 153 third-party dependencies.
+Lists of 155 third-party dependencies.
      (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Classic Module (ch.qos.logback:logback-classic:1.2.3 - http://logback.qos.ch/logback-classic)
      (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Core Module (ch.qos.logback:logback-core:1.2.3 - http://logback.qos.ch/logback-core)
      (The Apache Software License, Version 2.0) Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.11.3 - http://github.com/FasterXML/jackson)
@@ -40,6 +40,7 @@ Lists of 153 third-party dependencies.
      (The Apache Software License, Version 2.0) CloudEvents - Vert.x Http Binding (io.cloudevents:cloudevents-http-vertx:2.2.0 - https://cloudevents.github.io/sdk-java/cloudevents-http-vertx/)
      (The Apache Software License, Version 2.0) CloudEvents - JSON Jackson (io.cloudevents:cloudevents-json-jackson:2.2.0 - https://cloudevents.github.io/sdk-java/cloudevents-json-jackson/)
      (The Apache Software License, Version 2.0) CloudEvents - Kafka Binding (io.cloudevents:cloudevents-kafka:2.2.0 - https://cloudevents.github.io/sdk-java/cloudevents-kafka/)
+     (The Apache Software License, Version 2.0) cloudevents-sql (io.cloudevents:cloudevents-sql:2.2.0 - https://cloudevents.github.io/sdk-java/cloudevents-sql/)
      (Apache Software License 2.0) Debezium API (io.debezium:debezium-api:1.5.3.Final - https://debezium.io/debezium-parent/debezium-api)
      (Apache Software License 2.0) Debezium Core (io.debezium:debezium-core:1.5.3.Final - https://debezium.io/debezium-parent/debezium-core)
      (Apache License, Version 2.0) Fabric8 :: Kubernetes :: Java Client (io.fabric8:kubernetes-client:5.4.1 - http://fabric8.io/kubernetes-client/)
@@ -117,6 +118,7 @@ Lists of 153 third-party dependencies.
      (Apache License, Version 2.0) (MIT License) Logstash Logback Encoder (net.logstash.logback:logstash-logback-encoder:6.6 - https://github.com/logstash/logstash-logback-encoder)
      (The MIT License) JOpt Simple (net.sf.jopt-simple:jopt-simple:4.6 - http://pholser.github.com/jopt-simple)
      (The MIT License) JOpt Simple (net.sf.jopt-simple:jopt-simple:5.0.4 - http://jopt-simple.github.io/jopt-simple)
+     (The BSD License) ANTLR 4 Runtime (org.antlr:antlr4-runtime:4.9.2 - http://www.antlr.org/antlr4-runtime)
      (The Apache Software License, Version 2.0) Commons Math (org.apache.commons:commons-math3:3.2 - http://commons.apache.org/proper/commons-math/)
      (The Apache Software License, Version 2.0) Apache Kafka (org.apache.kafka:kafka-clients:2.7.0 - https://kafka.apache.org)
      (The Apache Software License, Version 2.0) Apache Kafka (org.apache.kafka:kafka-raft:2.7.0 - https://kafka.apache.org)

--- a/data-plane/core/pom.xml
+++ b/data-plane/core/pom.xml
@@ -99,6 +99,10 @@
       <artifactId>cloudevents-http-vertx</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.cloudevents</groupId>
+      <artifactId>cloudevents-sql</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-micrometer-metrics</artifactId>
       <exclusions>

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/AllFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/AllFilter.java
@@ -1,0 +1,24 @@
+package dev.knative.eventing.kafka.broker.core.filter.impl;
+
+import dev.knative.eventing.kafka.broker.core.filter.Filter;
+import io.cloudevents.CloudEvent;
+import java.util.Set;
+
+public class AllFilter implements Filter {
+
+  private final Set<Filter> filters;
+
+  public AllFilter(Set<Filter> filters) {
+    this.filters = filters;
+  }
+
+  @Override
+  public boolean test(CloudEvent cloudEvent) {
+    for (Filter filter : filters) {
+      if (!filter.test(cloudEvent)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/AllFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/AllFilter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.core.filter.impl;
 
 import dev.knative.eventing.kafka.broker.core.filter.Filter;

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/AnyFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/AnyFilter.java
@@ -1,0 +1,24 @@
+package dev.knative.eventing.kafka.broker.core.filter.impl;
+
+import dev.knative.eventing.kafka.broker.core.filter.Filter;
+import io.cloudevents.CloudEvent;
+import java.util.Set;
+
+public class AnyFilter implements Filter {
+
+  private final Set<Filter> filters;
+
+  public AnyFilter(Set<Filter> filters) {
+    this.filters = filters;
+  }
+
+  @Override
+  public boolean test(CloudEvent cloudEvent) {
+    for (Filter filter : filters) {
+      if (filter.test(cloudEvent)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/AnyFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/AnyFilter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.core.filter.impl;
 
 import dev.knative.eventing.kafka.broker.core.filter.Filter;

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/BaseStringFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/BaseStringFilter.java
@@ -1,0 +1,30 @@
+package dev.knative.eventing.kafka.broker.core.filter.impl;
+
+import dev.knative.eventing.kafka.broker.core.filter.Filter;
+import io.cloudevents.CloudEvent;
+import java.util.function.Function;
+
+public abstract class BaseStringFilter implements Filter {
+
+  protected final Function<CloudEvent, String> extractor;
+  protected final String expectedValue;
+
+  public BaseStringFilter(String attribute, String expectedValue) {
+    if (attribute == null || attribute.isBlank()) {
+      throw new IllegalArgumentException("Attribute name is empty");
+    }
+    if (expectedValue == null || expectedValue.isBlank()) {
+      throw new IllegalArgumentException("Attribute value is empty");
+    }
+
+    this.extractor = AttributesFilter.attributesMapper.getOrDefault(attribute, e -> {
+      Object extValue = e.getExtension(attribute);
+      if (extValue == null) {
+        return null;
+      }
+      return extValue.toString();
+    });
+    this.expectedValue = expectedValue;
+  }
+
+}

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/BaseStringFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/BaseStringFilter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.core.filter.impl;
 
 import dev.knative.eventing.kafka.broker.core.filter.Filter;

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/ExactFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/ExactFilter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.core.filter.impl;
 
 import io.cloudevents.CloudEvent;

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/ExactFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/ExactFilter.java
@@ -1,0 +1,15 @@
+package dev.knative.eventing.kafka.broker.core.filter.impl;
+
+import io.cloudevents.CloudEvent;
+
+public class ExactFilter extends BaseStringFilter {
+
+  public ExactFilter(String attribute, String expectedValue) {
+    super(attribute, expectedValue);
+  }
+
+  @Override
+  public boolean test(CloudEvent cloudEvent) {
+    return expectedValue.equals(this.extractor.apply(cloudEvent));
+  }
+}

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/PrefixFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/PrefixFilter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.core.filter.impl;
 
 import io.cloudevents.CloudEvent;

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/PrefixFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/PrefixFilter.java
@@ -1,0 +1,16 @@
+package dev.knative.eventing.kafka.broker.core.filter.impl;
+
+import io.cloudevents.CloudEvent;
+
+public class PrefixFilter extends BaseStringFilter {
+
+  public PrefixFilter(String attribute, String expectedValue) {
+    super(attribute, expectedValue);
+  }
+
+  @Override
+  public boolean test(CloudEvent cloudEvent) {
+    String value = this.extractor.apply(cloudEvent);
+    return value != null && value.startsWith(this.expectedValue);
+  }
+}

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/SqlFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/SqlFilter.java
@@ -21,7 +21,7 @@ public class SqlFilter implements Filter {
   @Override
   public boolean test(CloudEvent cloudEvent) {
     try {
-      Object value = this.expression.evaluate(this.runtime, cloudEvent);
+      Object value = this.expression.tryEvaluate(this.runtime, cloudEvent);
       return (Boolean) this.runtime.cast(null /* TODO https://github.com/cloudevents/sdk-java/pull/396 */, value, Type.BOOLEAN);
     } catch (EvaluationException evaluationException) {
       return false;

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/SqlFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/SqlFilter.java
@@ -22,7 +22,7 @@ public class SqlFilter implements Filter {
   public boolean test(CloudEvent cloudEvent) {
     try {
       Object value = this.expression.tryEvaluate(this.runtime, cloudEvent);
-      return (Boolean) this.runtime.cast(null /* TODO https://github.com/cloudevents/sdk-java/pull/396 */, value, Type.BOOLEAN);
+      return (Boolean) this.runtime.cast(value, Type.BOOLEAN);
     } catch (EvaluationException evaluationException) {
       return false;
     }

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/SqlFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/SqlFilter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.core.filter.impl;
 
 import dev.knative.eventing.kafka.broker.core.filter.Filter;

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/SqlFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/SqlFilter.java
@@ -1,0 +1,30 @@
+package dev.knative.eventing.kafka.broker.core.filter.impl;
+
+import dev.knative.eventing.kafka.broker.core.filter.Filter;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.sql.EvaluationException;
+import io.cloudevents.sql.EvaluationRuntime;
+import io.cloudevents.sql.Expression;
+import io.cloudevents.sql.Parser;
+import io.cloudevents.sql.Type;
+
+public class SqlFilter implements Filter {
+
+  private final Expression expression;
+  private final EvaluationRuntime runtime;
+
+  public SqlFilter(String sqlExpression) {
+    this.expression = Parser.parseDefault(sqlExpression);
+    this.runtime = EvaluationRuntime.getDefault();
+  }
+
+  @Override
+  public boolean test(CloudEvent cloudEvent) {
+    try {
+      Object value = this.expression.evaluate(this.runtime, cloudEvent);
+      return (Boolean) this.runtime.cast(null /* TODO https://github.com/cloudevents/sdk-java/pull/396 */, value, Type.BOOLEAN);
+    } catch (EvaluationException evaluationException) {
+      return false;
+    }
+  }
+}

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/SuffixFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/SuffixFilter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.core.filter.impl;
 
 import io.cloudevents.CloudEvent;

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/SuffixFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/impl/SuffixFilter.java
@@ -1,0 +1,16 @@
+package dev.knative.eventing.kafka.broker.core.filter.impl;
+
+import io.cloudevents.CloudEvent;
+
+public class SuffixFilter extends BaseStringFilter {
+
+  public SuffixFilter(String attribute, String expectedValue) {
+    super(attribute, expectedValue);
+  }
+
+  @Override
+  public boolean test(CloudEvent cloudEvent) {
+    String value = this.extractor.apply(cloudEvent);
+    return value != null && value.endsWith(this.expectedValue);
+  }
+}

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/AllFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/AllFilterTest.java
@@ -1,0 +1,51 @@
+package dev.knative.eventing.kafka.broker.core.filter.impl;
+
+import dev.knative.eventing.kafka.broker.core.filter.Filter;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AllFilterTest {
+
+  final static CloudEvent event = CloudEventBuilder.v1()
+    .withId("123-42")
+    .withDataContentType("application/cloudevents+json")
+    .withDataSchema(URI.create("/api/schema"))
+    .withSource(URI.create("/api/some-source"))
+    .withSubject("a-subject-42")
+    .withType("type")
+    .withTime(OffsetDateTime.of(
+      1985, 4, 12,
+      23, 20, 50, 0,
+      ZoneOffset.UTC
+    ))
+    .build();
+
+  @ParameterizedTest
+  @MethodSource(value = {"testCases"})
+  public void match(CloudEvent event, Filter filter, boolean shouldMatch) {
+    assertThat(filter.test(event))
+      .isEqualTo(shouldMatch);
+  }
+
+  static Stream<Arguments> testCases() {
+    return Stream.of(
+      Arguments.of(event, new AllFilter(Set.of(new ExactFilter("id", "123-42"))), true),
+      Arguments.of(event, new AllFilter(Set.of(new ExactFilter("id", "123-42"), new ExactFilter("source", "/api/some-source"))), true),
+      Arguments.of(event, new AllFilter(Set.of(new ExactFilter("id", "123"), new ExactFilter("source", "/api/some-source"))), false),
+      Arguments.of(event, new AllFilter(Set.of(new ExactFilter("id", "123-42"), new ExactFilter("source", "/api/something-else"))), false),
+      Arguments.of(event, new AllFilter(Collections.emptySet()), true)
+    );
+  }
+
+}

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/AllFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/AllFilterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.core.filter.impl;
 
 import dev.knative.eventing.kafka.broker.core.filter.Filter;

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/AnyFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/AnyFilterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.core.filter.impl;
 
 import dev.knative.eventing.kafka.broker.core.filter.Filter;

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/AnyFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/AnyFilterTest.java
@@ -1,0 +1,52 @@
+package dev.knative.eventing.kafka.broker.core.filter.impl;
+
+import dev.knative.eventing.kafka.broker.core.filter.Filter;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnyFilterTest {
+
+  final static CloudEvent event = CloudEventBuilder.v1()
+    .withId("123-42")
+    .withDataContentType("application/cloudevents+json")
+    .withDataSchema(URI.create("/api/schema"))
+    .withSource(URI.create("/api/some-source"))
+    .withSubject("a-subject-42")
+    .withType("type")
+    .withTime(OffsetDateTime.of(
+      1985, 4, 12,
+      23, 20, 50, 0,
+      ZoneOffset.UTC
+    ))
+    .build();
+
+  @ParameterizedTest
+  @MethodSource(value = {"testCases"})
+  public void match(CloudEvent event, Filter filter, boolean shouldMatch) {
+    assertThat(filter.test(event))
+      .isEqualTo(shouldMatch);
+  }
+
+  static Stream<Arguments> testCases() {
+    return Stream.of(
+      Arguments.of(event, new AnyFilter(Set.of(new ExactFilter("id", "123-42"))), true),
+      Arguments.of(event, new AnyFilter(Set.of(new ExactFilter("id", "123-42"), new ExactFilter("source", "/api/some-source"))), true),
+      Arguments.of(event, new AnyFilter(Set.of(new ExactFilter("id", "123"), new ExactFilter("source", "/api/some-source"))), true),
+      Arguments.of(event, new AnyFilter(Set.of(new ExactFilter("id", "123-42"), new ExactFilter("source", "/api/something-else"))), true),
+      Arguments.of(event, new AnyFilter(Set.of(new ExactFilter("id", "123"), new ExactFilter("source", "/api/something-else"))), false),
+      Arguments.of(event, new AnyFilter(Collections.emptySet()), false)
+    );
+  }
+
+}

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/ExactFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/ExactFilterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.core.filter.impl;
 
 import io.cloudevents.CloudEvent;

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/ExactFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/ExactFilterTest.java
@@ -21,11 +21,13 @@ import java.net.URI;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ExactFilterTest {
 
@@ -41,7 +43,25 @@ public class ExactFilterTest {
       23, 20, 50, 0,
       ZoneOffset.UTC
     ))
+    .withExtension("abc", "123")
+    .withExtension("urlext", URI.create("/ext"))
     .build();
+
+  @Test
+  public void testInvalidKey() {
+    assertThatThrownBy(() -> new ExactFilter(null, "123"))
+      .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new ExactFilter("", "123"))
+      .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void testInvalidValue() {
+    assertThatThrownBy(() -> new ExactFilter("abc", null))
+      .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new ExactFilter("abc", ""))
+      .isInstanceOf(IllegalArgumentException.class);
+  }
 
   @ParameterizedTest
   @MethodSource(value = {"testCases"})
@@ -56,7 +76,11 @@ public class ExactFilterTest {
       Arguments.of(event, "id", "123-42", true),
       Arguments.of(event, "id", "123-43", false),
       Arguments.of(event, "source", "/api/some-source", true),
-      Arguments.of(event, "source", "/api/something-else", false)
+      Arguments.of(event, "source", "/api/something-else", false),
+      Arguments.of(event, "abc", "123", true),
+      Arguments.of(event, "abc", "456", false),
+      Arguments.of(event, "urlext", "/ext", true),
+      Arguments.of(event, "urlext", "/no-ext", false)
     );
   }
 

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/ExactFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/ExactFilterTest.java
@@ -1,0 +1,48 @@
+package dev.knative.eventing.kafka.broker.core.filter.impl;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExactFilterTest {
+
+  final static CloudEvent event = CloudEventBuilder.v1()
+    .withId("123-42")
+    .withDataContentType("application/cloudevents+json")
+    .withDataSchema(URI.create("/api/schema"))
+    .withSource(URI.create("/api/some-source"))
+    .withSubject("a-subject-42")
+    .withType("type")
+    .withTime(OffsetDateTime.of(
+      1985, 4, 12,
+      23, 20, 50, 0,
+      ZoneOffset.UTC
+    ))
+    .build();
+
+  @ParameterizedTest
+  @MethodSource(value = {"testCases"})
+  public void match(CloudEvent event, String key, String value, boolean shouldMatch) {
+    var filter = new ExactFilter(key, value);
+    assertThat(filter.test(event))
+      .isEqualTo(shouldMatch);
+  }
+
+  static Stream<Arguments> testCases() {
+    return Stream.of(
+      Arguments.of(event, "id", "123-42", true),
+      Arguments.of(event, "id", "123-43", false),
+      Arguments.of(event, "source", "/api/some-source", true),
+      Arguments.of(event, "source", "/api/something-else", false)
+    );
+  }
+
+}

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/PrefixFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/PrefixFilterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.core.filter.impl;
 
 import io.cloudevents.CloudEvent;

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/PrefixFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/PrefixFilterTest.java
@@ -1,0 +1,48 @@
+package dev.knative.eventing.kafka.broker.core.filter.impl;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PrefixFilterTest {
+
+  final static CloudEvent event = CloudEventBuilder.v1()
+    .withId("123-42")
+    .withDataContentType("application/cloudevents+json")
+    .withDataSchema(URI.create("/api/schema"))
+    .withSource(URI.create("/api/some-source"))
+    .withSubject("a-subject-42")
+    .withType("type")
+    .withTime(OffsetDateTime.of(
+      1985, 4, 12,
+      23, 20, 50, 0,
+      ZoneOffset.UTC
+    ))
+    .build();
+
+  @ParameterizedTest
+  @MethodSource(value = {"testCases"})
+  public void match(CloudEvent event, String key, String value, boolean shouldMatch) {
+    var filter = new PrefixFilter(key, value);
+    assertThat(filter.test(event))
+      .isEqualTo(shouldMatch);
+  }
+
+  static Stream<Arguments> testCases() {
+    return Stream.of(
+      Arguments.of(event, "id", "123", true),
+      Arguments.of(event, "id", "124", false),
+      Arguments.of(event, "source", "/api", true),
+      Arguments.of(event, "source", "/news", false)
+    );
+  }
+
+}

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/SqlFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/SqlFilterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.core.filter.impl;
 
 import io.cloudevents.CloudEvent;

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/SqlFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/SqlFilterTest.java
@@ -1,0 +1,50 @@
+package dev.knative.eventing.kafka.broker.core.filter.impl;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SqlFilterTest {
+
+  final static CloudEvent event = CloudEventBuilder.v1()
+    .withId("123-42")
+    .withDataContentType("application/cloudevents+json")
+    .withDataSchema(URI.create("/api/schema"))
+    .withSource(URI.create("/api/some-source"))
+    .withSubject("a-subject-42")
+    .withType("type")
+    .withTime(OffsetDateTime.of(
+      1985, 4, 12,
+      23, 20, 50, 0,
+      ZoneOffset.UTC
+    ))
+    .build();
+
+  @ParameterizedTest
+  @MethodSource(value = {"testCases"})
+  public void match(CloudEvent event, String expression, boolean shouldMatch) {
+    var filter = new SqlFilter(expression);
+    assertThat(filter.test(event))
+      .isEqualTo(shouldMatch);
+  }
+
+  static Stream<Arguments> testCases() {
+    return Stream.of(
+      Arguments.of(event, "'TRUE'", true),
+      Arguments.of(event, "'FALSE'", false),
+      Arguments.of(event, "0", false),
+      Arguments.of(event, "1", false),
+      Arguments.of(event, "id LIKE '123%'", true),
+      Arguments.of(event, "NOT(id LIKE '123%')", false)
+    );
+  }
+
+}

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/SuffixFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/SuffixFilterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.core.filter.impl;
 
 import io.cloudevents.CloudEvent;

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/SuffixFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/impl/SuffixFilterTest.java
@@ -1,0 +1,48 @@
+package dev.knative.eventing.kafka.broker.core.filter.impl;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SuffixFilterTest {
+
+  final static CloudEvent event = CloudEventBuilder.v1()
+    .withId("123-42")
+    .withDataContentType("application/cloudevents+json")
+    .withDataSchema(URI.create("/api/schema"))
+    .withSource(URI.create("/api/some-source"))
+    .withSubject("a-subject-42")
+    .withType("type")
+    .withTime(OffsetDateTime.of(
+      1985, 4, 12,
+      23, 20, 50, 0,
+      ZoneOffset.UTC
+    ))
+    .build();
+
+  @ParameterizedTest
+  @MethodSource(value = {"testCases"})
+  public void match(CloudEvent event, String key, String value, boolean shouldMatch) {
+    var filter = new SuffixFilter(key, value);
+    assertThat(filter.test(event))
+      .isEqualTo(shouldMatch);
+  }
+
+  static Stream<Arguments> testCases() {
+    return Stream.of(
+      Arguments.of(event, "id", "42", true),
+      Arguments.of(event, "id", "43", false),
+      Arguments.of(event, "source", "source", true),
+      Arguments.of(event, "source", "sink", false)
+    );
+  }
+
+}

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -238,6 +238,11 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>io.cloudevents</groupId>
+        <artifactId>cloudevents-sql</artifactId>
+        <version>${cloudevents.sdk.version}</version>
+      </dependency>
 
       <!-- Protobuf -->
       <dependency>


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

This is a totally WIP PR meant to experiment what's missing in the cloudevents-sql package in order to implement subscriptions api filters.

Depends on https://github.com/knative/eventing/issues/5204 (unless we resort to create our own Trigger api).

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :gift: Implement `Filter` for all the subscriptions API filters 