### PR TITLE
Resolve response already sent with a chain of handlers

### DIFF
--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/MethodNotAllowedHandler.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/MethodNotAllowedHandler.java
@@ -33,12 +33,10 @@ public class MethodNotAllowedHandler implements Handler<HttpServerRequest> {
 
   private static final Logger logger = LoggerFactory.getLogger(MethodNotAllowedHandler.class);
 
-  private static class SingletonContainer {
-    private static final MethodNotAllowedHandler INSTANCE = new MethodNotAllowedHandler();
-  }
+  private final Handler<HttpServerRequest> next;
 
-  public static MethodNotAllowedHandler getInstance() {
-    return MethodNotAllowedHandler.SingletonContainer.INSTANCE;
+  public MethodNotAllowedHandler(final Handler<HttpServerRequest> next) {
+    this.next = next;
   }
 
   @Override
@@ -49,6 +47,8 @@ public class MethodNotAllowedHandler implements Handler<HttpServerRequest> {
       logger.warn("Only POST method is allowed. Method not allowed: {}",
         keyValue("method", request.method())
       );
+      return;
     }
+    this.next.handle(request);
   }
 }

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/ProbeHandler.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/ProbeHandler.java
@@ -20,6 +20,8 @@ import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 
+import java.util.Objects;
+
 /**
  * This class is an handler that respond to specified liveness and readiness probes.
  * <p>
@@ -31,26 +33,32 @@ public class ProbeHandler implements Handler<HttpServerRequest> {
 
   private final String livenessPath;
   private final String readinessPath;
+  private final Handler<HttpServerRequest> next;
 
   /**
    * All args constructor for creating a new instance of this class.
    *
    * @param livenessPath  request path at which respond to liveness checks.
    * @param readinessPath request path at which respond to readiness checks.
+   * @param next          next handler
    */
-  public ProbeHandler(
-    final String livenessPath,
-    final String readinessPath
-  ) {
+  public ProbeHandler(final String livenessPath,
+                      final String readinessPath,
+                      final Handler<HttpServerRequest> next) {
+    Objects.requireNonNull(next);
+
     this.livenessPath = livenessPath;
     this.readinessPath = readinessPath;
+    this.next = next;
   }
 
   @Override
   public void handle(final HttpServerRequest request) {
     if (isProbeRequest(request)) {
       request.response().setStatusCode(STATUS_OK).end();
+      return;
     }
+    this.next.handle(request);
   }
 
   private boolean isProbeRequest(final HttpServerRequest request) {

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverEnv.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverEnv.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
 
-class ReceiverEnv extends BaseEnv {
+public class ReceiverEnv extends BaseEnv {
 
   public static final String INGRESS_PORT = "INGRESS_PORT";
   private final int ingressPort;
@@ -34,7 +34,7 @@ class ReceiverEnv extends BaseEnv {
   public static final String HTTPSERVER_CONFIG_FILE_PATH = "HTTPSERVER_CONFIG_FILE_PATH";
   private final String httpServerConfigFilePath;
 
-  ReceiverEnv(final Function<String, String> envProvider) {
+  public ReceiverEnv(final Function<String, String> envProvider) {
     super(envProvider);
 
     this.ingressPort = Integer.parseInt(envProvider.apply(INGRESS_PORT));

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/MethodNotAllowedHandlerTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/MethodNotAllowedHandlerTest.java
@@ -22,6 +22,7 @@ import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
+import static org.mockito.Mockito.mock;
 
 public class MethodNotAllowedHandlerTest extends PreHandlerTest {
 
@@ -36,7 +37,8 @@ public class MethodNotAllowedHandlerTest extends PreHandlerTest {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public Handler<HttpServerRequest> createHandler() {
-    return MethodNotAllowedHandler.getInstance();
+    return new MethodNotAllowedHandler(mock(Handler.class));
   }
 }

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/ProbeHandlerTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/ProbeHandlerTest.java
@@ -22,6 +22,8 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
 
+import static org.mockito.Mockito.mock;
+
 public class ProbeHandlerTest extends PreHandlerTest {
 
   private static final String LIVENESS_PATH = "/healthz";
@@ -49,7 +51,8 @@ public class ProbeHandlerTest extends PreHandlerTest {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public Handler<HttpServerRequest> createHandler() {
-    return new ProbeHandler(LIVENESS_PATH, READINESS_PATH);
+    return new ProbeHandler(LIVENESS_PATH, READINESS_PATH, mock(Handler.class));
   }
 }

--- a/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/DataPlaneTest.java
+++ b/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/DataPlaneTest.java
@@ -27,6 +27,7 @@ import dev.knative.eventing.kafka.broker.receiver.impl.IngressProducerReconcilab
 import dev.knative.eventing.kafka.broker.receiver.impl.ReceiverVerticle;
 import dev.knative.eventing.kafka.broker.receiver.impl.StrictRequestToRecordMapper;
 import dev.knative.eventing.kafka.broker.receiver.impl.handler.IngressRequestHandlerImpl;
+import dev.knative.eventing.kafka.broker.receiver.main.ReceiverEnv;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.message.MessageReader;
 import io.cloudevents.core.v1.CloudEventV1;
@@ -70,6 +71,7 @@ import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
 public class DataPlaneTest {
@@ -336,14 +338,18 @@ public class DataPlaneTest {
     final var httpServerOptions = new HttpServerOptions();
     httpServerOptions.setPort(INGRESS_PORT);
 
+    final var env = mock(ReceiverEnv.class);
+    when(env.getLivenessProbePath()).thenReturn("/healthz");
+    when(env.getReadinessProbePath()).thenReturn("/readyz");
+
     final var verticle = new ReceiverVerticle(
+      env,
       httpServerOptions,
       v -> new IngressProducerReconcilableStore(
         null,
         producerConfigs(),
         properties -> KafkaProducer.create(v, properties)
       ),
-      Collections.emptyList(),
       new IngressRequestHandlerImpl(
         StrictRequestToRecordMapper.getInstance(),
         mock(Counter.class),


### PR DESCRIPTION
Fixes #1101 

In our receiver verticle, we want to compose handlers
using the chain of responsibility pattern. 
For example, our probe handler handles the request only when it is
a kubelet request for readiness or liveness.

Now, we are checking in our main handler if  `response.isEnded()`
to understand if a previous handler has handled the request.
This leads to the error linked in the linked issue and it's not 
a robust design (as discussed in https://github.com/knative-sandbox/eventing-kafka-broker/pull/1041#discussion_r658261607).

## Proposed Changes

- Resolve response already sent with a chain of handlers

/kind bug