### PR TITLE
[WIP] Probe resource address for ingress readiness

### DIFF
--- a/control-plane/config/500-controller.yaml
+++ b/control-plane/config/500-controller.yaml
@@ -97,6 +97,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: BROKER_PROBE_FAILURE_REQUEUE_DELAY_MS
+              value: "50"
+            - name: SINK_PROBE_FAILURE_REQUEUE_DELAY_MS
+              value: "50"
           ports:
             - containerPort: 9090
               name: metrics

--- a/control-plane/pkg/config/env_config.go
+++ b/control-plane/pkg/config/env_config.go
@@ -30,6 +30,7 @@ type Env struct {
 	SystemNamespace             string `required:"true" split_words:"true"`
 	DataPlaneConfigFormat       string `required:"true" split_words:"true"`
 	DefaultBackoffDelayMs       uint64 `required:"false" split_words:"true"`
+	ProbeFailureRequeueDelayMs  int64  `required:"false" split_words:"true" default:"50"`
 }
 
 // ValidationOption represents a function to validate the Env configurations.

--- a/control-plane/pkg/config/env_config_test.go
+++ b/control-plane/pkg/config/env_config_test.go
@@ -43,6 +43,7 @@ func TestGetEnvConfig(t *testing.T) {
 				IngressName:                 "kafka-broker-ingress",
 				SystemNamespace:             "knative-eventing",
 				DataPlaneConfigFormat:       "json",
+				ProbeFailureRequeueDelayMs:  50,
 			},
 			setEnv: func() {
 				_ = os.Setenv("BROKER_DATA_PLANE_CONFIG_MAP_NAMESPACE", "knative-eventing")
@@ -64,6 +65,7 @@ func TestGetEnvConfig(t *testing.T) {
 				IngressName:                 "kafka-sink-ingress",
 				SystemNamespace:             "knative-eventing",
 				DataPlaneConfigFormat:       "json",
+				ProbeFailureRequeueDelayMs:  50,
 			},
 			setEnv: func() {
 				_ = os.Setenv("SINK_DATA_PLANE_CONFIG_MAP_NAMESPACE", "knative-eventing")

--- a/control-plane/pkg/prober/cache.go
+++ b/control-plane/pkg/prober/cache.go
@@ -1,0 +1,88 @@
+package prober
+
+import (
+	"container/list"
+	"context"
+	"sync"
+	"time"
+)
+
+type Status int
+
+const (
+	// StatusReady signals that a given object is ready.
+	StatusReady Status = iota
+	// StatusUnknown signals that a given object is not ready and its state is unknown.
+	StatusUnknown
+	// StatusNotReady signals that a given object is not ready.
+	StatusNotReady
+)
+
+type Cache struct {
+	mu      sync.RWMutex
+	targets map[string]*list.Element
+	entries list.List
+
+	expireDurationMs int64
+}
+
+type ExpiredFunc func(key string, arg interface{})
+
+type value struct {
+	status     Status
+	lastUpdate int64
+	key        string
+	arg        interface{}
+	onExpired  ExpiredFunc
+}
+
+func NewCache(ctx context.Context, expireDuration time.Duration) *Cache {
+	c := &Cache{}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(expireDuration):
+				c.removeExpiredEntries(time.Now().UnixNano())
+			}
+		}
+	}()
+	return c
+}
+
+func (c *Cache) GetStatus(key string) Status {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if v, ok := c.targets[key]; ok {
+		return v.Value.(*value).status
+	}
+	return StatusUnknown
+}
+
+func (c *Cache) UpdateStatus(key string, status Status, arg interface{}, onExpired ExpiredFunc) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if v, ok := c.targets[key]; ok {
+		c.entries.Remove(v)
+		delete(c.targets, key)
+	}
+
+	value := &value{status: status, lastUpdate: time.Now().UnixNano(), key: key, arg: arg, onExpired: onExpired}
+	element := c.entries.PushBack(value)
+	c.targets[key] = element
+}
+
+func (c *Cache) removeExpiredEntries(now int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for e := c.entries.Front(); e.Value.(*value).lastUpdate+c.expireDurationMs < now; e = e.Next() {
+		v := e.Value.(*value)
+		delete(c.targets, v.key)
+		c.entries.Remove(e)
+		v.onExpired(v.key, v.arg)
+	}
+}

