### PR TITLE
Removed terminology of Dead Letter Queue

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/OffsetManager.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/OffsetManager.java
@@ -32,12 +32,12 @@ public interface OffsetManager {
   Future<Void> recordReceived(KafkaConsumerRecord<?, ?> record);
 
   /**
-   * The given record cannot be delivered to dead letter queue.
+   * The given record cannot be delivered to dead letter sink.
    *
-   * @param record record undeliverable to dead letter queue.
+   * @param record record undeliverable to dead letter sink.
    * @param ex     exception occurred.
    */
-  Future<Void> failedToSendToDLQ(KafkaConsumerRecord<?, ?> record, Throwable ex);
+  Future<Void> failedToSendToDeadLetterSink(KafkaConsumerRecord<?, ?> record, Throwable ex);
 
   /**
    * The given event doesn't pass the filter.
@@ -54,9 +54,9 @@ public interface OffsetManager {
   Future<Void> successfullySentToSubscriber(KafkaConsumerRecord<?, ?> record);
 
   /**
-   * The given record has been successfully sent to dead letter queue.
+   * The given record has been successfully sent to dead letter sink.
    *
-   * @param record record sent to dead letter queue.
+   * @param record record sent to dead letter sink.
    */
-  Future<Void> successfullySentToDLQ(KafkaConsumerRecord<?, ?> record);
+  Future<Void> successfullySentToDeadLetterSink(KafkaConsumerRecord<?, ?> record);
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/OrderedOffsetManager.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/OrderedOffsetManager.java
@@ -76,7 +76,7 @@ public final class OrderedOffsetManager implements OffsetManager {
    * {@inheritDoc}
    */
   @Override
-  public Future<Void> successfullySentToDLQ(final KafkaConsumerRecord<?, ?> record) {
+  public Future<Void> successfullySentToDeadLetterSink(final KafkaConsumerRecord<?, ?> record) {
     return commit(record);
   }
 
@@ -84,7 +84,7 @@ public final class OrderedOffsetManager implements OffsetManager {
    * {@inheritDoc}
    */
   @Override
-  public Future<Void> failedToSendToDLQ(final KafkaConsumerRecord<?, ?> record, final Throwable ex) {
+  public Future<Void> failedToSendToDeadLetterSink(final KafkaConsumerRecord<?, ?> record, final Throwable ex) {
     return Future.succeededFuture();
   }
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/UnorderedOffsetManager.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/UnorderedOffsetManager.java
@@ -86,7 +86,7 @@ public final class UnorderedOffsetManager implements OffsetManager {
    * {@inheritDoc}
    */
   @Override
-  public Future<Void> successfullySentToDLQ(final KafkaConsumerRecord<?, ?> record) {
+  public Future<Void> successfullySentToDeadLetterSink(final KafkaConsumerRecord<?, ?> record) {
     return commit(record);
   }
 
@@ -94,7 +94,7 @@ public final class UnorderedOffsetManager implements OffsetManager {
    * {@inheritDoc}
    */
   @Override
-  public Future<Void> failedToSendToDLQ(final KafkaConsumerRecord<?, ?> record, final Throwable ex) {
+  public Future<Void> failedToSendToDeadLetterSink(final KafkaConsumerRecord<?, ?> record, final Throwable ex) {
     this.offsetTrackers.get(new TopicPartition(record.topic(), record.partition()))
       .recordNewOffset(record.offset());
     return Future.succeededFuture();

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerVerticleFactory.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerVerticleFactory.java
@@ -70,8 +70,8 @@ public class HttpConsumerVerticleFactory implements ConsumerVerticleFactory {
 
   private static final Logger logger = LoggerFactory.getLogger(HttpConsumerVerticleFactory.class);
 
-  private final static ConsumerRecordSender NO_DLQ_SENDER =
-    ConsumerRecordSender.create(Future.failedFuture("No DLQ set"), Future.succeededFuture());
+  private final static ConsumerRecordSender NO_DLS_SENDER =
+    ConsumerRecordSender.create(Future.failedFuture("No dead letter sink set"), Future.succeededFuture());
 
   private final Map<String, Object> consumerConfigs;
   private final WebClientOptions webClientOptions;
@@ -157,7 +157,7 @@ public class HttpConsumerVerticleFactory implements ConsumerVerticleFactory {
 
         final var egressDeadLetterSender = hasDeadLetterSink(egressConfig)
           ? createConsumerRecordSender(vertx, egressConfig.getDeadLetter(), egressConfig)
-          : NO_DLQ_SENDER;
+          : NO_DLS_SENDER;
 
         final var filter = egress.hasFilter() ?
           new AttributesFilter(egress.getFilter().getAttributesMap()) :

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/AbstractConsumerVerticleTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/AbstractConsumerVerticleTest.java
@@ -58,7 +58,7 @@ public abstract class AbstractConsumerVerticleTest {
     final var recordDispatcher = new RecordDispatcher(
       value -> false,
       ConsumerRecordSender.create(Future.failedFuture("subscriber send called"), Future.succeededFuture()),
-      ConsumerRecordSender.create(Future.failedFuture("DLQ send called"), Future.succeededFuture()),
+      ConsumerRecordSender.create(Future.failedFuture("dead letter sink send called"), Future.succeededFuture()),
       new SinkResponseHandlerMock(
         Future::succeededFuture,
         response -> Future.succeededFuture()
@@ -97,7 +97,7 @@ public abstract class AbstractConsumerVerticleTest {
     final var recordDispatcher = new RecordDispatcher(
       value -> false,
       ConsumerRecordSender.create(Future.failedFuture("subscriber send called"), Future.succeededFuture()),
-      ConsumerRecordSender.create(Future.failedFuture("DLQ send called"), Future.succeededFuture()),
+      ConsumerRecordSender.create(Future.failedFuture("dead letter sink send called"), Future.succeededFuture()),
       new SinkResponseHandlerMock(
         Future::succeededFuture,
         response -> Future.succeededFuture()

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/OrderedOffsetManagerTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/OrderedOffsetManagerTest.java
@@ -40,9 +40,9 @@ public class OrderedOffsetManagerTest extends AbstractOffsetManagerTest {
   }
 
   @Test
-  public void shouldNotCommitAfterFailedToSendToDLQ() {
+  public void shouldNotCommitAfterFailedToSendToDLS() {
     assertThatOffsetCommitted(List.of(new TopicPartition("aaa", 0)), offsetStrategy -> {
-      offsetStrategy.failedToSendToDLQ(record("aaa", 0, 0), new IllegalStateException());
+      offsetStrategy.failedToSendToDeadLetterSink(record("aaa", 0, 0), new IllegalStateException());
     }).isEmpty();
   }
 
@@ -62,9 +62,9 @@ public class OrderedOffsetManagerTest extends AbstractOffsetManagerTest {
   }
 
   @Test
-  public void shouldCommitAfterSuccessfullySentToDLQ() {
+  public void shouldCommitAfterSuccessfullySentToDLS() {
     assertThatOffsetCommitted(List.of(new TopicPartition("aaa", 0)), offsetStrategy -> {
-      offsetStrategy.successfullySentToDLQ(record("aaa", 0, 0));
+      offsetStrategy.successfullySentToDeadLetterSink(record("aaa", 0, 0));
     }).containsEntry(new TopicPartition("aaa", 0), 1L);
   }
 

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerVerticleFactoryTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerVerticleFactoryTest.java
@@ -97,7 +97,7 @@ public class HttpConsumerVerticleFactoryTest {
   }
 
   @Test
-  public void shouldNotThrowIllegalArgumentExceptionIfNotDLQ() {
+  public void shouldNotThrowIllegalArgumentExceptionIfNotDLS() {
 
     final var consumerProperties = new Properties();
     consumerProperties.setProperty(BOOTSTRAP_SERVERS_CONFIG, "0.0.0.0:9092");


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Across our codebase, we use quite often the term dead letter queue, while the correct term should be dead letter sink, because we don't send specifically to a queue but to a generic sink. This creates some confusion also in the logs, eg https://github.com/knative-sandbox/eventing-kafka-broker/issues/1011#issuecomment-863288386

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :broom: Cleanup the term dead letter queue and use instead DLS or dead letter sink. No changes except aesthetics

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->