### PR TITLE
Bump JVM version to 16

### DIFF
--- a/.github/workflows/knative-java-test.yaml
+++ b/.github/workflows/knative-java-test.yaml
@@ -28,7 +28,7 @@ jobs:
     name: Java Unit Tests
     strategy:
       matrix:
-        java-version: [ 15 ]
+        java-version: [ 16 ]
         platform: [ ubuntu-latest ]
 
     runs-on: ${{ matrix.platform }}

--- a/hack/data-plane.sh
+++ b/hack/data-plane.sh
@@ -44,7 +44,7 @@ readonly dispatcher="${KNATIVE_KAFKA_BROKER_DISPATCHER:-knative-kafka-broker-dis
 # The BASE_IMAGE must have system libraries (libc, zlib, etc) compatible with the JAVA_IMAGE because
 # Jlink generates a jdk linked to the same system libraries available on the base images.
 readonly BASE_IMAGE=gcr.io/distroless/java-debian10:base-nonroot # Based on debian:buster
-readonly JAVA_IMAGE=docker.io/adoptopenjdk/openjdk15:debian      # Based on debian:buster
+readonly JAVA_IMAGE=docker.io/adoptopenjdk/openjdk16:debian      # Based on debian:buster
 
 readonly RECEIVER_JAR="receiver-1.0-SNAPSHOT.jar"
 readonly RECEIVER_DIRECTORY=receiver


### PR DESCRIPTION
JDK 15 is not supported anymore https://adoptopenjdk.net/support.html.

Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>