--- a/control-plane/pkg/prober/cache.go
+++ b/control-plane/pkg/prober/cache.go
@@ -7,8 +7,6 @@ import (
 	"time"
 )
 
-type Status int
-
 const (
 	// StatusReady signals that a given object is ready.
 	StatusReady Status = iota
@@ -18,71 +16,103 @@ const (
 	StatusNotReady
 )
 
-type Cache struct {
-	mu      sync.RWMutex
-	targets map[string]*list.Element
-	entries list.List
+// Status represents the resource status.
+type Status int
 
-	expireDurationMs int64
+// Cache is a key-status store.
+type Cache interface {
+	// GetStatus retries the status associated with the given key.
+	GetStatus(key string) Status
+	// UpsertStatus add or updates the status associated with the given key.
+	// Once the given key expires the onExpired callback will be called passing the arg parameter.
+	UpsertStatus(key string, status Status, arg interface{}, onExpired ExpiredFunc)
 }
 
+// ExpiredFunc is a callback called once an entry in the cache is expired.
 type ExpiredFunc func(key string, arg interface{})
+
+type inMemoryLocalCache struct {
+	// mu protects targets and entries
+	mu sync.RWMutex
+	// targets is a map of key-pointer to an element in the entries list.
+	targets map[string]*list.Element
+	// entries is a doubly-linked list of all entries present in the cache.
+	// This allow fast deletion of expired entries.
+	entries *list.List
+
+	expireDuration time.Duration
+}
 
 type value struct {
 	status     Status
-	lastUpdate int64
+	lastUpsert time.Time
 	key        string
 	arg        interface{}
 	onExpired  ExpiredFunc
 }
 
-func NewCache(ctx context.Context, expireDuration time.Duration) *Cache {
-	c := &Cache{}
+func NewInMemoryLocalCache(ctx context.Context, expireDuration time.Duration) Cache {
+	c := &inMemoryLocalCache{
+		mu:             sync.RWMutex{},
+		targets:        make(map[string]*list.Element, 64),
+		entries:        list.New().Init(),
+		expireDuration: expireDuration,
+	}
 	go func() {
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-time.After(expireDuration):
-				c.removeExpiredEntries(time.Now().UnixNano())
+				c.removeExpiredEntries(time.Now())
 			}
 		}
 	}()
 	return c
 }
 
-func (c *Cache) GetStatus(key string) Status {
+func (c *inMemoryLocalCache) GetStatus(key string) Status {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	if v, ok := c.targets[key]; ok {
-		return v.Value.(*value).status
+		value := v.Value.(*value)
+		if !c.isExpired(value, time.Now()) {
+			return value.status
+		}
 	}
 	return StatusUnknown
 }
 
-func (c *Cache) UpdateStatus(key string, status Status, arg interface{}, onExpired ExpiredFunc) {
+func (c *inMemoryLocalCache) UpsertStatus(key string, status Status, arg interface{}, onExpired ExpiredFunc) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	if v, ok := c.targets[key]; ok {
-		c.entries.Remove(v)
 		delete(c.targets, key)
+		c.entries.Remove(v)
 	}
 
-	value := &value{status: status, lastUpdate: time.Now().UnixNano(), key: key, arg: arg, onExpired: onExpired}
+	value := &value{status: status, lastUpsert: time.Now(), key: key, arg: arg, onExpired: onExpired}
 	element := c.entries.PushBack(value)
 	c.targets[key] = element
 }
 
-func (c *Cache) removeExpiredEntries(now int64) {
+func (c *inMemoryLocalCache) removeExpiredEntries(now time.Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for e := c.entries.Front(); e.Value.(*value).lastUpdate+c.expireDurationMs < now; e = e.Next() {
-		v := e.Value.(*value)
+	for curr := c.entries.Front(); curr != nil && c.isExpired(curr.Value.(*value), now); {
+		v := curr.Value.(*value)
 		delete(c.targets, v.key)
-		c.entries.Remove(e)
+		prev := curr
+		curr = curr.Next()
+		c.entries.Remove(prev)
+
 		v.onExpired(v.key, v.arg)
 	}
+}
+
+func (c *inMemoryLocalCache) isExpired(v *value, now time.Time) bool {
+	return v.lastUpsert.Add(c.expireDuration).Before(now)
 }

--- a/control-plane/pkg/prober/cache_test.go
+++ b/control-plane/pkg/prober/cache_test.go
@@ -1,0 +1,78 @@
+package prober_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
+)
+
+func TestInMemoryLocalCache(t *testing.T) {
+	d := time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), d*2)
+	defer cancel()
+	c := prober.NewInMemoryLocalCache(ctx, d)
+	testCache(t, ctx, c, d)
+}
+
+func testCache(t *testing.T, ctx context.Context, c prober.Cache, d time.Duration) {
+	var wg sync.WaitGroup
+	errors := make(chan error, 1)
+
+	wg.Add(2)
+
+	c.UpsertStatus("key1", prober.StatusUnknown, 4, verifyNoExpired(errors))
+	require.Equal(t, prober.StatusUnknown, c.GetStatus("key1"))
+
+	c.UpsertStatus("key2", prober.StatusNotReady, 42, verifyNoExpired(errors))
+	require.Equal(t, prober.StatusNotReady, c.GetStatus("key2"))
+
+	c.UpsertStatus("key1", prober.StatusReady, 41, verifyOnExpired("key1", 41, &wg, errors))
+	require.Equal(t, prober.StatusReady, c.GetStatus("key1"))
+
+	c.UpsertStatus("key2", prober.StatusReady, 43, verifyOnExpired("key2", 43, &wg, errors))
+	require.Equal(t, prober.StatusReady, c.GetStatus("key2"))
+
+	ctx, cancel := context.WithTimeout(ctx, d*2)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-ctx.Done():
+		t.Errorf("Timeout waiting for wait group to be done")
+	case err := <-errors:
+		t.Errorf(err.Error())
+	case <-done:
+		// Wait expiration
+		require.Nil(t, wait.PollImmediate(d, d*2, func() (done bool, err error) { return prober.StatusUnknown == c.GetStatus("key1"), nil }))
+		require.Nil(t, wait.PollImmediate(d, d*2, func() (done bool, err error) { return prober.StatusUnknown == c.GetStatus("key2"), nil }))
+	}
+}
+
+func verifyNoExpired(errors chan<- error) func(key string, arg interface{}) {
+	return func(key string, arg interface{}) {
+		errors <- fmt.Errorf("unexpected call to onExpired callback")
+	}
+}
+
+func verifyOnExpired(expectedKey string, expectedArg interface{}, wg *sync.WaitGroup, errors chan<- error) func(key string, arg interface{}) {
+	return func(key string, arg interface{}) {
+		if expectedKey != key {
+			errors <- fmt.Errorf("expected key to be %v got %v", expectedKey, key)
+		}
+		if expectedArg != arg {
+			errors <- fmt.Errorf("expected arg for key %v to be %v got %v", key, expectedArg, arg)
+		}
+		wg.Done()
+	}
+}

