### PR TITLE
Add placeholder for Claims in the KafkaSource status

### DIFF
--- a/control-plane/pkg/reconciler/source/source.go
+++ b/control-plane/pkg/reconciler/source/source.go
@@ -167,6 +167,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *sources.KafkaSource)
 		logger.Debug("Updated dispatcher pod annotation")
 	}
 
+	// TODO(pierDipi) Claims feature is complex, figure out if we really need this.
+	ks.Status.Claims = "unknown"
+
 	return statusConditionManager.Reconciled()
 }
 

--- a/control-plane/pkg/reconciler/testing/objects_source.go
+++ b/control-plane/pkg/reconciler/testing/objects_source.go
@@ -63,6 +63,9 @@ func NewSource(options ...SourceOption) *sources.KafkaSource {
 				Sink: NewSourceSinkReference(),
 			},
 		},
+		Status: sources.KafkaSourceStatus{
+			Claims: "unknown",
+		},
 	}
 	for _, opt := range options {
 		opt(s)


### PR DESCRIPTION
I'm adding a placeholder for `Claims` field of the KafkaSource.

I'd like to discuss if we really need this feature which is quite
complex and I'm not sure if it's worth the effort.

Part of #312

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add placeholder for Claims in the KafkaSource status

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
None
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
None