### PR TITLE
Update k8s versions for KinD tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -21,9 +21,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - v1.18.8
-          - v1.19.4
-          - v1.20.0
+          - v1.19.11
+          - v1.20.7
+          - v1.21.1
 
         eventing-config:
           - "./third_party/eventing-latest/"
@@ -38,15 +38,15 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0
         include:
-          - k8s-version: v1.18.8
-            kind-version: v0.9.0
-            kind-image-sha: sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb
-          - k8s-version: v1.19.4
-            kind-version: v0.9.0
-            kind-image-sha: sha256:796d09e217d93bed01ecf8502633e48fd806fe42f9d02fdd468b81cd4e3bd40b
-          - k8s-version: v1.20.0
-            kind-version: v0.9.0
-            kind-image-sha: sha256:b40ecf8bcb188f6a0d0f5d406089c48588b75edc112c6f635d26be5de1c89040
+          - k8s-version: v1.19.11
+            kind-version: v0.11.1
+            kind-image-sha: sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
+          - k8s-version: v1.20.7
+            kind-version: v0.11.1
+            kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+          - k8s-version: v1.21.1
+            kind-version: v0.11.1
+            kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
 
           # Add the flags we use for each of these test suites.
           - test-suite: ./test/e2e


### PR DESCRIPTION
Update KinD version as in https://github.com/knative/eventing/pull/5480

Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>
