### PR TITLE
Add permission to update namespaces/finalizer to webhook cluster role

### DIFF
--- a/control-plane/config/sink/100-webhook-cluster-role.yaml
+++ b/control-plane/config/sink/100-webhook-cluster-role.yaml
@@ -81,3 +81,12 @@ rules:
     resources:
       - "leases"
     verbs: *everything
+
+  # finalizers are needed for the owner reference of the webhook
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces/finalizers"
+    verbs:
+      - "update"
+


### PR DESCRIPTION
(similar to https://github.com/knative/eventing/pull/5501)

This patch adds the permission to update `namespaces/finalizers`.

Since knative/pkg#2098 added ownerRef refers to namespace for webhook,
we need this permission. Without it, cluster which has a stricter RBAC
rules gets the following error:

```
cannot set blockOwnerDeletion if an ownerReference refers to a resource
you can't set finalizers on ...
```

Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>
