### PR TITLE
runAsNonRoot should be good enough

### DIFF
--- a/data-plane/config/broker/template/500-dispatcher.yaml
+++ b/data-plane/config/broker/template/500-dispatcher.yaml
@@ -36,7 +36,6 @@ spec:
       serviceAccountName: knative-kafka-data-plane
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65532
       containers:
         - name: kafka-broker-dispatcher
           image: ${KNATIVE_KAFKA_BROKER_DISPATCHER_IMAGE}

--- a/data-plane/config/broker/template/500-receiver.yaml
+++ b/data-plane/config/broker/template/500-receiver.yaml
@@ -36,7 +36,6 @@ spec:
       serviceAccountName: knative-kafka-data-plane
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65532
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
         podAntiAffinity:

--- a/data-plane/config/sink/template/500-receiver.yaml
+++ b/data-plane/config/sink/template/500-receiver.yaml
@@ -36,7 +36,6 @@ spec:
       serviceAccountName: knative-kafka-data-plane
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65532
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #1002

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- using the `runAsNonRoot: true` should be enough. If do not have a hard requirement for `runAsUser`. 

If that is required, I'd think of a good way to introudce this SCC related permissions:
```

        - apiGroups:
          - security.openshift.io
          resources:
          - securitycontextconstraints
          resourceNames:
          - anyuid
          verbs:
          - use
 ```
<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
