### PR TITLE
Enable Channel controller

### DIFF
--- a/control-plane/cmd/kafka-controller/main.go
+++ b/control-plane/cmd/kafka-controller/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"log"
 
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/channel"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection/sharedmain"
@@ -41,6 +42,11 @@ func main() {
 		log.Fatal("cannot process environment variables with prefix BROKER", err)
 	}
 
+	channelEnv, err := config.GetEnvConfig("CHANNEL")
+	if err != nil {
+		log.Fatal("cannot process environment variables with prefix CHANNEL", err)
+	}
+
 	sinkEnv, err := config.GetEnvConfig("SINK")
 	if err != nil {
 		log.Fatal("cannot process environment variables with prefix SINK", err)
@@ -57,6 +63,10 @@ func main() {
 		// Trigger controller
 		func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
 			return trigger.NewController(ctx, watcher, brokerEnv)
+		},
+
+		func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
+			return channel.NewController(ctx, watcher, &channel.Configs{Env: *channelEnv})
 		},
 
 		// KafkaSink controller

--- a/data-plane/config/channel/100-config-kafka-channel-data-plane.yaml
+++ b/data-plane/config/channel/100-config-kafka-channel-data-plane.yaml
@@ -1,0 +1,120 @@
+---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-kafka-channel-data-plane
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
+data:
+  config-kafka-channel-producer.properties: |
+    key.serializer=org.apache.kafka.common.serialization.StringSerializer
+    value.serializer=io.cloudevents.kafka.CloudEventSerializer
+    acks=all
+    buffer.memory=33554432
+    # compression.type=snappy
+    retries=2147483647
+    batch.size=16384
+    client.dns.lookup=use_all_dns_ips
+    connections.max.idle.ms=600000
+    delivery.timeout.ms=120000
+    linger.ms=0
+    max.block.ms=60000
+    max.request.size=1048576
+    partitioner.class=org.apache.kafka.clients.producer.internals.DefaultPartitioner
+    receive.buffer.bytes=-1
+    request.timeout.ms=30000
+    enable.idempotence=false
+    max.in.flight.requests.per.connection=5
+    metadata.max.age.ms=300000
+    # metric.reporters=""
+    metrics.num.samples=2
+    metrics.recording.level=INFO
+    metrics.sample.window.ms=30000
+    reconnect.backoff.max.ms=1000
+    reconnect.backoff.ms=50
+    retry.backoff.ms=100
+    # transaction.timeout.ms=60000
+    # transactional.id=null
+  config-kafka-channel-consumer.properties: |
+    key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+    value.deserializer=io.cloudevents.kafka.CloudEventDeserializer
+    fetch.min.bytes=1
+    heartbeat.interval.ms=3000
+    max.partition.fetch.bytes=1048576
+    session.timeout.ms=10000
+    # ssl.key.password=
+    # ssl.keystore.location=
+    # ssl.keystore.password=
+    # ssl.truststore.location=
+    # ssl.truststore.password=
+    allow.auto.create.topics=true
+    auto.offset.reset=earliest
+    client.dns.lookup=use_all_dns_ips
+    connections.max.idle.ms=540000
+    default.api.timeout.ms=60000
+    enable.auto.commit=false
+    exclude.internal.topics=true
+    fetch.max.bytes=52428800
+    isolation.level=read_uncommitted
+    max.poll.interval.ms=300000
+    max.poll.records=500
+    # partition.assignment.strategy=org.apache.kafka.clients.consumer.CooperativeStickyAssignor
+    receive.buffer.bytes=65536
+    request.timeout.ms=30000
+    # sasl.client.callback.handler.class=
+    # sasl.jaas.config=
+    # sasl.kerberos.service.name=
+    # sasl.login.callback.handler.class
+    # sasl.login.class
+    # sasl.mechanism
+    security.protocol=PLAINTEXT
+    send.buffer.bytes=131072
+    # ssl.enabled.protocols=
+    # ssl.keystore.type=
+    # ssl.protocol=
+    # ssl.provider=
+    auto.commit.interval.ms=5000
+    check.crcs=true
+    # client.rack=
+    fetch.max.wait.ms=500
+    # interceptor.classes=
+    metadata.max.age.ms=600000
+    # metrics.reporters=
+    # metrics.num.samples=
+    # metrics.recording.level=INFO
+    # metrics.sample.window.ms=
+    reconnect.backoff.max.ms=1000
+    retry.backoff.ms=100
+    # sasl.kerberos.kinit.cmd=
+    # sasl.kerberos.min.time.before.relogin=
+    # sasl.kerberos.ticket.renew.jitter=
+    # sasl.login.refresh.buffer.seconds=
+    # sasl.login.refresh.min.period.seconds=
+    # sasl.login.refresh.window.factor
+    # sasl.login.refresh.window.jitter
+    # security.providers
+    # ssl.cipher.suites
+    # ssl.endpoint.identification.algorithm
+    # ssl.keymanager.algorithm
+    # ssl.secure.random.implementation
+    # ssl.trustmanager.algorithm
+  config-kafka-channel-webclient.properties: |
+    idleTimeout=10000
+  config-kafka-channel-httpserver.properties: |
+    idleTimeout=0

