### PR TITLE
[WIP] Support tracing B3 headers

### DIFF
--- a/data-plane/core/pom.xml
+++ b/data-plane/core/pom.xml
@@ -83,6 +83,10 @@
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-exporter-logging</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-extension-trace-propagators</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.vertx</groupId>

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/tracing/TracingConfigTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/tracing/TracingConfigTest.java
@@ -19,6 +19,7 @@ import dev.knative.eventing.kafka.broker.core.tracing.TracingConfig.Backend;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
@@ -39,12 +40,15 @@ public class TracingConfigTest {
     write(dir, "/backend", " zipkin ");
     write(dir, "/sample-rate", " 0.1 ");
     write(dir, "/zipkin-endpoint", "  http://localhost:9241/v2/api/spans/     ");
+    write(dir, "/trace-propagation-format", "w3c, b3");
 
     final var config = TracingConfig.fromDir(dir.toAbsolutePath().toString());
 
     assertThat(config.getBackend()).isEqualTo(Backend.ZIPKIN);
     assertThat(config.getSamplingRate()).isEqualTo(0.1F);
     assertThat(config.getUrl()).isEqualTo("http://localhost:9241/v2/api/spans/");
+    assertThat(config.getTracePropagationFormat())
+      .containsExactlyInAnyOrder(TracingConfig.TracePropagationFormat.W3C, TracingConfig.TracePropagationFormat.B3);
   }
 
   @Test
@@ -55,6 +59,7 @@ public class TracingConfigTest {
     write(dir, "/backend", " 1234 ");
     write(dir, "/sample-rate", " 0.1 ");
     write(dir, "/zipkin-endpoint", "  http://localhost:9241/v2/api/spans/     ");
+    write(dir, "/trace-propagation-format", "w3c, b3");
 
     final var config = TracingConfig.fromDir(dir.toAbsolutePath().toString());
 
@@ -105,7 +110,8 @@ public class TracingConfigTest {
 
   @Test
   public void setupShouldNotFailWhenBackendIsUnknown() {
-    assertThatNoException().isThrownBy(() -> new TracingConfig(Backend.UNKNOWN, null, 0F).setup());
+    assertThatNoException()
+      .isThrownBy(() -> new TracingConfig(Backend.UNKNOWN, null, 0F, Collections.emptyList()).setup());
   }
 
   private static void write(final Path root, final String name, final String s) throws IOException {


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #725

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :gift: Support configuration of tracing context injectors.
- :gift: Support context extraction both from b3 and w3c headers

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:gift: Support context extraction both from w3c and b3 headers transparently
:gift: Support configuration of tracing context injectors. Now you can specify in the config-tracing ConfigMap whether you want to emit tracing headers in w3c format, b3 format or both 
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

Perhaps we need that?
