### PR TITLE
Adding annotation to drive the name of the backing topic

### DIFF
--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -43,9 +43,10 @@ import (
 )
 
 const (
-	BrokerUUID      = "e7185016-5d98-4b54-84e8-3b1cd4acc6b4"
-	BrokerNamespace = "test-namespace"
-	BrokerName      = "test-broker"
+	BrokerUUID        = "e7185016-5d98-4b54-84e8-3b1cd4acc6b4"
+	BrokerNamespace   = "test-namespace"
+	BrokerName        = "test-broker"
+	ExternalTopicName = "test-topic"
 
 	TriggerName      = "test-trigger"
 	TriggerNamespace = "test-namespace"
@@ -132,6 +133,17 @@ func WithBrokerConfig(reference *duckv1.KReference) func(*eventing.Broker) {
 	}
 }
 
+func WithExternalTopic(topic string) func(*eventing.Broker) {
+	return func(broker *eventing.Broker) {
+		annotations := broker.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string, 1)
+		}
+		annotations[ExternalTopicAnnotation] = topic
+		broker.SetAnnotations(annotations)
+	}
+}
+
 type CMOption func(cm *corev1.ConfigMap)
 
 func BrokerConfig(bootstrapServers string, numPartitions, replicationFactor int, options ...CMOption) *corev1.ConfigMap {
@@ -189,6 +201,12 @@ func StatusBrokerTopicReady(broker *eventing.Broker) {
 	StatusTopicReadyWithName(kafka.BrokerTopic(TopicPrefix, broker))(broker)
 }
 
+func StatusExternalBrokerTopicReady(topic string) func(broker *eventing.Broker) {
+	return func(broker *eventing.Broker) {
+		StatusTopicReadyWithName(topic)(broker)
+	}
+}
+
 func StatusBrokerDataPlaneAvailable(broker *eventing.Broker) {
 	StatusDataPlaneAvailable(broker)
 }
@@ -244,9 +262,13 @@ func BrokerDLSResolved(uri string) func(broker *eventing.Broker) {
 }
 
 func StatusBrokerFailedToCreateTopic(broker *eventing.Broker) {
-
 	StatusFailedToCreateTopic(BrokerTopic())(broker)
+}
 
+func StatusExternalBrokerTopicNotPresentOrInvalid(topicname string) func(broker *eventing.Broker) {
+	return func(broker *eventing.Broker) {
+		StatusTopicNotPresentOrInvalid(topicname)(broker)
+	}
 }
 
 func BrokerDispatcherPod(namespace string, annotations map[string]string) runtime.Object {

--- a/control-plane/pkg/reconciler/testing/objects_common.go
+++ b/control-plane/pkg/reconciler/testing/objects_common.go
@@ -374,6 +374,7 @@ func StatusFailedToCreateTopic(topicName string) func(obj duckv1.KRShaped) {
 		)
 	}
 }
+
 func StatusTopicNotPresentOrInvalid(topicName string) func(obj duckv1.KRShaped) {
 	return func(obj duckv1.KRShaped) {
 		obj.GetConditionSet().Manage(obj.GetStatus()).MarkFalse(

--- a/control-plane/pkg/reconciler/testing/objects_common.go
+++ b/control-plane/pkg/reconciler/testing/objects_common.go
@@ -374,6 +374,15 @@ func StatusFailedToCreateTopic(topicName string) func(obj duckv1.KRShaped) {
 		)
 	}
 }
+func StatusTopicNotPresentOrInvalid(topicName string) func(obj duckv1.KRShaped) {
+	return func(obj duckv1.KRShaped) {
+		obj.GetConditionSet().Manage(obj.GetStatus()).MarkFalse(
+			base.ConditionTopicReady,
+			base.ReasonTopicNotPresentOrInvalid,
+			fmt.Sprintf("topics %v: invalid topic %s", []string{topicName}, topicName),
+		)
+	}
+}
 
 func StatusInitialOffsetsCommitted(obj duckv1.KRShaped) {
 	obj.GetConditionSet().Manage(obj.GetStatus()).MarkTrue(base.ConditionInitialOffsetsCommitted)


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #977 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- adding support for `kafka.eventing.knative.dev/external.topic` annotation for external topic usage

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
With the `kafka.eventing.knative.dev/external.topic` annotation it is possible to use an externally managed Apache Kafka topic for the broker usage
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
