### PR TITLE
Add namespace to referenced addressable before resolving destination

### DIFF
--- a/control-plane/pkg/core/config/utils.go
+++ b/control-plane/pkg/core/config/utils.go
@@ -62,6 +62,10 @@ func EgressConfigFromDelivery(
 	egressConfig := &contract.EgressConfig{}
 
 	if delivery.DeadLetterSink != nil {
+		destination := *delivery.DeadLetterSink // Do not update object Spec, so copy destination.
+		if destination.Ref != nil && destination.Ref.Namespace == "" {
+			destination.Ref.Namespace = parent.GetNamespace()
+		}
 		deadLetterSinkURL, err := resolver.URIFromDestinationV1(ctx, *delivery.DeadLetterSink, parent)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve Spec.Delivery.DeadLetterSink: %w", err)

--- a/control-plane/pkg/reconciler/broker/broker_test.go
+++ b/control-plane/pkg/reconciler/broker/broker_test.go
@@ -218,6 +218,63 @@ func brokerReconciliation(t *testing.T, format string, configs Configs) {
 			},
 		},
 		{
+			Name: "Reconciled normal - with DLS - no DLS ref namespace",
+			Objects: []runtime.Object{
+				NewBroker(
+					WithDelivery(WithNoDeadLetterSinkNamespace),
+				),
+				NewConfigMapFromContract(&contract.Contract{
+					Generation: 1,
+				}, &configs),
+				NewService(WithServiceNamespace(BrokerNamespace)),
+				BrokerReceiverPod(configs.SystemNamespace, map[string]string{base.VolumeGenerationAnnotationKey: "3"}),
+				BrokerDispatcherPod(configs.SystemNamespace, map[string]string{base.VolumeGenerationAnnotationKey: "1"}),
+			},
+			Key: testKey,
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
+			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapUpdate(&configs, &contract.Contract{
+					Resources: []*contract.Resource{
+						{
+							Uid:              BrokerUUID,
+							Topics:           []string{BrokerTopic()},
+							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_BINARY, IngressType: &contract.Ingress_Path{Path: receiver.Path(BrokerNamespace, BrokerName)}},
+							BootstrapServers: bootstrapServers,
+							EgressConfig:     &contract.EgressConfig{DeadLetter: ServiceURLFrom(BrokerNamespace, ServiceName)},
+						},
+					},
+					Generation: 2,
+				}),
+				BrokerReceiverPodUpdate(configs.SystemNamespace, map[string]string{
+					base.VolumeGenerationAnnotationKey: "2",
+				}),
+				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+					base.VolumeGenerationAnnotationKey: "2",
+				}),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: NewBroker(
+						WithDelivery(WithNoDeadLetterSinkNamespace),
+						reconcilertesting.WithInitBrokerConditions,
+						BrokerConfigMapUpdatedReady(&configs),
+						BrokerDataPlaneAvailable,
+						BrokerTopicReady,
+						BrokerConfigParsed,
+						BrokerAddressable(&configs),
+					),
+				},
+			},
+			OtherTestData: map[string]interface{}{
+				BootstrapServersConfigMapKey: bootstrapServers,
+			},
+		},
+		{
 			Name: "Failed to create topic",
 			Objects: []runtime.Object{
 				NewBroker(),

--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -77,7 +77,7 @@ func NewDeletedBroker(options ...reconcilertesting.BrokerOption) runtime.Object 
 	)
 }
 
-func WithDelivery() func(*eventing.Broker) {
+func WithDelivery(mutations ...func(spec *eventingduck.DeliverySpec)) func(*eventing.Broker) {
 	service := NewService()
 
 	return func(broker *eventing.Broker) {
@@ -92,6 +92,15 @@ func WithDelivery() func(*eventing.Broker) {
 				APIVersion: service.APIVersion,
 			},
 		}
+		for _, mut := range mutations {
+			mut(broker.Spec.Delivery)
+		}
+	}
+}
+
+func WithNoDeadLetterSinkNamespace(spec *eventingduck.DeliverySpec) {
+	if spec.DeadLetterSink != nil && spec.DeadLetterSink.Ref != nil {
+		spec.DeadLetterSink.Ref.Namespace = ""
 	}
 }
 


### PR DESCRIPTION
The resolver uses `ref.namespace` to lookup the destination
addressable.
`ref.namespace` for the `deadLetterSink` is not defaulted by the
webhook like for `trigger.subscriber.ref`, so we might receive a
destination with an empty string for
`deadLetterSink.ref.namespace` which leads to not finding the
referenced addressable service.

Fixes #1011 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add namespace to referenced addressable before resolving destination

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
The fields `Broker.spec.delivery.deadLetterSink.ref.namespace` and `Trigger.spec.delivery.deadLetterSink.ref.namespace` are optional.
By default the controller uses the object namespace. 
```
