### PR TITLE
Introduced `AsyncCloseable`

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/AsyncCloseable.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/AsyncCloseable.java
@@ -56,9 +56,11 @@ public interface AsyncCloseable extends Closeable {
    * @return the composed closeables
    */
   static AsyncCloseable compose(AsyncCloseable... closeables) {
-    return () -> CompositeFuture
-      .all(Arrays.stream(closeables).map(AsyncCloseable::close).collect(Collectors.toList()))
-      .mapEmpty();
+    return () -> CompositeFuture.all(
+      Arrays.stream(closeables)
+        .map(AsyncCloseable::close)
+        .collect(Collectors.toList())
+    ).mapEmpty();
   }
 
   /**

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/AsyncCloseable.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/AsyncCloseable.java
@@ -1,0 +1,47 @@
+package dev.knative.eventing.kafka.broker.core;
+
+import io.vertx.core.Closeable;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * Interface for components that can be closed asynchronously.
+ */
+@FunctionalInterface
+public interface AsyncCloseable extends Closeable {
+
+  /**
+   * Close this object.
+   *
+   * @return a future notifying the completion of the close operation
+   */
+  Future<Void> close();
+
+  @Override
+  default void close(Promise<Void> completion) {
+    this.close().onComplete(completion);
+  }
+
+  /**
+   * @return an implementation of {@link AutoCloseable} that will block when invoked.
+   */
+  default AutoCloseable toAutoCloseable() {
+    return () -> this.close().toCompletionStage().toCompletableFuture();
+  }
+
+  /**
+   * Compose several {@link AsyncCloseable} into a single {@link AsyncCloseable}. One close failure will cause the whole close to fail.
+   *
+   * @param closeables the closeables to compose
+   * @return the composed closeables
+   */
+  static AsyncCloseable compose(AsyncCloseable... closeables) {
+    return () -> CompositeFuture
+      .all(Arrays.stream(closeables).map(AsyncCloseable::close).collect(Collectors.toList()))
+      .mapEmpty();
+  }
+
+}

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/AsyncCloseable.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/AsyncCloseable.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.core;
 
 import io.vertx.core.Closeable;

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
@@ -98,22 +98,4 @@ public class Metrics {
     clientMetrics.bindTo(getRegistry());
     return clientMetrics;
   }
-
-  /**
-   * Close the given meter binder.
-   *
-   * @param vertx       vertx instance.
-   * @param meterBinder meter binder to close.
-   * @return A succeeded or a failed future.
-   */
-  public static Future<?> close(final Vertx vertx, final AutoCloseable meterBinder) {
-    return vertx.executeBlocking(promise -> {
-      try {
-        meterBinder.close();
-        promise.complete();
-      } catch (Exception e) {
-        promise.fail(e);
-      }
-    });
-  }
 }

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/metrics/MetricsTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/metrics/MetricsTest.java
@@ -43,24 +43,16 @@ public class MetricsTest {
   }
 
   @Test
