### PR TITLE
Moved receiver Main to a dedicated package

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/BaseEnv.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/BaseEnv.java
@@ -22,27 +22,27 @@ import static java.util.Objects.requireNonNull;
 public class BaseEnv {
 
   public static final String PRODUCER_CONFIG_FILE_PATH = "PRODUCER_CONFIG_FILE_PATH";
-  public static final String DATA_PLANE_CONFIG_FILE_PATH = "DATA_PLANE_CONFIG_FILE_PATH";
-
-  public static final String METRICS_PORT = "METRICS_PORT";
-  public static final String METRICS_PATH = "METRICS_PATH";
-  public static final String METRICS_PUBLISH_QUANTILES = "METRICS_PUBLISH_QUANTILES";
-  public static final String METRICS_JVM_ENABLED = "METRICS_JVM_ENABLED";
-
-  public static final String CONFIG_TRACING_PATH = "CONFIG_TRACING_PATH";
-
-  public static final String WAIT_STARTUP_SECONDS = "WAIT_STARTUP_SECONDS";
-
   private final String producerConfigFilePath;
+
+  public static final String DATA_PLANE_CONFIG_FILE_PATH = "DATA_PLANE_CONFIG_FILE_PATH";
   private final String dataPlaneConfigFilePath;
 
+  public static final String METRICS_PORT = "METRICS_PORT";
   private final int metricsPort;
+
+  public static final String METRICS_PATH = "METRICS_PATH";
   private final String metricsPath;
+
+  public static final String METRICS_PUBLISH_QUANTILES = "METRICS_PUBLISH_QUANTILES";
   private final boolean metricsPublishQuantiles;
+
+  public static final String METRICS_JVM_ENABLED = "METRICS_JVM_ENABLED";
   private final boolean metricsJvmEnabled;
 
+  public static final String CONFIG_TRACING_PATH = "CONFIG_TRACING_PATH";
   private final String configTracingPath;
 
+  public static final String WAIT_STARTUP_SECONDS = "WAIT_STARTUP_SECONDS";
   private final int waitStartupSeconds;
 
   public BaseEnv(Function<String, String> envProvider) {

--- a/data-plane/receiver/pom.xml
+++ b/data-plane/receiver/pom.xml
@@ -125,7 +125,7 @@
                 <transformer
                   implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>
-                    dev.knative.eventing.kafka.broker.receiver.Main
+                      dev.knative.eventing.kafka.broker.receiver.main.Main
                   </mainClass>
                 </transformer>
               </transformers>

--- a/data-plane/receiver/pom.xml
+++ b/data-plane/receiver/pom.xml
@@ -124,9 +124,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <transformer
                   implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>
-                      dev.knative.eventing.kafka.broker.receiver.main.Main
-                  </mainClass>
+                  <mainClass>dev.knative.eventing.kafka.broker.receiver.main.Main</mainClass>
                 </transformer>
               </transformers>
               <filters>

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.knative.eventing.kafka.broker.receiver;
+package dev.knative.eventing.kafka.broker.receiver.main;
 
 import dev.knative.eventing.kafka.broker.core.eventbus.ContractMessageCodec;
 import dev.knative.eventing.kafka.broker.core.eventbus.ContractPublisher;
@@ -33,12 +33,6 @@ import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.tracing.opentelemetry.OpenTelemetryOptions;
-import net.logstash.logback.encoder.LogstashEncoder;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.StringSerializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.ClosedWatchServiceException;
@@ -47,6 +41,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
+import net.logstash.logback.encoder.LogstashEncoder;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static dev.knative.eventing.kafka.broker.core.utils.Logging.keyValue;
 

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverEnv.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverEnv.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.knative.eventing.kafka.broker.receiver;
-
-import static java.util.Objects.requireNonNull;
+package dev.knative.eventing.kafka.broker.receiver.main;
 
 import dev.knative.eventing.kafka.broker.core.utils.BaseEnv;
 import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
 
 class ReceiverEnv extends BaseEnv {
 

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-package dev.knative.eventing.kafka.broker.receiver;
+package dev.knative.eventing.kafka.broker.receiver.main;
 
 import dev.knative.eventing.kafka.broker.core.security.AuthProvider;
+import dev.knative.eventing.kafka.broker.receiver.CloudEventRequestToRecordMapper;
+import dev.knative.eventing.kafka.broker.receiver.ReceiverVerticle;
+import dev.knative.eventing.kafka.broker.receiver.RequestMapper;
+import dev.knative.eventing.kafka.broker.receiver.SimpleProbeHandlerDecorator;
 import io.micrometer.core.instrument.Counter;
 import io.vertx.core.Verticle;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.kafka.client.producer.KafkaProducer;
-
 import java.util.Properties;
 import java.util.function.Supplier;
 

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverEnvTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverEnvTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.knative.eventing.kafka.broker.receiver;
+package dev.knative.eventing.kafka.broker.receiver.main;
 
 import dev.knative.eventing.kafka.broker.core.utils.BaseEnv;
 import org.junit.jupiter.api.Test;

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactoryTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactoryTest.java
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package dev.knative.eventing.kafka.broker.receiver;
+package dev.knative.eventing.kafka.broker.receiver.main;
 
 import io.micrometer.core.instrument.Counter;
 import io.vertx.core.http.HttpServerOptions;
-import org.junit.jupiter.api.Test;
-
 import java.util.Properties;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
## Proposed Changes

- :broom: Moved receiver `Main`, together with the env class and the receiver factory class in a dedicated package, called `dev.knative.eventing.kafka.broker.receiver.main`
- :broom: Reorganized fields declaration in `BaseEnv` to match the style used in `ReceiverEnv`

In a followup I'll apply the same change to the dispatcher Main