### PR TITLE
Get rid of `func (f NewClusterAdminFunc) CreateTopicIfDoesntExist(...)`

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -125,7 +125,22 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 		return fmt.Errorf("failed to track secret: %w", err)
 	}
 
-	topic, err := r.ClusterAdmin.CreateTopicIfDoesntExist(logger, kafka.Topic(TopicPrefix, broker), topicConfig, securityOption)
+	saramaConfig, err := kafka.GetClusterAdminSaramaConfig(securityOption)
+	if err != nil {
+		// even in error case, we return `normal`, since we are fine with leaving the
+		// topic undeleted e.g. when we lose connection
+		return fmt.Errorf("error getting cluster admin sarama config: %w", err)
+	}
+
+	kafkaClusterAdmin, err := r.ClusterAdmin(topicConfig.BootstrapServers, saramaConfig)
+	if err != nil {
+		// even in error case, we return `normal`, since we are fine with leaving the
+		// topic undeleted e.g. when we lose connection
+		return fmt.Errorf("cannot obtain Kafka cluster admin, %w", err)
+	}
+	defer kafkaClusterAdmin.Close()
+
+	topic, err := kafka.CreateTopicIfDoesntExist(kafkaClusterAdmin, logger, kafka.Topic(TopicPrefix, broker), topicConfig)
 	if err != nil {
 		return statusConditionManager.FailedToCreateTopic(topic, err)
 	}

--- a/control-plane/pkg/reconciler/kafka/topic.go
+++ b/control-plane/pkg/reconciler/kafka/topic.go
@@ -103,17 +103,6 @@ func DeleteTopic(admin sarama.ClusterAdmin, topic string) (string, error) {
 	return topic, nil
 }
 
-func (f NewClusterAdminFunc) CreateTopicIfDoesntExist(logger *zap.Logger, topic string, config *TopicConfig, secOptions security.ConfigOption) (string, error) {
-
-	kafkaClusterAdmin, err := GetClusterAdmin(f, config.BootstrapServers, secOptions)
-	if err != nil {
-		return topic, err
-	}
-	defer kafkaClusterAdmin.Close()
-
-	return CreateTopicIfDoesntExist(kafkaClusterAdmin, logger, topic, config)
-}
-
 func (f NewClusterAdminFunc) IsTopicPresentAndValid(topic string, bootstrapServers []string, secOptions security.ConfigOption) (bool, error) {
 
 	kafkaClusterAdmin, err := GetClusterAdmin(f, bootstrapServers, secOptions)

--- a/control-plane/pkg/reconciler/kafka/topic_test.go
+++ b/control-plane/pkg/reconciler/kafka/topic_test.go
@@ -296,8 +296,6 @@ func TestCreateTopicTopicAlreadyExists(t *testing.T) {
 	topic := Topic("", b)
 	errMsg := "topic already exists"
 
-	var f NewClusterAdminFunc
-
 	ca := &kafkatesting.MockKafkaClusterAdmin{
 		ExpectedTopicName:   topic,
 		ExpectedTopicDetail: sarama.TopicDetail{},
@@ -308,15 +306,10 @@ func TestCreateTopicTopicAlreadyExists(t *testing.T) {
 		T: t,
 	}
 
-	f = func(addrs []string, config *sarama.Config) (sarama.ClusterAdmin, error) {
-		return ca, nil
-	}
-
-	topicRet, err := f.CreateTopicIfDoesntExist(zap.NewNop(), topic, &TopicConfig{}, security.NoOp)
+	topicRet, err := CreateTopicIfDoesntExist(ca, zap.NewNop(), topic, &TopicConfig{})
 
 	assert.Equal(t, topicRet, topic, "expected topic %s go %s", topic, topicRet)
 	assert.Nil(t, err, "expected nil error on topic already exists")
-	assert.True(t, ca.ExpectedClose, "expected call to Close() on ClusterAdmin")
 }
 
 func TestNewClusterAdminFuncIsTopicPresent(t *testing.T) {

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -106,7 +106,22 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 
 		topicConfig := topicConfigFromSinkSpec(&ks.Spec)
 
-		topic, err := r.ClusterAdmin.CreateTopicIfDoesntExist(logger, ks.Spec.Topic, topicConfig, securityOption)
+		saramaConfig, err := kafka.GetClusterAdminSaramaConfig(securityOption)
+		if err != nil {
+			// even in error case, we return `normal`, since we are fine with leaving the
+			// topic undeleted e.g. when we lose connection
+			return fmt.Errorf("error getting cluster admin sarama config: %w", err)
+		}
+
+		kafkaClusterAdmin, err := r.ClusterAdmin(ks.Spec.BootstrapServers, saramaConfig)
+		if err != nil {
+			// even in error case, we return `normal`, since we are fine with leaving the
+			// topic undeleted e.g. when we lose connection
+			return fmt.Errorf("cannot obtain Kafka cluster admin, %w", err)
+		}
+		defer kafkaClusterAdmin.Close()
+
+		topic, err := kafka.CreateTopicIfDoesntExist(kafkaClusterAdmin, logger, ks.Spec.Topic, topicConfig)
 		if err != nil {
 			return statusConditionManager.FailedToCreateTopic(topic, err)
 		}


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Same with https://github.com/knative-sandbox/eventing-kafka-broker/pull/1355, except this time I delete  `CreateTopicIfDoesntExist`
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