--- a/control-plane/pkg/prober/ingress_prober.go
+++ b/control-plane/pkg/prober/ingress_prober.go
@@ -1,0 +1,1 @@
+package prober

--- a/control-plane/pkg/prober/ingress_prober.go
+++ b/control-plane/pkg/prober/ingress_prober.go
@@ -1,1 +1,88 @@
 package prober
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/network"
+)
+
+type IngressProbeRequest struct {
+	object metav1.Object
+	path   string
+	pod    corev1.Pod
+}
+
+type RequestOption func(r *http.Request) error
+
+type Prober interface {
+	Probe(ctx context.Context, pods []*corev1.Pod, object metav1.Object, opts ...RequestOption) error
+}
+
+type KeyFunc func(r *http.Request) string
+
+type asyncProber struct {
+	onExpire  ExpiredFunc
+	keyFunc   KeyFunc
+	cache     Cache
+	doRequest func(r *http.Request) (*http.Response, error)
+}
+
+func (prober *asyncProber) Probe(ctx context.Context, pods []*corev1.Pod, object metav1.Object, opts ...RequestOption) error {
+
+	for _, p := range pods {
+		if podIP := p.Status.PodIP; podIP != "" {
+			if err := prober.probe(ctx, p, object, opts); err != nil {
+				return err // probe already decorates err.
+			}
+		}
+	}
+
+	return nil
+}
+
+func (prober *asyncProber) probe(ctx context.Context, pod *corev1.Pod, object metav1.Object, opts []RequestOption) error {
+	r, err := http.NewRequest("GET", "", nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request %w", err)
+	}
+	for _, op := range opts {
+		if err := op(r); err != nil {
+			return err
+		}
+	}
+
+	// We don't want to probe object based on their content, so header values are constant.
+	r.Header.Add(network.ProbeHeaderName, "probe")
+	r.Header.Add(network.HashHeaderName, "hash")
+
+	go func() {
+		response, err := prober.doRequest(r)
+		if err != nil {
+			prober.cache.UpsertStatus(prober.keyFunc(r), StatusUnknown, object, prober.onExpire)
+			logging.FromContext(ctx).Desugar().Error("failed to probe pod",
+				zap.String("url", r.URL.String()),
+				zap.Error(err),
+			)
+			return
+		}
+
+		if response.StatusCode != http.StatusOK {
+			prober.cache.UpsertStatus(prober.keyFunc(r), StatusNotReady, object, prober.onExpire)
+			logging.FromContext(ctx).Desugar().Info("probe failed unexpected response status code",
+				zap.Int("statusCode", response.StatusCode),
+				zap.String("url", r.URL.String()),
+				zap.Error(err),
+			)
+			return
+		}
+		prober.cache.UpsertStatus(prober.keyFunc(r), StatusReady, object, prober.onExpire)
+	}()
+
+	return nil
+}

