### PR TITLE
Prefactoring the structure to be able to mock ClusterAdmin - DeleteTopic func

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -287,7 +287,6 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 
 	saramaConfig, err := kafka.GetClusterAdminSaramaConfig(securityOption)
 	if err != nil {
-		logger.Error("error getting cluster admin sarama config", zap.Any("broker", broker), zap.Error(err))
 		// even in error case, we return `normal`, since we are fine with leaving the
 		// topic undeleted e.g. when we lose connection
 		return fmt.Errorf("error getting cluster admin sarama config: %w", err)
@@ -295,7 +294,6 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 
 	kafkaClusterAdmin, err := r.ClusterAdmin(topicConfig.BootstrapServers, saramaConfig)
 	if err != nil {
-		logger.Error("cannot obtain Kafka cluster admin", zap.Any("broker", broker), zap.Error(err))
 		// even in error case, we return `normal`, since we are fine with leaving the
 		// topic undeleted e.g. when we lose connection
 		return fmt.Errorf("cannot obtain Kafka cluster admin, %w", err)

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -314,7 +314,6 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 
 	saramaConfig, err := kafka.GetClusterAdminSaramaConfig(saramaSecurityOption)
 	if err != nil {
-		logger.Error("error getting cluster admin sarama config", zap.Any("channel", channel), zap.Error(err))
 		// even in error case, we return `normal`, since we are fine with leaving the
 		// topic undeleted e.g. when we lose connection
 		return fmt.Errorf("error getting cluster admin sarama config: %w", err)
@@ -322,7 +321,6 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 
 	kafkaClusterAdmin, err := r.ClusterAdmin(topicConfig.BootstrapServers, saramaConfig)
 	if err != nil {
-		logger.Error("cannot obtain Kafka cluster admin", zap.Any("channel", channel), zap.Error(err))
 		// even in error case, we return `normal`, since we are fine with leaving the
 		// topic undeleted e.g. when we lose connection
 		return fmt.Errorf("cannot obtain Kafka cluster admin, %w", err)

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -312,7 +312,24 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 	// get security option for Sarama with secret info in it
 	saramaSecurityOption := security.NewSaramaSecurityOptionFromSecret(secret)
 
-	topic, err := r.ClusterAdmin.DeleteTopic(kafka.Topic(TopicPrefix, channel), topicConfig.BootstrapServers, saramaSecurityOption)
+	saramaConfig, err := kafka.GetClusterAdminSaramaConfig(saramaSecurityOption)
+	if err != nil {
+		logger.Error("error getting cluster admin sarama config", zap.Any("channel", channel), zap.Error(err))
+		// even in error case, we return `normal`, since we are fine with leaving the
+		// topic undeleted e.g. when we lose connection
+		return fmt.Errorf("error getting cluster admin sarama config: %w", err)
+	}
+
+	kafkaClusterAdmin, err := r.ClusterAdmin(topicConfig.BootstrapServers, saramaConfig)
+	if err != nil {
+		logger.Error("cannot obtain Kafka cluster admin", zap.Any("channel", channel), zap.Error(err))
+		// even in error case, we return `normal`, since we are fine with leaving the
+		// topic undeleted e.g. when we lose connection
+		return fmt.Errorf("cannot obtain Kafka cluster admin, %w", err)
+	}
+	defer kafkaClusterAdmin.Close()
+
+	topic, err := kafka.DeleteTopic(kafkaClusterAdmin, kafka.Topic(TopicPrefix, channel))
 	if err != nil {
 		return err
 	}

--- a/control-plane/pkg/reconciler/kafka/config.go
+++ b/control-plane/pkg/reconciler/kafka/config.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka
+
+import (
+	"github.com/Shopify/sarama"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/security"
+)
+
+// GetClusterAdminSaramaConfig returns Kafka Admin configurations that the ConfigOptions are applied to
+func GetClusterAdminSaramaConfig(secOptions security.ConfigOption) (*sarama.Config, error) {
+	config := sarama.NewConfig()
+	config.Version = sarama.MaxVersion
+
+	err := secOptions(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}

--- a/control-plane/pkg/reconciler/kafka/topic.go
+++ b/control-plane/pkg/reconciler/kafka/topic.go
@@ -114,17 +114,6 @@ func (f NewClusterAdminFunc) CreateTopicIfDoesntExist(logger *zap.Logger, topic 
 	return CreateTopicIfDoesntExist(kafkaClusterAdmin, logger, topic, config)
 }
 
-func (f NewClusterAdminFunc) DeleteTopic(topic string, bootstrapServers []string, secOptions security.ConfigOption) (string, error) {
-
-	kafkaClusterAdmin, err := GetClusterAdmin(f, bootstrapServers, secOptions)
-	if err != nil {
-		return topic, err
-	}
-	defer kafkaClusterAdmin.Close()
-
-	return DeleteTopic(kafkaClusterAdmin, topic)
-}
-
 func (f NewClusterAdminFunc) IsTopicPresentAndValid(topic string, bootstrapServers []string, secOptions security.ConfigOption) (bool, error) {
 
 	kafkaClusterAdmin, err := GetClusterAdmin(f, bootstrapServers, secOptions)

--- a/control-plane/pkg/reconciler/kafka/topic_test.go
+++ b/control-plane/pkg/reconciler/kafka/topic_test.go
@@ -25,10 +25,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
-
 	kafkatesting "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka/testing"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/security"
+	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
 )
 
 func TestCreateTopic(t *testing.T) {
@@ -317,32 +316,6 @@ func TestCreateTopicTopicAlreadyExists(t *testing.T) {
 
 	assert.Equal(t, topicRet, topic, "expected topic %s go %s", topic, topicRet)
 	assert.Nil(t, err, "expected nil error on topic already exists")
-	assert.True(t, ca.ExpectedClose, "expected call to Close() on ClusterAdmin")
-}
-
-func TestNewClusterAdminFuncDeleteTopicCloseClusterAdmin(t *testing.T) {
-
-	topic := "topic-name-1"
-
-	ca := &kafkatesting.MockKafkaClusterAdmin{
-		ExpectedTopicName: topic,
-		ExpectedClose:     true,
-		T:                 t,
-	}
-
-	f := NewClusterAdminFunc(func(addrs []string, config *sarama.Config) (sarama.ClusterAdmin, error) {
-		return ca, nil
-	})
-
-	got, err := f.DeleteTopic("topic-name-1", []string{}, security.NoOp)
-	if err != nil {
-		t.Errorf("DeleteTopic() error = %v, wantErr %v", err, false)
-		return
-	}
-	if got != topic {
-		t.Errorf("DeleteTopic() got = %v, want %v", got, topic)
-	}
-
 	assert.True(t, ca.ExpectedClose, "expected call to Close() on ClusterAdmin")
 }
 

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -278,7 +278,6 @@ func (r *Reconciler) finalizeKind(ctx context.Context, ks *eventing.KafkaSink) e
 
 		saramaConfig, err := kafka.GetClusterAdminSaramaConfig(securityOption)
 		if err != nil {
-			logger.Error("error getting cluster admin sarama config", zap.Any("sink", ks), zap.Error(err))
 			// even in error case, we return `normal`, since we are fine with leaving the
 			// topic undeleted e.g. when we lose connection
 			return fmt.Errorf("error getting cluster admin sarama config: %w", err)
@@ -286,7 +285,6 @@ func (r *Reconciler) finalizeKind(ctx context.Context, ks *eventing.KafkaSink) e
 
 		kafkaClusterAdmin, err := r.ClusterAdmin(ks.Spec.BootstrapServers, saramaConfig)
 		if err != nil {
-			logger.Error("cannot obtain Kafka cluster admin", zap.Any("sink", ks), zap.Error(err))
 			// even in error case, we return `normal`, since we are fine with leaving the
 			// topic undeleted e.g. when we lose connection
 			return fmt.Errorf("cannot obtain Kafka cluster admin, %w", err)

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -276,7 +276,24 @@ func (r *Reconciler) finalizeKind(ctx context.Context, ks *eventing.KafkaSink) e
 		// get security option for Sarama with secret info in it
 		securityOption := security.NewSaramaSecurityOptionFromSecret(secret)
 
-		topic, err := r.ClusterAdmin.DeleteTopic(ks.Spec.Topic, ks.Spec.BootstrapServers, securityOption)
+		saramaConfig, err := kafka.GetClusterAdminSaramaConfig(securityOption)
+		if err != nil {
+			logger.Error("error getting cluster admin sarama config", zap.Any("sink", ks), zap.Error(err))
+			// even in error case, we return `normal`, since we are fine with leaving the
+			// topic undeleted e.g. when we lose connection
+			return fmt.Errorf("error getting cluster admin sarama config: %w", err)
+		}
+
+		kafkaClusterAdmin, err := r.ClusterAdmin(ks.Spec.BootstrapServers, saramaConfig)
+		if err != nil {
+			logger.Error("cannot obtain Kafka cluster admin", zap.Any("sink", ks), zap.Error(err))
+			// even in error case, we return `normal`, since we are fine with leaving the
+			// topic undeleted e.g. when we lose connection
+			return fmt.Errorf("cannot obtain Kafka cluster admin, %w", err)
+		}
+		defer kafkaClusterAdmin.Close()
+
+		topic, err := kafka.DeleteTopic(kafkaClusterAdmin, ks.Spec.Topic)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Getting rid of the confusing code here, which defines a function type and then defines functions under it: https://github.com/knative-sandbox/eventing-kafka-broker/blob/c3b0e1bd9afa7e6ea1dc22f30504baf2130a5bf3/control-plane/pkg/reconciler/kafka/topic.go#L117

For me, this is a bit confusing:
```go
... 
// func type definition
type NewClusterAdminFunc func(addrs []string, config *sarama.Config) (sarama.ClusterAdmin, error)

// func definition for that func type
func (f NewClusterAdminFunc) DeleteTopic(topic string, bootstrapServers []string, secOptions security.ConfigOption) (string, error) {
...
}

// how the func is used as a struct member
type Reconciler struct {
	...
	// ClusterAdmin creates new sarama ClusterAdmin. It's convenient to add this as Reconciler field so that we can
	// mock the function used during the reconciliation loop.
	ClusterAdmin kafka.NewClusterAdminFunc
}

// how the func is called
r.ClusterAdmin.DeleteTopic(...)
// r.ClusterAdmin is a func itself
```

I understand the usefulness here but I think having a function that either creates a mock cluster admin OR a real one is simple enough and should be fine.

-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
