### PR TITLE
Replaced ConsumerRecordSender.create with ConsumerRecordSender.noop

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerRecordSender.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerRecordSender.java
@@ -39,26 +39,21 @@ public interface ConsumerRecordSender {
   Future<?> close();
 
   /**
-   * Create a ConsumerRecordSender from the given futures.
+   * Create a noop {@link ConsumerRecordSender} that fails every send with the specified message.
    *
-   * @param closeFuture Future to return on close.
-   * @param sendFuture  Future to return on send.
-   * @return A ConsumerRecordSender that returns a failed future on send.
+   * @param failureMessage future failure message when invoking send.
+   * @return A ConsumerRecordSender that always fails the send invocations with the specified message and always succeeds the close invocations.
    */
-  static ConsumerRecordSender create(Future<HttpResponse<Buffer>> sendFuture, Future<?> closeFuture) {
+  static ConsumerRecordSender noop(String failureMessage) {
     return new ConsumerRecordSender() {
-
-      private final Future<HttpResponse<Buffer>> send = sendFuture;
-      private final Future<?> close = closeFuture;
-
       @Override
       public Future<HttpResponse<Buffer>> send(KafkaConsumerRecord<String, CloudEvent> record) {
-        return this.send;
+        return Future.failedFuture(failureMessage);
       }
 
       @Override
       public Future<?> close() {
-        return this.close;
+        return Future.succeededFuture();
       }
     };
   }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerVerticleFactory.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/http/HttpConsumerVerticleFactory.java
@@ -71,7 +71,7 @@ public class HttpConsumerVerticleFactory implements ConsumerVerticleFactory {
   private static final Logger logger = LoggerFactory.getLogger(HttpConsumerVerticleFactory.class);
 
   private final static ConsumerRecordSender NO_DEAD_LETTER_SINK_SENDER =
-    ConsumerRecordSender.create(Future.failedFuture("No dead letter sink set"), Future.succeededFuture());
+    ConsumerRecordSender.noop("No dead letter sink set");
 
   private final Map<String, Object> consumerConfigs;
   private final WebClientOptions webClientOptions;

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/RecordDispatcherTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/RecordDispatcherTest.java
@@ -49,8 +49,8 @@ public class RecordDispatcherTest {
 
     final var dispatcherHandler = new RecordDispatcher(
       value -> false,
-      ConsumerRecordSender.create(Future.failedFuture("subscriber send called"), Future.succeededFuture()),
-      ConsumerRecordSender.create(Future.failedFuture("DLS send called"), Future.succeededFuture()),
+      ConsumerRecordSender.noop("subscriber send called"),
+      ConsumerRecordSender.noop("DLS send called"),
       new SinkResponseHandlerMock(
         Future::succeededFuture,
         response -> Future.succeededFuture()
@@ -189,7 +189,7 @@ public class RecordDispatcherTest {
           return Future.failedFuture("");
         }
       ),
-      ConsumerRecordSender.create(Future.failedFuture("No DLS configured"), Future.succeededFuture()),
+      ConsumerRecordSender.noop("No DLS configured"),
       new SinkResponseHandlerMock(
         Future::succeededFuture,
         response -> Future.succeededFuture()

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/AbstractConsumerVerticleTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/consumer/impl/AbstractConsumerVerticleTest.java
@@ -57,8 +57,8 @@ public abstract class AbstractConsumerVerticleTest {
     final var consumer = new MockConsumer<String, CloudEvent>(OffsetResetStrategy.LATEST);
     final var recordDispatcher = new RecordDispatcher(
       value -> false,
-      ConsumerRecordSender.create(Future.failedFuture("subscriber send called"), Future.succeededFuture()),
-      ConsumerRecordSender.create(Future.failedFuture("dead letter sink send called"), Future.succeededFuture()),
+      ConsumerRecordSender.noop("subscriber send called"),
+      ConsumerRecordSender.noop("dead letter sink send called"),
       new SinkResponseHandlerMock(
         Future::succeededFuture,
         response -> Future.succeededFuture()
@@ -96,8 +96,8 @@ public abstract class AbstractConsumerVerticleTest {
     final var consumer = new MockConsumer<String, CloudEvent>(OffsetResetStrategy.LATEST);
     final var recordDispatcher = new RecordDispatcher(
       value -> false,
-      ConsumerRecordSender.create(Future.failedFuture("subscriber send called"), Future.succeededFuture()),
-      ConsumerRecordSender.create(Future.failedFuture("dead letter sink send called"), Future.succeededFuture()),
+      ConsumerRecordSender.noop("subscriber send called"),
+      ConsumerRecordSender.noop("dead letter sink send called"),
       new SinkResponseHandlerMock(
         Future::succeededFuture,
         response -> Future.succeededFuture()


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

This removes the "mockish" `ConsumerRecordSender.create` and replaces it with `ConsumerRecordSender.noop`. The reason is that the method `ConsumerRecordSender.create` is not really useful in the production code, but instead for mocking. Instead, I've introduced `ConsumerRecordSender.noop` which is more specialized and serves our purpose.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :broom: Replaced `ConsumerRecordSender.create` with `ConsumerRecordSender.noop`