### PR TITLE
Reorganize CloudEventRequestToRecordMapper

### DIFF
--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/RequestToRecordMapper.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/RequestToRecordMapper.java
@@ -30,7 +30,7 @@ public interface RequestToRecordMapper {
    * @param topic   topic to send the event
    * @return kafka record (record can be null).
    */
-  Future<KafkaProducerRecord<String, CloudEvent>> recordFromRequest(
+  Future<KafkaProducerRecord<String, CloudEvent>> requestToRecord(
     final HttpServerRequest request,
     final String topic
   );

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
@@ -57,7 +57,7 @@ class ReceiverVerticleFactory implements Supplier<Verticle> {
         v,
         AuthProvider.kubernetes(),
         producerConfigs,
-        new CloudEventRequestToRecordMapper(),
+        StrictRequestToRecordMapper.getInstance(),
         properties -> KafkaProducer.create(v, properties),
         badRequestCounter,
         produceEventsCounter

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
@@ -17,10 +17,10 @@
 package dev.knative.eventing.kafka.broker.receiver.main;
 
 import dev.knative.eventing.kafka.broker.core.security.AuthProvider;
-import dev.knative.eventing.kafka.broker.receiver.CloudEventRequestToRecordMapper;
 import dev.knative.eventing.kafka.broker.receiver.ReceiverVerticle;
 import dev.knative.eventing.kafka.broker.receiver.RequestMapper;
 import dev.knative.eventing.kafka.broker.receiver.SimpleProbeHandlerDecorator;
+import dev.knative.eventing.kafka.broker.receiver.StrictRequestToRecordMapper;
 import io.micrometer.core.instrument.Counter;
 import io.vertx.core.Verticle;
 import io.vertx.core.http.HttpServerOptions;

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/ReceiverTracingVerticleTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/ReceiverTracingVerticleTest.java
@@ -103,7 +103,7 @@ public class ReceiverTracingVerticleTest {
       vertx,
       null,
       new Properties(),
-      new CloudEventRequestToRecordMapper(),
+      StrictRequestToRecordMapper.getInstance(),
       properties -> KafkaProducer.create(vertx, mockProducer),
       new CumulativeCounter(mock(Id.class)),
       new CumulativeCounter(mock(Id.class))

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/ReceiverVerticleTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/ReceiverVerticleTest.java
@@ -97,7 +97,7 @@ public class ReceiverVerticleTest {
       vertx,
       null,
       new Properties(),
-      new CloudEventRequestToRecordMapper(),
+      StrictRequestToRecordMapper.getInstance(),
       properties -> producer,
       badRequestCount,
       produceRequestCount

--- a/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/DataPlaneTest.java
+++ b/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/DataPlaneTest.java
@@ -23,9 +23,9 @@ import dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcile
 import dev.knative.eventing.kafka.broker.core.security.AuthProvider;
 import dev.knative.eventing.kafka.broker.dispatcher.ConsumerDeployerVerticle;
 import dev.knative.eventing.kafka.broker.dispatcher.http.HttpConsumerVerticleFactory;
-import dev.knative.eventing.kafka.broker.receiver.CloudEventRequestToRecordMapper;
 import dev.knative.eventing.kafka.broker.receiver.ReceiverVerticle;
 import dev.knative.eventing.kafka.broker.receiver.RequestMapper;
+import dev.knative.eventing.kafka.broker.receiver.StrictRequestToRecordMapper;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.message.MessageReader;
 import io.cloudevents.core.v1.CloudEventV1;
@@ -336,7 +336,7 @@ public class DataPlaneTest {
       v,
       null,
       producerConfigs(),
-      new CloudEventRequestToRecordMapper(),
+      StrictRequestToRecordMapper.getInstance(),
       properties -> KafkaProducer.create(v, properties),
       mock(Counter.class),
       mock(Counter.class)


### PR DESCRIPTION
## Proposed Changes

- :broom: Renamed `CloudEventRequestToRecordMapper` to `StrictRequestToRecordMapper`. The reason is that, by the types, it's clearly mapping `CloudEvent`s and because `Strict` specifies that the conversion fails if the input request is not a cloudevent
- :broom: Now the `StrictRequestToRecordMapper` is a singleton
- :broom: Removed tracing logic in `StrictRequestToRecordMapper` and moved it to `RequestMapper`, where I think it belongs