### PR TITLE
Encapsulate runtime hook registration inside Shutdown

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/Shutdown.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/Shutdown.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Shutdown {
+public final class Shutdown {
 
   private static final Logger logger = LoggerFactory.getLogger(Shutdown.class);
 

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/utils/ShutdownTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/utils/ShutdownTest.java
@@ -15,19 +15,16 @@
  */
 package dev.knative.eventing.kafka.broker.core.utils;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import java.io.Closeable;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class ShutdownTest {
 
@@ -36,31 +33,24 @@ public class ShutdownTest {
     final var vertx = mockVertxClose();
     final var closeable = mock(Closeable.class);
 
-    Shutdown.run(vertx, closeable).run();
+    Shutdown.createRunnable(vertx, closeable).run();
 
-    verify(vertx, times(1)).close(any());
+    verify(vertx, times(1)).close();
     verify(closeable).close();
   }
 
   @Test
-  public void closeSync() {
+  public void closeVertxSync() {
     final var vertx = mockVertxClose();
 
-    Shutdown.closeSync(vertx).run();
+    Shutdown.closeVertxSync(vertx);
 
-    verify(vertx).close(any());
+    verify(vertx).close();
   }
 
   private Vertx mockVertxClose() {
     final var vertx = mock(Vertx.class);
-
-    doAnswer(invocation -> {
-      final Handler<AsyncResult<Void>> callback = invocation.getArgument(0);
-      callback.handle(Future.succeededFuture());
-      return null;
-    })
-      .when(vertx).close(any());
-
+    doReturn(Future.succeededFuture()).when(vertx).close();
     return vertx;
   }
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
@@ -147,8 +147,7 @@ public class Main {
       final var fw = new FileWatcher(fs, publisher, new File(env.getDataPlaneConfigFilePath()));
 
       // Gracefully clean up resources.
-      Runtime.getRuntime()
-        .addShutdownHook(new Thread(Shutdown.run(vertx, fw, publisher, openTelemetry.getSdkTracerProvider())));
+      Shutdown.registerHook(vertx, publisher, fw, openTelemetry.getSdkTracerProvider());
 
       fw.watch(); // block forever
 
@@ -157,7 +156,7 @@ public class Main {
     } catch (final Exception ex) {
       logger.error("Failed during filesystem watch", ex);
 
-      Shutdown.closeSync(vertx).run();
+      Shutdown.closeVertxSync(vertx);
       System.exit(1);
     }
   }

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
@@ -141,8 +141,7 @@ public class Main {
       var fw = new FileWatcher(fs, publisher, new File(env.getDataPlaneConfigFilePath()));
 
       // Gracefully clean up resources.
-      Runtime.getRuntime()
-        .addShutdownHook(new Thread(Shutdown.run(vertx, fw, publisher, openTelemetry.getSdkTracerProvider())));
+      Shutdown.registerHook(vertx, publisher, fw, openTelemetry.getSdkTracerProvider());
 
       fw.watch(); // block forever
 
@@ -151,7 +150,7 @@ public class Main {
     } catch (final Exception ex) {
       logger.error("Failed during filesystem watch", ex);
 
-      Shutdown.closeSync(vertx).run();
+      Shutdown.closeVertxSync(vertx);
       System.exit(1);
     }
   }


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- `Shutdown` does not expose a method that returns a `Runnable` anymore, but instead it exposes a method that automatically register the hook inside the `Runtime`
- Added private constructor to `Shutdown` and now the class is `final`
- Renamed `closeSync` to `closeVertxSync`