### PR TITLE
Save release artifacts only after building from source

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -26,9 +26,8 @@ fi
 
 if ! ${SKIP_INITIALIZE}; then
   initialize $@ --skip-istio-addon
+  save_release_artifacts || fail_test "Failed to save release artifacts"
 fi
-
-save_release_artifacts || fail_test "Failed to save release artifacts"
 
 if ! ${LOCAL_DEVELOPMENT}; then
   scale_controlplane kafka-controller kafka-webhook-eventing eventing-webhook eventing-controller


### PR DESCRIPTION
`save_release_artifacts` assumes that we have built
artifacts from source, I want to run tests without building 
from source code, 

/cc @aliok @matzew 