-  public void shouldRegisterAndCloseProducerMetricsThread(final Vertx vertx, final VertxTestContext context) {
-    final var producer = new MockProducer<>();
-
-    final var meterBinder = Metrics.register(producer);
-
-    Metrics.close(vertx, meterBinder)
-      .onFailure(context::failNow)
-      .onSuccess(r -> context.completeNow());
+  public void shouldRegisterAndCloseProducerMetricsThread()
+    throws Exception {
+    final var meterBinder = Metrics.register(new MockProducer<>());
+    meterBinder.close();
   }
 
   @Test
-  public void shouldRegisterAndCloseConsumerMetricsThread(final Vertx vertx, final VertxTestContext context) {
-    final var consumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
-
-    final var meterBinder = Metrics.register(consumer);
-
-    Metrics.close(vertx, meterBinder)
-      .onFailure(context::failNow)
-      .onSuccess(r -> context.completeNow());
+  public void shouldRegisterAndCloseConsumerMetricsThread()
+    throws Exception {
+    final var meterBinder = Metrics.register(new MockConsumer<>(OffsetResetStrategy.LATEST));
+    meterBinder.close();
   }
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerRecordSender.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerRecordSender.java
@@ -15,13 +15,14 @@
  */
 package dev.knative.eventing.kafka.broker.dispatcher;
 
+import dev.knative.eventing.kafka.broker.core.AsyncCloseable;
 import io.cloudevents.CloudEvent;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 
-public interface ConsumerRecordSender {
+public interface ConsumerRecordSender extends AsyncCloseable {
 
   /**
    * Send the given record. (the record passed the filter)
@@ -30,13 +31,6 @@ public interface ConsumerRecordSender {
    * @return a successful future or a failed future.
    */
   Future<HttpResponse<Buffer>> send(KafkaConsumerRecord<String, CloudEvent> record);
-
-  /**
-   * Close consumer record sender.
-   *
-   * @return a successful future or a failed future.
-   */
-  Future<?> close();
 
   /**
    * Create a noop {@link ConsumerRecordSender} that fails every send with the specified message.
@@ -52,7 +46,7 @@ public interface ConsumerRecordSender {
       }
 
       @Override
-      public Future<?> close() {
+      public Future<Void> close() {
         return Future.succeededFuture();
       }
     };

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/SinkResponseHandler.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/SinkResponseHandler.java
@@ -15,6 +15,7 @@
  */
 package dev.knative.eventing.kafka.broker.dispatcher;
 
+import dev.knative.eventing.kafka.broker.core.AsyncCloseable;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.client.HttpResponse;
@@ -22,7 +23,7 @@ import io.vertx.ext.web.client.HttpResponse;
 /**
  * SinkResponseHandler is responsible for reading the response and acting on it based on its content.
  */
-public interface SinkResponseHandler {
+public interface SinkResponseHandler extends AsyncCloseable {
 
   /**
    * Handler the response.
@@ -31,11 +32,4 @@ public interface SinkResponseHandler {
    * @return A succeeded or failed future.
    */
   Future<Void> handle(final HttpResponse<Buffer> response);
-
-  /**
-   * Close resources.
-   *
-   * @return A succeeded or failed future.
-   */
-  Future<?> close();
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerRecordSender.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerRecordSender.java
@@ -122,7 +122,7 @@ public final class HttpConsumerRecordSender implements ConsumerRecordSender {
   }
 
   @Override
-  public Future<?> close() {
+  public Future<Void> close() {
     this.circuitBreaker.close();
     this.client.close();
     return Future.succeededFuture();

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerVerticleFactory.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerVerticleFactory.java
@@ -17,6 +17,7 @@ package dev.knative.eventing.kafka.broker.dispatcher.http;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract.EgressConfig;
+import dev.knative.eventing.kafka.broker.core.AsyncCloseable;
 import dev.knative.eventing.kafka.broker.core.filter.Filter;
 import dev.knative.eventing.kafka.broker.core.filter.impl.AttributesFilter;
 import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
@@ -181,7 +182,7 @@ public class HttpConsumerVerticleFactory implements ConsumerVerticleFactory {
         // Set all the built objects in the consumer verticle
         consumerVerticle.setRecordDispatcher(recordDispatcher);
         consumerVerticle.setConsumer(consumer);
-        consumerVerticle.setCloser(() -> Metrics.close(vertx, metricsCloser));
+        consumerVerticle.setCloser(AsyncCloseable.wrapAutoCloseable(metricsCloser));
       })
         .mapEmpty();
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpSinkResponseHandler.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpSinkResponseHandler.java
@@ -15,6 +15,7 @@
  */
 package dev.knative.eventing.kafka.broker.dispatcher.http;
 
+import dev.knative.eventing.kafka.broker.core.AsyncCloseable;
 import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
 import dev.knative.eventing.kafka.broker.core.tracing.TracingSpan;
 import dev.knative.eventing.kafka.broker.dispatcher.SinkResponseHandler;
@@ -111,10 +112,10 @@ public final class HttpSinkResponseHandler implements SinkResponseHandler {
   }
 
   @Override
-  public Future<?> close() {
+  public Future<Void> close() {
     return CompositeFuture.all(
       this.producer.close(),
-      Metrics.close(vertx, producerMeterBinder)
-    );
+      AsyncCloseable.wrapAutoCloseable(producerMeterBinder).close()
+    ).mapEmpty();
   }
 }

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerRecordSenderMock.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerRecordSenderMock.java
@@ -25,14 +25,19 @@ import java.util.function.Supplier;
 
 public class ConsumerRecordSenderMock implements ConsumerRecordSender {
 
-  private final Supplier<Future<?>> onClose;
+  private final Supplier<Future<Void>> onClose;
   private final Function<KafkaConsumerRecord<String, CloudEvent>, Future<HttpResponse<Buffer>>> onSend;
 
   public ConsumerRecordSenderMock(
-    final Supplier<Future<?>> onClose,
     final Function<KafkaConsumerRecord<String, CloudEvent>, Future<HttpResponse<Buffer>>> onSend) {
-    this.onClose = onClose;
+    this(onSend, null);
+  }
+
+  public ConsumerRecordSenderMock(
+    final Function<KafkaConsumerRecord<String, CloudEvent>, Future<HttpResponse<Buffer>>> onSend,
+    final Supplier<Future<Void>> onClose) {
     this.onSend = onSend;
+    this.onClose = onClose != null ? onClose : Future::succeededFuture;
   }
 
   @Override
@@ -41,7 +46,7 @@ public class ConsumerRecordSenderMock implements ConsumerRecordSender {
   }
 
   @Override
-  public Future<?> close() {
+  public Future<Void> close() {
     return this.onClose.get();
   }
 }

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/RecordDispatcherTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/RecordDispatcherTest.java
@@ -51,10 +51,10 @@ public class RecordDispatcherTest {
       value -> false,
       ConsumerRecordSender.noop("subscriber send called"),
       ConsumerRecordSender.noop("DLS send called"),
-      new SinkResponseHandlerMock(
-        Future::succeededFuture,
-        response -> Future.succeededFuture()
-      ), receiver, null);
+      new SinkResponseHandlerMock(),
+      receiver,
+      null
+    );
 
     final var record = record();
     dispatcherHandler.handle(record);
@@ -74,22 +74,21 @@ public class RecordDispatcherTest {
 
     final var dispatcherHandler = new RecordDispatcher(
       value -> true, new ConsumerRecordSenderMock(
-      Future::succeededFuture,
       record -> {
         sendCalled.set(true);
         return Future.succeededFuture();
       }
     ),
       new ConsumerRecordSenderMock(
-        Future::succeededFuture,
         record -> {
           fail("DLS send called");
           return Future.succeededFuture();
         }
-      ), new SinkResponseHandlerMock(
-      Future::succeededFuture,
-      response -> Future.succeededFuture()
-    ), receiver, null);
+      ),
+      new SinkResponseHandlerMock(),
+      receiver,
+      null
+    );
     final var record = record();
     dispatcherHandler.handle(record);
 
@@ -110,22 +109,20 @@ public class RecordDispatcherTest {
 
     final var dispatcherHandler = new RecordDispatcher(
       value -> true, new ConsumerRecordSenderMock(
-      Future::succeededFuture,
       record -> {
         subscriberSenderSendCalled.set(true);
         return Future.failedFuture("");
       }
     ),
       new ConsumerRecordSenderMock(
-        Future::succeededFuture,
         record -> {
           dlsSenderSendCalled.set(true);
           return Future.succeededFuture();
         }
-      ), new SinkResponseHandlerMock(
-      Future::succeededFuture,
-      response -> Future.succeededFuture()
-    ), receiver, null);
+      ), new SinkResponseHandlerMock(),
+      receiver,
+      null
+    );
     final var record = record();
     dispatcherHandler.handle(record);
 
@@ -147,22 +144,21 @@ public class RecordDispatcherTest {
 
     final var dispatcherHandler = new RecordDispatcher(
       value -> true, new ConsumerRecordSenderMock(
-      Future::succeededFuture,
       record -> {
         subscriberSenderSendCalled.set(true);
         return Future.failedFuture("");
       }
     ),
       new ConsumerRecordSenderMock(
-        Future::succeededFuture,
         record -> {
           dlsSenderSendCalled.set(true);
           return Future.failedFuture("");
         }
-      ), new SinkResponseHandlerMock(
-      Future::succeededFuture,
-      response -> Future.succeededFuture()
-    ), receiver, null);
+      ),
+      new SinkResponseHandlerMock(),
+      receiver,
+      null
+    );
     final var record = record();
     dispatcherHandler.handle(record);
 
@@ -183,18 +179,16 @@ public class RecordDispatcherTest {
     final var dispatcherHandler = new RecordDispatcher(
       value -> true,
       new ConsumerRecordSenderMock(
-        Future::succeededFuture,
         record -> {
           subscriberSenderSendCalled.set(true);
           return Future.failedFuture("");
         }
       ),
       ConsumerRecordSender.noop("No DLS configured"),
-      new SinkResponseHandlerMock(
-        Future::succeededFuture,
-        response -> Future.succeededFuture()
-      ),
-      receiver, null);
+      new SinkResponseHandlerMock(),
+      receiver,
+      null
+    );
     final var record = record();
     dispatcherHandler.handle(record);
 

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/SinkResponseHandlerMock.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/SinkResponseHandlerMock.java
@@ -23,13 +23,21 @@ import java.util.function.Supplier;
 
 public class SinkResponseHandlerMock implements SinkResponseHandler {
 
-  private final Supplier<Future<?>> onClose;
+  private final Supplier<Future<Void>> onClose;
   private final Function<HttpResponse<Buffer>, Future<Void>> onSend;
 
-  public SinkResponseHandlerMock(final Supplier<Future<?>> onClose,
-                                 final Function<HttpResponse<Buffer>, Future<Void>> onSend) {
-    this.onClose = onClose;
-    this.onSend = onSend;
+  public SinkResponseHandlerMock(final Function<HttpResponse<Buffer>, Future<Void>> onSend,
+                                 final Supplier<Future<Void>> onClose) {
+    this.onSend = onSend != null ? onSend : r -> Future.succeededFuture();
+    this.onClose = onClose != null ? onClose : Future::succeededFuture;
+  }
+
+  public SinkResponseHandlerMock(final Function<HttpResponse<Buffer>, Future<Void>> onSend) {
+    this(onSend, null);
+  }
+
+  public SinkResponseHandlerMock() {
+    this(null, null);
   }
 
   @Override
@@ -38,7 +46,7 @@ public class SinkResponseHandlerMock implements SinkResponseHandler {
   }
 
   @Override
-  public Future<?> close() {
+  public Future<Void> close() {
     return this.onClose.get();
   }
 }

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/AbstractConsumerVerticleTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/AbstractConsumerVerticleTest.java
@@ -59,10 +59,7 @@ public abstract class AbstractConsumerVerticleTest {
       value -> false,
       ConsumerRecordSender.noop("subscriber send called"),
       ConsumerRecordSender.noop("dead letter sink send called"),
-      new SinkResponseHandlerMock(
-        Future::succeededFuture,
-        response -> Future.succeededFuture()
-      ),
+      new SinkResponseHandlerMock(),
       RecordDispatcherTest.offsetManagerMock(),
       null
     );
@@ -98,10 +95,7 @@ public abstract class AbstractConsumerVerticleTest {
       value -> false,
       ConsumerRecordSender.noop("subscriber send called"),
       ConsumerRecordSender.noop("dead letter sink send called"),
-      new SinkResponseHandlerMock(
-        Future::succeededFuture,
-        response -> Future.succeededFuture()
-      ),
+      new SinkResponseHandlerMock(),
       RecordDispatcherTest.offsetManagerMock(),
       null
     );
@@ -174,25 +168,22 @@ public abstract class AbstractConsumerVerticleTest {
     final var recordDispatcher = new RecordDispatcher(
       ce -> true,
       new ConsumerRecordSenderMock(
-        () -> {
+        record -> Future.succeededFuture(), () -> {
           consumerRecordSenderClosed.set(true);
           return Future.succeededFuture();
-        },
-        record -> Future.succeededFuture()
+        }
       ),
       new ConsumerRecordSenderMock(
-        () -> {
+        record -> Future.succeededFuture(), () -> {
           dlsSenderClosed.set(true);
           return Future.succeededFuture();
-        },
-        record -> Future.succeededFuture()
+        }
       ),
       new SinkResponseHandlerMock(
-        () -> {
+        response -> Future.succeededFuture(), () -> {
           sinkClosed.set(true);
           return Future.succeededFuture();
-        },
-        response -> Future.succeededFuture()
+        }
       ),
       RecordDispatcherTest.offsetManagerMock(),
       null

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpSinkResponseHandlerTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpSinkResponseHandlerTest.java
@@ -189,11 +189,13 @@ public class HttpSinkResponseHandlerTest {
       producer
     );
 
-    sinkResponseHandler.close()
-      .onFailure(context::failNow)
-      .onSuccess(r -> context.verify(() -> {
-        verify(producer, times(1)).close();
-        context.completeNow();
-      }));
+    vertx.runOnContext(v -> {
+      sinkResponseHandler.close()
+        .onFailure(context::failNow)
+        .onSuccess(r -> context.verify(() -> {
+          verify(producer, times(1)).close();
+          context.completeNow();
+        }));
+    });
   }
 }


### PR DESCRIPTION
While working on improving the dispatcher code base, I've found out we have several code snippets, all around the `close` problem. This PR is an attempt to solidify, abstract and share code for "closing" components

The `AsyncCloseable` is like the vert.x `Closeable`, but more than accepting a promise, it returns a `Future` instead. It implements vert.x `Closeable` and can be converted to a blocking `java.util.AutoCloseable`.

It has static methods to compose multiple `AsyncCloseable` and to wrap `AutoCloseable`, for better integration with our blocking components.

## Proposed Changes

- :gift: Introduce `AsyncCloseable` interface
- :broom: Cleanup all various usages of close routines and replace them with `AsyncCloseable`