--- a/control-plane/pkg/reconciler/base/receiver_condition_set.go
+++ b/control-plane/pkg/reconciler/base/receiver_condition_set.go
@@ -37,6 +37,7 @@ const (
 	ConditionTopicReady         apis.ConditionType = "TopicReady"
 	ConditionConfigMapUpdated   apis.ConditionType = "ConfigMapUpdated"
 	ConditionConfigParsed       apis.ConditionType = "ConfigParsed"
+	ConditionProbeSucceeded     apis.ConditionType = "ProbeSucceeded"
 )
 
 var ConditionSet = apis.NewLivingConditionSet(
@@ -45,6 +46,7 @@ var ConditionSet = apis.NewLivingConditionSet(
 	ConditionTopicReady,
 	ConditionConfigMapUpdated,
 	ConditionConfigParsed,
+	ConditionProbeSucceeded,
 )
 
 const (
@@ -54,6 +56,8 @@ const (
 	MessageDataPlaneNotAvailable = "Did you install the data plane for this component?"
 
 	ReasonTopicNotPresent = "Topic is not present"
+
+	ReasonProbeFailed = "A probe request failed"
 )
 
 type Object interface {
@@ -241,4 +245,16 @@ func (manager *StatusConditionManager) TopicNotPresentOrInvalid() error {
 
 	return fmt.Errorf("topic is not present: check topic configuration")
 
+}
+
+func (manager *StatusConditionManager) ProbeFailed(err error) {
+	manager.Object.GetConditionSet().Manage(manager.Object.GetStatus()).MarkFalse(
+		ConditionProbeSucceeded,
+		ReasonProbeFailed,
+		err.Error(),
+	)
+}
+
+func (manager *StatusConditionManager) ProbeSucceeded() {
+	manager.Object.GetConditionSet().Manage(manager.Object.GetStatus()).MarkTrue(ConditionProbeSucceeded)
 }

--- a/control-plane/pkg/reconciler/base/reconciler_test.go
+++ b/control-plane/pkg/reconciler/base/reconciler_test.go
@@ -290,7 +290,7 @@ func TestProbeReceivers(t *testing.T) {
 		ReceiverLabel:    base.BrokerReceiverLabel,
 	}
 
-	assert.Nil(t, r.ProbeReceivers("/hello/hello"))
+	assert.Nil(t, r.ProbeReceivers("/hello/hello", nil))
 }
 
 func TestProbeReceiversFailure(t *testing.T) {
@@ -325,7 +325,7 @@ func TestProbeReceiversFailure(t *testing.T) {
 				ReceiverLabel:    base.BrokerReceiverLabel,
 			}
 
-			assert.NotNil(t, r.ProbeReceivers(tc.path))
+			assert.NotNil(t, r.ProbeReceivers(tc.path, nil))
 		})
 	}
 }

