### PR TITLE
Streamline the usage of the ResourcesReconciler

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/ResourcesReconciler.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/ResourcesReconciler.java
@@ -16,6 +16,7 @@
 package dev.knative.eventing.kafka.broker.core.reconciler;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
+import dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerBuilder;
 import io.vertx.core.Future;
 import java.util.Collection;
 
@@ -23,5 +24,9 @@ import java.util.Collection;
 public interface ResourcesReconciler {
 
   Future<Void> reconcile(Collection<DataPlaneContract.Resource> resources);
+
+  static ResourcesReconcilerBuilder builder() {
+    return new ResourcesReconcilerBuilder();
+  }
 
 }

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerBuilder.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.core.reconciler.impl;
 
 import dev.knative.eventing.kafka.broker.core.reconciler.EgressReconcilerListener;

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerBuilder.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerBuilder.java
@@ -1,0 +1,45 @@
+package dev.knative.eventing.kafka.broker.core.reconciler.impl;
+
+import dev.knative.eventing.kafka.broker.core.reconciler.EgressReconcilerListener;
+import dev.knative.eventing.kafka.broker.core.reconciler.IngressReconcilerListener;
+import dev.knative.eventing.kafka.broker.core.reconciler.ResourcesReconciler;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.MessageConsumer;
+import java.util.Objects;
+
+public class ResourcesReconcilerBuilder {
+
+  private IngressReconcilerListener ingressReconcilerListener;
+  private EgressReconcilerListener egressReconcilerListener;
+
+  public ResourcesReconcilerBuilder watchIngress(
+    IngressReconcilerListener ingressReconcilerListener) {
+    Objects.requireNonNull(ingressReconcilerListener);
+    this.ingressReconcilerListener = ingressReconcilerListener;
+    return this;
+  }
+
+  public ResourcesReconcilerBuilder watchEgress(
+    EgressReconcilerListener egressReconcilerListener) {
+    Objects.requireNonNull(egressReconcilerListener);
+    this.egressReconcilerListener = egressReconcilerListener;
+    return this;
+  }
+
+  /**
+   * Build the {@link ResourcesReconciler} and start listening for new contracts using {@link ResourcesReconcilerMessageHandler}.
+   *
+   * @param vertx the vertx object to register the event bus listener
+   * @return the built message consumer
+   */
+  public MessageConsumer<Object> buildAndListen(Vertx vertx) {
+    return ResourcesReconcilerMessageHandler.start(vertx, build());
+  }
+
+  /**
+   * @return the built {@link ResourcesReconciler}
+   */
+  public ResourcesReconciler build() {
+    return new ResourcesReconcilerImpl(ingressReconcilerListener, egressReconcilerListener);
+  }
+}

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerImpl.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerImpl.java
@@ -50,7 +50,7 @@ public class ResourcesReconcilerImpl implements ResourcesReconciler {
   // egress uid -> <Egress, Resource>
   private final Map<String, Map.Entry<DataPlaneContract.Egress, DataPlaneContract.Resource>> cachedEgresses;
 
-  private ResourcesReconcilerImpl(
+  ResourcesReconcilerImpl(
     IngressReconcilerListener ingressReconcilerListener,
     EgressReconcilerListener egressReconcilerListener) {
     if (ingressReconcilerListener == null && egressReconcilerListener == null) {
@@ -244,33 +244,6 @@ public class ResourcesReconcilerImpl implements ResourcesReconciler {
       && Objects.equals(e1.getReplyToOriginalTopic(), e2.getReplyToOriginalTopic())
       && Objects.equals(e1.getEgressConfig(), e2.getEgressConfig())
       && Objects.equals(e1.getFilter(), e2.getFilter());
-  }
-
-  public static Builder builder() {
-    return new Builder();
-  }
-
-  public static class Builder {
-    private IngressReconcilerListener ingressReconcilerListener;
-    private EgressReconcilerListener egressReconcilerListener;
-
-    public Builder watchIngress(
-      IngressReconcilerListener ingressReconcilerListener) {
-      Objects.requireNonNull(ingressReconcilerListener);
-      this.ingressReconcilerListener = ingressReconcilerListener;
-      return this;
-    }
-
-    public Builder watchEgress(
-      EgressReconcilerListener egressReconcilerListener) {
-      Objects.requireNonNull(egressReconcilerListener);
-      this.egressReconcilerListener = egressReconcilerListener;
-      return this;
-    }
-
-    public ResourcesReconcilerImpl build() {
-      return new ResourcesReconcilerImpl(ingressReconcilerListener, egressReconcilerListener);
-    }
   }
 
   private static void logFailure(final String msg, final DataPlaneContract.Egress egress, final Throwable cause) {

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourceReconcilerTestRunner.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourceReconcilerTestRunner.java
@@ -16,8 +16,8 @@
 package dev.knative.eventing.kafka.broker.core.reconciler.impl;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
+import dev.knative.eventing.kafka.broker.core.reconciler.ResourcesReconciler;
 import io.vertx.core.Future;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -127,7 +127,7 @@ public class ResourceReconcilerTestRunner {
     final var ingressListener = this.ingressReconcilerListener;
     final var egressListener = this.egressReconcilerListener;
 
-    final var reconcilerBuilder = ResourcesReconcilerImpl
+    final var reconcilerBuilder = ResourcesReconciler
       .builder();
 
     if (ingressListener != null) {

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerImplTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerImplTest.java
@@ -15,14 +15,13 @@
  */
 package dev.knative.eventing.kafka.broker.core.reconciler.impl;
 
+import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
+import dev.knative.eventing.kafka.broker.core.reconciler.ResourcesReconciler;
 import io.vertx.core.Future;
-import org.junit.jupiter.api.Test;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-
-import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
+import org.junit.jupiter.api.Test;
 
 import static dev.knative.eventing.kafka.broker.contract.DataPlaneContract.Egress;
 import static dev.knative.eventing.kafka.broker.contract.DataPlaneContract.Filter;
@@ -33,7 +32,7 @@ class ResourcesReconcilerImplTest {
 
   @Test
   void nullPointerExceptionWhenNoListenerIsProvided() {
-    assertThatThrownBy(() -> ResourcesReconcilerImpl.builder().build())
+    assertThatThrownBy(() -> ResourcesReconciler.builder().build())
       .isInstanceOf(NullPointerException.class);
   }
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerDeployerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerDeployerVerticle.java
@@ -17,8 +17,7 @@ package dev.knative.eventing.kafka.broker.dispatcher;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import dev.knative.eventing.kafka.broker.core.reconciler.EgressReconcilerListener;
-import dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerImpl;
-import dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler;
+import dev.knative.eventing.kafka.broker.core.reconciler.ResourcesReconciler;
 import dev.knative.eventing.kafka.broker.dispatcher.consumer.ConsumerVerticleFactory;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
@@ -33,11 +32,7 @@ import org.slf4j.LoggerFactory;
 import static dev.knative.eventing.kafka.broker.core.utils.Logging.keyValue;
 
 /**
- * ResourcesManager manages Resource and Egress objects by instantiating and starting verticles based on resources
- * configurations.
- *
- * <p>Note: {@link ConsumerDeployerVerticle} is not thread-safe and it's not supposed to be shared between
- * threads.
+ * This verticle listens on Egress reconciliations by deploying/undeploying new consumer verticles.
  */
 public final class ConsumerDeployerVerticle extends AbstractVerticle implements EgressReconcilerListener {
 
@@ -67,13 +62,10 @@ public final class ConsumerDeployerVerticle extends AbstractVerticle implements 
 
   @Override
   public void start() {
-    this.messageConsumer = ResourcesReconcilerMessageHandler.start(
-      vertx,
-      ResourcesReconcilerImpl
-        .builder()
-        .watchEgress(this)
-        .build()
-    );
+    this.messageConsumer = ResourcesReconciler
+      .builder()
+      .watchEgress(this)
+      .buildAndListen(vertx);
   }
 
   @Override

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerDeployerVerticleTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/ConsumerDeployerVerticleTest.java
@@ -15,18 +15,8 @@
  */
 package dev.knative.eventing.kafka.broker.dispatcher;
 
-import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.egress1;
-import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.egress2;
-import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.egress3;
-import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.egress4;
-import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.egress5;
-import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.egress6;
-import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.resource1;
-import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.resource2;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
-import dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerImpl;
+import dev.knative.eventing.kafka.broker.core.reconciler.ResourcesReconciler;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
@@ -41,6 +31,16 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.egress1;
+import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.egress2;
+import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.egress3;
+import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.egress4;
+import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.egress5;
+import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.egress6;
+import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.resource1;
+import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.resource2;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(VertxExtension.class)
 @Execution(ExecutionMode.CONCURRENT)
@@ -70,7 +70,7 @@ public class ConsumerDeployerVerticleTest {
       .toCompletableFuture()
       .get();
 
-    final var reconciler = ResourcesReconcilerImpl
+    final var reconciler = ResourcesReconciler
       .builder()
       .watchEgress(consumerDeployer)
       .build();
@@ -107,7 +107,7 @@ public class ConsumerDeployerVerticleTest {
       .toCompletableFuture()
       .get();
 
-    final var reconciler = ResourcesReconcilerImpl
+    final var reconciler = ResourcesReconciler
       .builder()
       .watchEgress(consumerDeployer)
       .build();
@@ -156,7 +156,7 @@ public class ConsumerDeployerVerticleTest {
       .toCompletableFuture()
       .get();
 
-    final var reconciler = ResourcesReconcilerImpl
+    final var reconciler = ResourcesReconciler
       .builder()
       .watchEgress(consumerDeployer)
       .build();
@@ -226,7 +226,7 @@ public class ConsumerDeployerVerticleTest {
       .toCompletableFuture()
       .get();
 
-    final var reconciler = ResourcesReconcilerImpl
+    final var reconciler = ResourcesReconciler
       .builder()
       .watchEgress(consumerDeployer)
       .build();
@@ -307,7 +307,7 @@ public class ConsumerDeployerVerticleTest {
       .toCompletableFuture()
       .get();
 
-    final var reconciler = ResourcesReconcilerImpl
+    final var reconciler = ResourcesReconciler
       .builder()
       .watchEgress(consumerDeployer)
       .build();
@@ -380,7 +380,7 @@ public class ConsumerDeployerVerticleTest {
       .toCompletableFuture()
       .get();
 
-    final var reconciler = ResourcesReconcilerImpl
+    final var reconciler = ResourcesReconciler
       .builder()
       .watchEgress(consumerDeployer)
       .build();

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/ReceiverVerticle.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/ReceiverVerticle.java
@@ -15,8 +15,7 @@
  */
 package dev.knative.eventing.kafka.broker.receiver;
 
-import dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerImpl;
-import dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler;
+import dev.knative.eventing.kafka.broker.core.reconciler.ResourcesReconciler;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Handler;
@@ -26,7 +25,6 @@ import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
-
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -63,13 +61,10 @@ public class ReceiverVerticle extends AbstractVerticle {
   public void start(final Promise<Void> startPromise) {
     final var requestMapper = this.requestHandlerFactory.apply(vertx);
 
-    this.messageConsumer = ResourcesReconcilerMessageHandler.start(
-      vertx,
-      ResourcesReconcilerImpl
-        .builder()
-        .watchIngress(requestMapper)
-        .build()
-    );
+    this.messageConsumer = ResourcesReconciler
+      .builder()
+      .watchIngress(requestMapper)
+      .buildAndListen(vertx);
     this.server = vertx.createHttpServer(httpServerOptions);
 
     Handler<HttpServerRequest> requestHandler = requestMapper;

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/RequestMapperTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/RequestMapperTest.java
@@ -15,20 +15,10 @@
  */
 package dev.knative.eventing.kafka.broker.receiver;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
-import static org.assertj.core.api.InstanceOfAssertFactories.map;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract.Resource;
 import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
-import dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerImpl;
+import dev.knative.eventing.kafka.broker.core.reconciler.ResourcesReconciler;
 import dev.knative.eventing.kafka.broker.core.testing.CoreObjects;
 import io.cloudevents.CloudEvent;
 import io.micrometer.core.instrument.Counter;
@@ -56,6 +46,16 @@ import java.util.function.BiConsumer;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.InstanceOfAssertFactories.map;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
 public class RequestMapperTest {
@@ -114,7 +114,8 @@ public class RequestMapperTest {
       mock(Counter.class),
       mock(Counter.class)
     );
-    final var reconciler = ResourcesReconcilerImpl.builder()
+    final var reconciler = ResourcesReconciler
+      .builder()
       .watchIngress(handler)
       .build();
 
@@ -157,7 +158,8 @@ public class RequestMapperTest {
       mock(Counter.class),
       mock(Counter.class)
     );
-    final var reconciler = ResourcesReconcilerImpl.builder()
+    final var reconciler = ResourcesReconciler
+      .builder()
       .watchIngress(handler)
       .build();
 
@@ -428,7 +430,8 @@ public class RequestMapperTest {
       mock(Counter.class),
       mock(Counter.class)
     );
-    final var reconciler = ResourcesReconcilerImpl.builder()
+    final var reconciler = ResourcesReconciler
+      .builder()
       .watchIngress(handler)
       .build();
 


### PR DESCRIPTION
## Proposed Changes

- :broom: Moved inner class `ResourcesReconcilerImpl.Builder` to `ResourcesReconcilerBuilder`
- :broom: Moved `ResourcesReconcilerImpl.builder()` to `ResourcesReconciler.builder()`
- :gift: Now `ResourcesReconcilerBuilder` provides a `buildAndListen` method which builds directly the `ResourcesReconcilerMessageHandler` as well