### PR TITLE
Removed logstash main hack

### DIFF
--- a/data-plane/dispatcher/pom.xml
+++ b/data-plane/dispatcher/pom.xml
@@ -145,6 +145,12 @@
                   <artifact>*:*</artifact>
                   <excludeDefaults>false</excludeDefaults>
                 </filter>
+                <filter>
+                  <artifact>net.logstash.logback:logstash-logback-encoder</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
               </filters>
             </configuration>
           </execution>

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
@@ -38,7 +38,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import net.logstash.logback.encoder.LogstashEncoder;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.slf4j.Logger;
@@ -59,14 +58,6 @@ public class Main {
     DispatcherEnv env = new DispatcherEnv(System::getenv);
 
     OpenTelemetrySdk openTelemetry = TracingConfig.fromDir(env.getConfigTracingPath()).setup();
-
-    // HACK HACK HACK
-    // maven-shade-plugin doesn't include the LogstashEncoder class, neither by specifying the
-    // dependency with scope `provided` nor `runtime`, and adding include rules to
-    // maven-shade-plugin.
-    // Instantiating an Encoder here we force it to include the class.
-    // TODO this requires some fix in our maven-shade-plugin usage
-    new LogstashEncoder().getFieldNames();
 
     // Read consumer and producer kafka config
     Properties producerConfig = Configurations.readPropertiesSync(env.getProducerConfigFilePath());

--- a/data-plane/receiver/pom.xml
+++ b/data-plane/receiver/pom.xml
@@ -132,6 +132,12 @@
                   <artifact>*:*</artifact>
                   <excludeDefaults>false</excludeDefaults>
                 </filter>
+                <filter>
+                  <artifact>net.logstash.logback:logstash-logback-encoder</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
               </filters>
             </configuration>
           </execution>

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import net.logstash.logback.encoder.LogstashEncoder;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.slf4j.Logger;
@@ -59,13 +58,6 @@ public class Main {
     ReceiverEnv env = new ReceiverEnv(System::getenv);
 
     OpenTelemetrySdk openTelemetry = TracingConfig.fromDir(env.getConfigTracingPath()).setup();
-
-    // HACK HACK HACK
-    // maven-shade-plugin doesn't include the LogstashEncoder class, neither by specifying the
-    // dependency with scope `provided` nor `runtime`, and adding include rules to
-    // maven-shade-plugin.
-    // Instantiating an Encoder here we force it to include the class.
-    new LogstashEncoder().getFieldNames();
 
     // Read producer properties and override some defaults
     Properties producerConfigs = Configurations.readPropertiesSync(env.getProducerConfigFilePath());


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #1070

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :broom: Removed logstash encoder class packaging hack, now maven-shade-plugin will load by default the whole package inside the uber jar