--- a/control-plane/pkg/reconciler/base/reconciler_test.go
+++ b/control-plane/pkg/reconciler/base/reconciler_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
 	testinghttp "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/testing/http"
 	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -288,9 +289,10 @@ func TestProbeReceivers(t *testing.T) {
 		RequestProbeDoer: testinghttp.Do(http.StatusOK),
 		PodLister:        podinformer.Get(ctx).Lister(),
 		ReceiverLabel:    base.BrokerReceiverLabel,
+		ProbeCache:       prober.NewInMemoryLocalCache(ctx, time.Second),
 	}
 
-	assert.Nil(t, r.ProbeReceivers("/hello/hello", nil))
+	assert.Nil(t, r.ProbeReceivers(&eventing.Broker{}, "/hello/hello"))
 }
 
 func TestProbeReceiversFailure(t *testing.T) {
@@ -323,9 +325,10 @@ func TestProbeReceiversFailure(t *testing.T) {
 				RequestProbeDoer: testinghttp.Do(tc.statusCode),
 				PodLister:        podinformer.Get(ctx).Lister(),
 				ReceiverLabel:    base.BrokerReceiverLabel,
+				ProbeCache:       prober.NewInMemoryLocalCache(ctx, time.Second),
 			}
 
-			assert.NotNil(t, r.ProbeReceivers(tc.path, nil))
+			assert.Nil(t, r.ProbeReceivers(&eventing.Broker{}, tc.path))
 		})
 	}
 }

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -215,7 +215,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 
 	// To make sure that our receivers have got at least the first broker configuration, we probe our receivers pods
 	ingress := brokerResource.Ingress.IngressType.(*contract.Ingress_Path)
