### PR TITLE
[minor] Use Maven wrapper to run unit tests

### DIFF
--- a/hack/data-plane.sh
+++ b/hack/data-plane.sh
@@ -146,7 +146,7 @@ function k8s() {
 
 function data_plane_unit_tests() {
   pushd ${DATA_PLANE_DIR} || fail_test
-  mvn clean verify -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=6 --no-transfer-progress
+  ./mvnw clean verify -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=6 --no-transfer-progress
   mvn_output=$?
 
   echo "Copy test reports in ${ARTIFACTS}"


### PR DESCRIPTION
It's better to use the maven wrapper since it doesn't require a maven installation.

## Proposed Changes

- Use Maven wrapper to run unit tests