--- a/data-plane/config/channel/200-data-plane-cluster-role.yaml
+++ b/data-plane/config/channel/200-data-plane-cluster-role.yaml
@@ -1,0 +1,29 @@
+---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-kafka-data-plane
+  labels:
+    kafka.eventing.knative.dev/release: devel
+rules:
+  - apiGroups:
+      - "*"
+    resources:
+      - secrets
+    verbs:
+      - get

--- a/data-plane/config/channel/200-data-plane-service-account.yaml
+++ b/data-plane/config/channel/200-data-plane-service-account.yaml
@@ -1,0 +1,23 @@
+---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: knative-kafka-data-plane
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel

--- a/data-plane/config/channel/201-data-plane-cluster-role-binding.yaml
+++ b/data-plane/config/channel/201-data-plane-cluster-role-binding.yaml
@@ -1,0 +1,30 @@
+---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-kafka-data-plane
+  labels:
+    kafka.eventing.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: knative-kafka-data-plane
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: knative-kafka-data-plane
+  apiGroup: rbac.authorization.k8s.io

--- a/data-plane/config/channel/template/500-dispatcher.yaml
+++ b/data-plane/config/channel/template/500-dispatcher.yaml
@@ -1,0 +1,150 @@
+---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-channel-dispatcher
+  namespace: knative-eventing
+  labels:
+    app: kafka-channel-dispatcher
+    kafka.eventing.knative.dev/release: devel
+spec:
+  selector:
+    matchLabels:
+      app: kafka-channel-dispatcher
+  template:
+    metadata:
+      name: kafka-channel-dispatcher
+      labels:
+        app: kafka-channel-dispatcher
+        kafka.eventing.knative.dev/release: devel
+    spec:
+      serviceAccountName: knative-kafka-data-plane
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: kafka-channel-dispatcher
+          image: ${KNATIVE_KAFKA_CHANNEL_DISPATCHER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /etc/config
+              name: config-kafka-channel-data-plane
+              readOnly: true
+            - mountPath: /etc/channels-subscriptions
+              name: kafka-channel-channels-subscriptions
+              readOnly: true
+            - mountPath: /tmp
+              name: cache
+            - mountPath: /etc/logging
+              name: kafka-channel-config-logging
+              readOnly: true
+            - mountPath: /etc/tracing
+              name: config-tracing
+              readOnly: true
+          ports:
+            - containerPort: 9090
+              name: http-metrics
+              protocol: TCP
+          env:
+            - name: SERVICE_NAME
+              value: "kafka-channel-dispatcher"
+            - name: SERVICE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: PRODUCER_CONFIG_FILE_PATH
+              value: /etc/config/config-kafka-channel-producer.properties
+            - name: CONSUMER_CONFIG_FILE_PATH
+              value: /etc/config/config-kafka-channel-consumer.properties
+            - name: WEBCLIENT_CONFIG_FILE_PATH
+              value: /etc/config/config-kafka-channel-webclient.properties
+            - name: DATA_PLANE_CONFIG_FILE_PATH
+              value: /etc/channels-subscriptions/data
+            - name: EGRESSES_INITIAL_CAPACITY
+              value: "20"
+            - name: INSTANCE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: METRICS_PATH
+              value: /metrics
+            - name: METRICS_PORT
+              value: "9090"
+            - name: METRICS_PUBLISH_QUANTILES
+              value: "false"
+            - name: METRICS_JVM_ENABLED
+              value: "false"
+            - name: CONFIG_TRACING_PATH
+              value: "/etc/tracing"
+            # https://github.com/fabric8io/kubernetes-client/issues/2212
+            - name: HTTP2_DISABLE
+              value: "true"
+            # This should be set according to initial delay seconds
+            - name: WAIT_STARTUP_SECONDS
+              value: "8"
+          command:
+            - "java"
+          args:
+            - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-jar"
+            - "/app/app.jar"
+          # TODO set resources (limits and requests)
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              port: 9090
+              path: /metrics
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              port: 9090
+              path: /metrics
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 1
+          terminationMessagePolicy: FallbackToLogsOnError
+          terminationMessagePath: /dev/temination-log
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: config-kafka-channel-data-plane
+          configMap:
+            name: config-kafka-channel-data-plane
+        - name: kafka-channel-channels-subscriptions
+          configMap:
+            name: kafka-channel-channels-subscriptions
+        - name: cache
+          emptyDir: { }
+        - name: kafka-channel-config-logging
+          configMap:
+            name: kafka-config-logging
+        - name: config-tracing
+          configMap:
+            name: config-tracing
+      restartPolicy: Always
+      dnsConfig:
+        options:
+          - name: single-request-reopen

--- a/data-plane/config/channel/template/500-receiver.yaml
+++ b/data-plane/config/channel/template/500-receiver.yaml
@@ -1,0 +1,181 @@
+---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-channel-receiver
+  namespace: knative-eventing
+  labels:
+    app: kafka-channel-receiver
+    kafka.eventing.knative.dev/release: devel
+spec:
+  selector:
+    matchLabels:
+      app: kafka-channel-receiver
+  template:
+    metadata:
+      name: kafka-channel-receiver
+      labels:
+        app: kafka-channel-receiver
+        kafka.eventing.knative.dev/release: devel
+    spec:
+      serviceAccountName: knative-kafka-data-plane
+      securityContext:
+        runAsNonRoot: true
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: kafka-channel-receiver
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      containers:
+        - name: kafka-channel-receiver
+          image: ${KNATIVE_KAFKA_CHANNEL_RECEIVER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /etc/config
+              name: config-kafka-channel-data-plane
+              readOnly: true
+            - mountPath: /etc/channels-subscriptions
+              name: kafka-channel-channels-subscriptions
+              readOnly: true
+            - mountPath: /tmp
+              name: cache
+            - mountPath: /etc/logging
+              name: kafka-channel-config-logging
+              readOnly: true
+            - mountPath: /etc/tracing
+              name: config-tracing
+              readOnly: true
+          ports:
+            - containerPort: 9090
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            - name: SERVICE_NAME
+              value: "kafka-channel-receiver"
+            - name: SERVICE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: INGRESS_PORT
+              value: "8080"
+            - name: PRODUCER_CONFIG_FILE_PATH
+              value: /etc/config/config-kafka-channel-producer.properties
+            - name: HTTPSERVER_CONFIG_FILE_PATH
+              value: /etc/config/config-kafka-channel-httpserver.properties
+            - name: DATA_PLANE_CONFIG_FILE_PATH
+              value: /etc/channels-subscriptions/data
+            - name: LIVENESS_PROBE_PATH
+              value: /healthz
+            - name: READINESS_PROBE_PATH
+              value: /readyz
+            - name: METRICS_PATH
+              value: /metrics
+            - name: METRICS_PORT
+              value: "9090"
+            - name: METRICS_PUBLISH_QUANTILES
+              value: "false"
+            - name: METRICS_JVM_ENABLED
+              value: "false"
+            - name: CONFIG_TRACING_PATH
+              value: "/etc/tracing"
+            # https://github.com/fabric8io/kubernetes-client/issues/2212
+            - name: HTTP2_DISABLE
+              value: "true"
+            # This should be set according to initial delay seconds
+            - name: WAIT_STARTUP_SECONDS
+              value: "8"
+          command:
+            - "java"
+          args:
+            - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-jar"
+            - "/app/app.jar"
+          # TODO set resources (limits and requests)
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              port: 8080
+              path: /healthz
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              port: 8080
+              path: /readyz
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 1
+          terminationMessagePolicy: FallbackToLogsOnError
+          terminationMessagePath: /dev/temination-log
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: kafka-channel-channels-subscriptions
+          configMap:
+            name: kafka-channel-channels-subscriptions
+        - name: config-kafka-channel-data-plane
+          configMap:
+            name: config-kafka-channel-data-plane
+        - name: cache
+          emptyDir: { }
+        - name: kafka-channel-config-logging
+          configMap:
+            name: kafka-config-logging
+        - name: config-tracing
+          configMap:
+            name: config-tracing
+      restartPolicy: Always
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-channel-ingress
+  namespace: knative-eventing
+  labels:
+    app: kafka-channel-receiver
+    kafka.eventing.knative.dev/release: devel
+spec:
+  selector:
+    app: kafka-channel-receiver
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: http-metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+---

--- a/hack/control-plane.sh
+++ b/hack/control-plane.sh
@@ -19,13 +19,15 @@ source $(pwd)/hack/label.sh
 readonly CONTROL_PLANE_DIR=control-plane
 readonly CONTROL_PLANE_CONFIG_DIR=${CONTROL_PLANE_DIR}/config
 readonly KAFKA_SINK_CONFIG_DIR=${CONTROL_PLANE_CONFIG_DIR}/sink
+readonly KAFKA_CHANNEL_CONFIG_DIR=${CONTROL_PLANE_CONFIG_DIR}/channel
 
 readonly DATA_PLANE_LOGGING_CONFIG_DIR=data-plane/config
 
 # Note: do not change this function name, it's used during releases.
 function control_plane_setup() {
   ko resolve ${KO_FLAGS} -f "${CONTROL_PLANE_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" &&
-    ko resolve ${KO_FLAGS} -f "${KAFKA_SINK_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}"
+    ko resolve ${KO_FLAGS} -f "${KAFKA_SINK_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}"  &&
+    ko resolve ${KO_FLAGS} -f "${KAFKA_CHANNEL_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}"
 
   return $?
 }

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -30,6 +30,7 @@ readonly VENDOR_PKG_TEST_IMAGES="vendor/knative.dev/pkg/leaderelection/chaosduck
 export EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT="eventing-kafka-controller.yaml"
 export EVENTING_KAFKA_BROKER_ARTIFACT="eventing-kafka-broker.yaml"
 export EVENTING_KAFKA_SINK_ARTIFACT="eventing-kafka-sink.yaml"
+export EVENTING_KAFKA_CHANNEL_ARTIFACT="eventing-kafka-channel.yaml"
 
 # The number of control plane replicas to run.
 readonly REPLICAS=${REPLICAS:-1}
@@ -93,6 +94,7 @@ function build_components_from_source() {
   [ -f "${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" ] && rm "${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}"
   [ -f "${EVENTING_KAFKA_BROKER_ARTIFACT}" ] && rm "${EVENTING_KAFKA_BROKER_ARTIFACT}"
   [ -f "${EVENTING_KAFKA_SINK_ARTIFACT}" ] && rm "${EVENTING_KAFKA_SINK_ARTIFACT}"
+  [ -f "${EVENTING_KAFKA_CHANNEL_ARTIFACT}" ] && rm "${EVENTING_KAFKA_CHANNEL_ARTIFACT}"
 
   header "Data plane setup"
   data_plane_setup || fail_test "Failed to set up data plane components"
@@ -116,18 +118,24 @@ function test_setup() {
   kubectl apply -f "${EVENTING_KAFKA_SINK_ARTIFACT}" || fail_test "Failed to apply ${EVENTING_KAFKA_SINK_ARTIFACT}"
   wait_until_pods_running knative-eventing || fail_test "Sink data plane did not come up"
 
+  kubectl apply -f "${EVENTING_KAFKA_CHANNEL_ARTIFACT}" || fail_test "Failed to apply ${EVENTING_KAFKA_CHANNEL_ARTIFACT}"
+  wait_until_pods_running knative-eventing || fail_test "Channel data plane did not come up"
+
   # Apply test configurations, and restart data plane components (we don't have hot reload)
   ko apply -f ./test/config/ || fail_test "Failed to apply test configurations"
 
   kubectl rollout restart deployment -n knative-eventing kafka-broker-receiver
   kubectl rollout restart deployment -n knative-eventing kafka-broker-dispatcher
   kubectl rollout restart deployment -n knative-eventing kafka-sink-receiver
+  kubectl rollout restart deployment -n knative-eventing kafka-channel-receiver
+  kubectl rollout restart deployment -n knative-eventing kafka-channel-dispatcher
 }
 
 function test_teardown() {
   kubectl delete --ignore-not-found -f "${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" || fail_test "Failed to tear down control plane"
   kubectl delete --ignore-not-found -f "${EVENTING_KAFKA_BROKER_ARTIFACT}" || fail_test "Failed to tear down kafka broker"
   kubectl delete --ignore-not-found -f "${EVENTING_KAFKA_SINK_ARTIFACT}" || fail_test "Failed to tear down kafka sink"
+  kubectl delete --ignore-not-found -f "${EVENTING_KAFKA_CHANNEL_ARTIFACT}" || fail_test "Failed to tear down kafka channel"
 }
 
 function scale_controlplane() {
@@ -179,5 +187,6 @@ function save_release_artifacts() {
   # building the project from source.
   cp "${EVENTING_KAFKA_BROKER_ARTIFACT}" "${ARTIFACTS}/${EVENTING_KAFKA_BROKER_ARTIFACT}" || return $?
   cp "${EVENTING_KAFKA_SINK_ARTIFACT}" "${ARTIFACTS}/${EVENTING_KAFKA_SINK_ARTIFACT}" || return $?
+  cp "${EVENTING_KAFKA_CHANNEL_ARTIFACT}" "${ARTIFACTS}/${EVENTING_KAFKA_CHANNEL_ARTIFACT}" || return $?
   cp "${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" "${ARTIFACTS}/${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" || return $?
 }


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Enable Channel controller
- Ready status is not really done
- No subscriber reconciliation
- You can create a new KafkaChannel and delete it. Controller will handle it.

Testing instructions:
```bash
./hack/run.sh deploy-infra

k apply -f third_party/eventing-kafka-latest

cat <<EOS |kubectl apply -f -
---
apiVersion: v1
data:
  version: 1.0.0
  eventing-kafka: |
    kafka:
      authSecretName: kafka-cluster
      authSecretNamespace: knative-eventing
      brokers: my-cluster-kafka-bootstrap.kafka.svc:9092
kind: ConfigMap
metadata:
  name: config-kafka
  namespace: knative-eventing
EOS


./hack/run.sh deploy
```


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
