### PR TITLE
Renamed getProperties to readPropertiesSync

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/Configurations.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/Configurations.java
@@ -32,7 +32,7 @@ public class Configurations {
   /**
    * Retrieve a properties file. Note: this method is blocking
    */
-  public static Properties getProperties(final String path) {
+  public static Properties readPropertiesSync(final String path) {
     if (path == null) {
       return new Properties();
     }
@@ -50,8 +50,8 @@ public class Configurations {
   /**
    * Retrieve a properties file and translates it to json. Note: this method is blocking
    */
-  public static JsonObject getPropertiesAsJson(final String path) {
-    final var props = getProperties(path);
+  public static JsonObject readPropertiesAsJsonSync(final String path) {
+    final var props = readPropertiesSync(path);
 
     final JsonObject json = new JsonObject();
     props.stringPropertyNames().forEach(name -> json.put(name, convert(props.getProperty(name))));

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/Configurations.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/Configurations.java
@@ -30,7 +30,9 @@ public class Configurations {
   private static final Logger logger = LoggerFactory.getLogger(Configurations.class);
 
   /**
-   * Retrieve a properties file. Note: this method is blocking
+   * Retrieve a properties file.
+   * <p>
+   * Note: this method is blocking, thus it shouldn't be called on the event loop.
    */
   public static Properties readPropertiesSync(final String path) {
     if (path == null) {
@@ -48,7 +50,9 @@ public class Configurations {
   }
 
   /**
-   * Retrieve a properties file and translates it to json. Note: this method is blocking
+   * Retrieve a properties file and translates it to json.
+   * <p>
+   * Note: this method is blocking, thus it shouldn't be called on the event loop.
    */
   public static JsonObject readPropertiesAsJsonSync(final String path) {
     final var props = readPropertiesSync(path);

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/utils/ConfigurationsTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/utils/ConfigurationsTest.java
@@ -29,7 +29,7 @@ public class ConfigurationsTest {
   @Test
   public void shouldGetPropertiesFromFilePath() {
 
-    final var config = Configurations.getProperties(Objects.requireNonNull(
+    final var config = Configurations.readPropertiesSync(Objects.requireNonNull(
       getClass().getClassLoader().getResource(FILE_NAME)
     ).getFile());
 
@@ -43,7 +43,7 @@ public class ConfigurationsTest {
   @Test
   public void shouldGetPropertiesFromFilePathAsJsonObject() {
 
-    final var config = Configurations.getPropertiesAsJson(Objects.requireNonNull(
+    final var config = Configurations.readPropertiesAsJsonSync(Objects.requireNonNull(
       getClass().getClassLoader().getResource(FILE_NAME)
     ).getFile());
 
@@ -57,7 +57,7 @@ public class ConfigurationsTest {
   @Test
   public void shouldSetHttpServerOptions() {
 
-    final var config = Configurations.getPropertiesAsJson(Objects.requireNonNull(
+    final var config = Configurations.readPropertiesAsJsonSync(Objects.requireNonNull(
       getClass().getClassLoader().getResource(FILE_NAME)
     ).getFile());
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
@@ -98,12 +98,12 @@ public class Main {
       final var metricsRegistry = Metrics.getRegistry();
       final var eventsSentCounter = metricsRegistry.counter(HTTP_EVENTS_SENT_COUNT);
 
-      final var producerConfig = Configurations.getProperties(env.getProducerConfigFilePath());
+      final var producerConfig = Configurations.readPropertiesSync(env.getProducerConfigFilePath());
       producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, CloudEventSerializer.class.getName());
       producerConfig.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, PartitionKeyExtensionInterceptor.class.getName());
-      final var consumerConfig = Configurations.getProperties(env.getConsumerConfigFilePath());
+      final var consumerConfig = Configurations.readPropertiesSync(env.getConsumerConfigFilePath());
       consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, CloudEventDeserializer.class.getName());
-      final var webClientConfig = Configurations.getPropertiesAsJson(env.getWebClientConfigFilePath());
+      final var webClientConfig = Configurations.readPropertiesAsJsonSync(env.getWebClientConfigFilePath());
 
       logger.info("Configurations {} {} {}",
         keyValue("producerConfig", producerConfig),

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
@@ -87,7 +87,7 @@ public class Main {
     // Instantiating an Encoder here we force it to include the class.
     new LogstashEncoder().getFieldNames();
 
-    final var producerConfigs = Configurations.getProperties(env.getProducerConfigFilePath());
+    final var producerConfigs = Configurations.readPropertiesSync(env.getProducerConfigFilePath());
 
     logger.info("Starting Receiver {}", keyValue("env", env));
 
@@ -111,7 +111,7 @@ public class Main {
       producerConfigs.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, PartitionKeyExtensionInterceptor.class.getName());
 
       final var httpServerOptions = new HttpServerOptions(
-        Configurations.getPropertiesAsJson(env.getHttpServerConfigFilePath())
+        Configurations.readPropertiesAsJsonSync(env.getHttpServerConfigFilePath())
       );
       httpServerOptions.setPort(env.getIngressPort());
       httpServerOptions.setTracingPolicy(TracingPolicy.PROPAGATE);


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Renamed both `getProperties` and `getPropertiesAsJson` to `read[]Sync` in order to underline that the method is performing a file read and that the method is blocking, thus it shouldn't be called on the event loop