-	if err := r.ProbeReceivers(ingress.Path); err != nil {
+	if err := r.ProbeReceivers(broker, ingress.Path); err != nil {
 		statusConditionManager.ProbeFailed(err)
 		// When a probe fails, we don't return an error but we requeue our broker so that we can probe it again later.
 		r.EnqueueAfter(broker, time.Duration(r.Configs.ProbeFailureRequeueDelayMs)*time.Millisecond)

--- a/control-plane/pkg/reconciler/broker/broker_test.go
+++ b/control-plane/pkg/reconciler/broker/broker_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/utils/pointer"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
 	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/pkg/apis"
 	kubeclient "knative.dev/pkg/client/injection/kube/client/fake"
@@ -1837,6 +1838,7 @@ func useTable(t *testing.T, table TableTest, configs *Configs) {
 				DispatcherLabel:             base.BrokerDispatcherLabel,
 				ReceiverLabel:               base.BrokerReceiverLabel,
 				RequestProbeDoer:            tesingthttp.Do(probeResponseStatusCode),
+				ProbeCache:                  prober.NewInMemoryLocalCache(ctx, time.Second),
 			},
 			KafkaDefaultTopicDetails:     defaultTopicDetail,
 			KafkaDefaultTopicDetailsLock: sync.RWMutex{},
@@ -1856,7 +1858,6 @@ func useTable(t *testing.T, table TableTest, configs *Configs) {
 
 		reconciler.ConfigMapTracker = &FakeTracker{}
 		reconciler.SecretTracker = &FakeTracker{}
-		reconciler.EnqueueAfter = func(broker *eventing.Broker, duration time.Duration) {}
 
 		r := brokerreconciler.NewReconciler(
 			ctx,

--- a/control-plane/pkg/reconciler/broker/controller.go
+++ b/control-plane/pkg/reconciler/broker/controller.go
@@ -147,9 +147,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher, configs *Conf
 
 	brokerInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: kafka.BrokerClassFilter(),
-		Handler: cache.ResourceEventHandlerFuncs{
-			DeleteFunc: reconciler.OnDeleteObserver,
-		},
+		Handler:    cache.ResourceEventHandlerFuncs{DeleteFunc: reconciler.OnDeleteObserver},
 	})
 
 	cm, err := reconciler.KubeClient.CoreV1().ConfigMaps(configs.SystemNamespace).Get(ctx, configs.GeneralConfigMapName, metav1.GetOptions{})

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -197,7 +197,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 	}
 
 	ingress := sinkConfig.Ingress.IngressType.(*contract.Ingress_Path)
-	if err := r.ProbeReceivers(ingress.Path); err != nil {
+	if err := r.ProbeReceivers(ingress.Path, nil); err != nil {
 		statusConditionManager.ProbeFailed(err)
 		// When a probe fails, we don't return an error but we requeue our sink so that we can probe it again later.
 		r.EnqueueAfter(ks, time.Duration(r.Configs.ProbeFailureRequeueDelayMs)*time.Millisecond)

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -197,7 +197,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 	}
 
 	ingress := sinkConfig.Ingress.IngressType.(*contract.Ingress_Path)
-	if err := r.ProbeReceivers(ingress.Path, nil); err != nil {
+	if err := r.ProbeReceivers(ks, ingress.Path); err != nil {
 		statusConditionManager.ProbeFailed(err)
 		// When a probe fails, we don't return an error but we requeue our sink so that we can probe it again later.
 		r.EnqueueAfter(ks, time.Duration(r.Configs.ProbeFailureRequeueDelayMs)*time.Millisecond)

--- a/control-plane/pkg/reconciler/testing/http/client.go
+++ b/control-plane/pkg/reconciler/testing/http/client.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package http
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+func Do(statusCode int) func(r *http.Request) (*http.Response, error) {
+	return func(r *http.Request) (*http.Response, error) {
+		n := 2
+		if strings.Count(r.URL.Path, "/") < n {
+			return nil, fmt.Errorf("unexpected path %s expected at least %d '/'", r.URL.Path, n)
+		}
+		return &http.Response{Status: http.StatusText(statusCode), StatusCode: statusCode}, nil
+	}
+}

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -154,7 +154,11 @@ function apply_sacura() {
   ko apply -f ./test/config/sacura/100-broker-config.yaml || return $?
   ko apply -f ./test/config/sacura/101-broker.yaml || return $?
 
-  kubectl wait --for=condition=ready --timeout=3m -n sacura broker/broker || return $?
+  kubectl wait --for=condition=ready --timeout=3m -n sacura broker/broker || {
+    local failed=$?
+    kubectl describe broker -n sacura broker
+    return $failed
+  }
 
   ko apply -f ./test/config/sacura || return $?
 }


### PR DESCRIPTION
## Proposed changes

- Probe broker address
- Probe KafkaSink address

Probing is done using the knative/networking data-plane contract
(already implemented in Eventing through knative/pkg).
ref issue https://github.com/knative/eventing/issues/3911

Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>

Part of #864 (follow-up consumer readiness)

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
The control plane probes the data plane for determining resources readiness.
```


/kind bug
