### PR TITLE
Glue the new DeliverySpec.Timeout

### DIFF
--- a/control-plane/pkg/core/config/utils.go
+++ b/control-plane/pkg/core/config/utils.go
@@ -114,7 +114,7 @@ func BackoffPolicyFromString(backoffPolicy *duck.BackoffPolicyType) contract.Bac
 	}
 }
 
-// DurationMillisFromISO8601String returns the BackoffDelay from the given string.
+// DurationMillisFromISO8601String returns the duration in milliseconds from the given string.
 //
 // Default value is the specified defaultDelay.
 func DurationMillisFromISO8601String(durationStr *string, defaultDurationMillis uint64) (uint64, error) {

--- a/control-plane/pkg/core/config/utils.go
+++ b/control-plane/pkg/core/config/utils.go
@@ -55,7 +55,7 @@ func EgressConfigFromDelivery(
 	defaultBackoffDelayMs uint64,
 ) (*contract.EgressConfig, error) {
 
-	if delivery == nil || (delivery.DeadLetterSink == nil && delivery.Retry == nil) {
+	if delivery == nil || (delivery.DeadLetterSink == nil && delivery.Retry == nil && delivery.Timeout == nil) {
 		return nil, nil
 	}
 

--- a/control-plane/pkg/reconciler/trigger/trigger_test.go
+++ b/control-plane/pkg/reconciler/trigger/trigger_test.go
@@ -322,6 +322,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 										Retry:         3,
 										BackoffPolicy: contract.BackoffPolicy_Exponential,
 										BackoffDelay:  uint64(time.Second.Milliseconds()),
+										Timeout:       uint64((time.Second * 2).Milliseconds()),
 									},
 								},
 							},
@@ -1408,6 +1409,7 @@ func withDelivery(trigger *eventing.Trigger) {
 		Retry:          pointer.Int32Ptr(3),
 		BackoffPolicy:  &exponential,
 		BackoffDelay:   pointer.StringPtr("PT1S"),
+		Timeout:        pointer.StringPtr("PT2S"),
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #757, followup of #1021, part of https://github.com/knative/eventing/issues/5148

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :gift: Support the new `DeliverySpec.Timeout` field

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Now you can specify both in Broker and Trigger delivery specs the new timeout field, as part of the experimental feature delivery-timeout. For more details: https://knative.dev/docs/eventing/experimental-features/ 
```
