### PR TITLE
Kafka Channel Subscription reconciliation - control plane

### DIFF
--- a/control-plane/pkg/core/config/egress.go
+++ b/control-plane/pkg/core/config/egress.go
@@ -47,11 +47,11 @@ const (
 )
 
 // AddOrUpdateEgressConfig adds or updates the given egress to the given contract at the specified indexes.
-func AddOrUpdateEgressConfig(ct *contract.Contract, brokerIndex int, egress *contract.Egress, egressIndex int) int {
+func AddOrUpdateEgressConfig(ct *contract.Contract, resourceIndex int, egress *contract.Egress, egressIndex int) int {
 
 	if egressIndex != NoEgress {
-		prev := ct.Resources[brokerIndex].Egresses[egressIndex]
-		ct.Resources[brokerIndex].Egresses[egressIndex] = egress
+		prev := ct.Resources[resourceIndex].Egresses[egressIndex]
+		ct.Resources[resourceIndex].Egresses[egressIndex] = egress
 
 		if proto.Equal(prev, egress) {
 			return EgressUnchanged
@@ -59,8 +59,8 @@ func AddOrUpdateEgressConfig(ct *contract.Contract, brokerIndex int, egress *con
 		return EgressChanged
 	}
 
-	ct.Resources[brokerIndex].Egresses = append(
-		ct.Resources[brokerIndex].Egresses,
+	ct.Resources[resourceIndex].Egresses = append(
+		ct.Resources[resourceIndex].Egresses,
 		egress,
 	)
 

--- a/control-plane/pkg/core/config/egress.go
+++ b/control-plane/pkg/core/config/egress.go
@@ -67,6 +67,24 @@ func AddOrUpdateEgressConfig(ct *contract.Contract, resourceIndex int, egress *c
 	return EgressChanged
 }
 
+// AddOrUpdateEgressConfigForResource adds or updates the given egress to the given contract at the specified indexes.
+func AddOrUpdateEgressConfigForResource(resource *contract.Resource, egress *contract.Egress, egressIndex int) int {
+
+	if egressIndex != NoEgress {
+		prev := resource.Egresses[egressIndex]
+		resource.Egresses[egressIndex] = egress
+
+		if proto.Equal(prev, egress) {
+			return EgressUnchanged
+		}
+		return EgressChanged
+	}
+
+	resource.Egresses = append(resource.Egresses, egress)
+
+	return EgressChanged
+}
+
 // KeyTypeFromString returns the contract.KeyType associated to a given string.
 func KeyTypeFromString(s string) contract.KeyType {
 	switch s {

--- a/control-plane/pkg/core/config/egress_test.go
+++ b/control-plane/pkg/core/config/egress_test.go
@@ -221,6 +221,96 @@ func TestAddOrUpdateEgressConfig(t *testing.T) {
 	}
 }
 
+func TestAddOrUpdateEgressConfigForResource(t *testing.T) {
+	tests := []struct {
+		name        string
+		givenRes    *contract.Resource
+		egress      *contract.Egress
+		egressIndex int
+		changed     int
+		wantRes     *contract.Resource
+	}{
+		{
+			name: "Egress found - changed",
+			givenRes: &contract.Resource{
+				Egresses: []*contract.Egress{
+					{
+						Uid: "xyz",
+					},
+				},
+			},
+			egress: &contract.Egress{
+				Uid: "abc",
+			},
+			egressIndex: 0,
+			wantRes: &contract.Resource{
+				Egresses: []*contract.Egress{
+					{
+						Uid: "abc",
+					},
+				},
+			},
+		},
+		{
+			name: "Egress found - unchanged",
+			givenRes: &contract.Resource{
+				Egresses: []*contract.Egress{
+					{
+						Uid: "abc",
+					},
+				},
+			},
+			egress: &contract.Egress{
+				Uid: "abc",
+			},
+			egressIndex: 0,
+			wantRes: &contract.Resource{
+				Egresses: []*contract.Egress{
+					{
+						Uid: "abc",
+					},
+				},
+			},
+			changed: EgressUnchanged,
+		},
+		{
+			name: "Egress not found",
+			givenRes: &contract.Resource{
+				Egresses: []*contract.Egress{
+					{
+						Uid: "abc",
+					},
+				},
+			},
+			egress: &contract.Egress{
+				Uid: "abc",
+			},
+			egressIndex: NoEgress,
+			wantRes: &contract.Resource{
+				Egresses: []*contract.Egress{
+					{
+						Uid: "abc",
+					},
+					{
+						Uid: "abc",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AddOrUpdateEgressConfigForResource(tt.givenRes, tt.egress, tt.egressIndex); got != tt.changed {
+				t.Errorf("AddOrUpdateEgressConfig() = %v, want %v", got, tt.changed)
+			}
+
+			if diff := cmp.Diff(tt.wantRes, tt.givenRes, protocmp.Transform()); diff != "" {
+				t.Errorf("(-want, +got) %s", diff)
+			}
+		})
+	}
+}
+
 func TestKeyTypeFromString(t *testing.T) {
 	tests := []struct {
 		s    string

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -127,7 +127,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 
 	topicName := kafka.Topic(TopicPrefix, broker)
 
-	saramaConfig, err := kafka.GetClusterAdminSaramaConfig(securityOption)
+	saramaConfig, err := kafka.GetSaramaConfig(securityOption)
 	if err != nil {
 		return statusConditionManager.FailedToCreateTopic(topicName, fmt.Errorf("error getting cluster admin config: %w", err))
 	}
@@ -299,7 +299,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 	// get security option for Sarama with secret info in it
 	securityOption := security.NewSaramaSecurityOptionFromSecret(secret)
 
-	saramaConfig, err := kafka.GetClusterAdminSaramaConfig(securityOption)
+	saramaConfig, err := kafka.GetSaramaConfig(securityOption)
 	if err != nil {
 		// even in error case, we return `normal`, since we are fine with leaving the
 		// topic undeleted e.g. when we lose connection

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -65,8 +65,9 @@ type Reconciler struct {
 	// mock the function used during the reconciliation loop.
 	NewKafkaClusterAdmin kafka.NewClusterAdminFunc
 
-	// TODO: rename
-	KafkaClient kafka.NewClientFunc
+	// NewKafkaClient creates new sarama Client. It's convenient to add this as Reconciler field so that we can
+	// mock the function used during the reconciliation loop.
+	NewKafkaClient kafka.NewClientFunc
 
 	ConfigMapLister corelisters.ConfigMapLister
 
@@ -157,7 +158,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 	}
 	defer kafkaClusterAdmin.Close()
 
-	kafkaClient, err := r.KafkaClient(topicConfig.BootstrapServers, kafkaClientSaramaConfig)
+	kafkaClient, err := r.NewKafkaClient(topicConfig.BootstrapServers, kafkaClientSaramaConfig)
 	if err != nil {
 		return statusConditionManager.FailedToCreateTopic(topicName, fmt.Errorf("error getting sarama config: %w", err))
 	}

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -428,7 +428,7 @@ func (r *Reconciler) reconcileInitialOffset(ctx context.Context, channel *messag
 	}
 
 	topicName := topic(TopicPrefix, channel)
-	groupID := fmt.Sprintf("kafka.%s.%s.%s", channel.Namespace, channel.Name, string(sub.UID))
+	groupID := consumerGroup(channel, sub)
 	_, err := offset.InitOffsets(ctx, kafkaClient, kafkaClusterAdmin, []string{topicName}, groupID)
 	if err != nil {
 		logger := logging.FromContext(ctx)
@@ -523,10 +523,15 @@ func (r *Reconciler) getChannelContractResource(ctx context.Context, topic strin
 	return resource, nil
 }
 
-// Topic returns a topic name given a topic prefix and a generic object.
+// topic returns a topic name given a topic prefix and a generic object.
 // This function uses a different format than the kafkatopic.Topic function
 func topic(prefix string, obj metav1.Object) string {
 	return fmt.Sprintf("%s.%s.%s", prefix, obj.GetNamespace(), obj.GetName())
+}
+
+// consumerGroup returns a consumerGroup name for the given channel and subscription
+func consumerGroup(channel *messagingv1beta1.KafkaChannel, sub v1.SubscriberSpec) string {
+	return fmt.Sprintf("kafka.%s.%s.%s", channel.Namespace, channel.Name, string(sub.UID))
 }
 
 func findSubscriptionStatus(kc *messagingv1beta1.KafkaChannel, subUID types.UID) *v1.SubscriberStatus {

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -454,11 +454,17 @@ func (r *Reconciler) getSubscriberConfig(ctx context.Context, channel *messaging
 		Uid:           string(subscriber.UID),
 	}
 
-	egressConfig, err := coreconfig.EgressConfigFromDelivery(ctx, r.Resolver, channel, subscriber.Delivery, r.Configs.DefaultBackoffDelayMs)
+	subscriptionEgressConfig, err := coreconfig.EgressConfigFromDelivery(ctx, r.Resolver, channel, subscriber.Delivery, r.Configs.DefaultBackoffDelayMs)
 	if err != nil {
 		return nil, err
 	}
-	egress.EgressConfig = egressConfig
+	channelEgressConfig, err := coreconfig.EgressConfigFromDelivery(ctx, r.Resolver, channel, channel.Spec.Delivery, r.Configs.DefaultBackoffDelayMs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge Channel and Subscription egress configuration prioritizing the Subscription configuration.
+	egress.EgressConfig = coreconfig.MergeEgressConfig(subscriptionEgressConfig, channelEgressConfig)
 
 	return egress, nil
 }

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -387,9 +387,10 @@ func (r *Reconciler) reconcileSubscribers(ctx context.Context, kafkaClient saram
 
 	channel.Status.Subscribers = make([]v1.SubscriberStatus, 0)
 	var globalErr error
-	for _, s := range channel.Spec.Subscribers {
+	for i, _ := range channel.Spec.Subscribers {
+		s := &channel.Spec.Subscribers[i]
 		logger = logger.With(zap.Any("subscription", s))
-		err := r.reconcileSubscriber(ctx, kafkaClient, kafkaClusterAdmin, channel, &s, channelContractResource)
+		err := r.reconcileSubscriber(ctx, kafkaClient, kafkaClusterAdmin, channel, s, channelContractResource)
 		if err != nil {
 			logger.Error("error reconciling subscription. marking subscription as not ready", zap.Error(err))
 			channel.Status.Subscribers = append(channel.Status.Subscribers, v1.SubscriberStatus{

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -387,7 +387,7 @@ func (r *Reconciler) reconcileSubscribers(ctx context.Context, kafkaClient saram
 
 	channel.Status.Subscribers = make([]v1.SubscriberStatus, 0)
 	var globalErr error
-	for i, _ := range channel.Spec.Subscribers {
+	for i := range channel.Spec.Subscribers {
 		s := &channel.Spec.Subscribers[i]
 		logger = logger.With(zap.Any("subscription", s))
 		err := r.reconcileSubscriber(ctx, kafkaClient, kafkaClusterAdmin, channel, s, channelContractResource)

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -142,7 +142,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 
 	topicName := topic(TopicPrefix, channel)
 
-	kafkaClusterAdminSaramaConfig, err := kafka.GetClusterAdminSaramaConfig(saramaSecurityOption)
+	kafkaClusterAdminSaramaConfig, err := kafka.GetSaramaConfig(saramaSecurityOption)
 	if err != nil {
 		return statusConditionManager.FailedToCreateTopic(topicName, fmt.Errorf("error getting cluster admin sarama config: %w", err))
 	}
@@ -150,7 +150,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 	// Manually commit the offsets in KafkaChannel controller.
 	// That's because we want to make sure we initialize the offsets within the controller
 	// before dispatcher actually starts consuming messages.
-	kafkaClientSaramaConfig, err := kafka.GetClientSaramaConfig(saramaSecurityOption, kafka.DisableOffsetAutoCommitConfigOption)
+	kafkaClientSaramaConfig, err := kafka.GetSaramaConfig(saramaSecurityOption, kafka.DisableOffsetAutoCommitConfigOption)
 	if err != nil {
 		return statusConditionManager.FailedToCreateTopic(topicName, fmt.Errorf("error getting cluster admin sarama config: %w", err))
 	}
@@ -350,7 +350,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 	// get security option for Sarama with secret info in it
 	saramaSecurityOption := security.NewSaramaSecurityOptionFromSecret(secret)
 
-	saramaConfig, err := kafka.GetClusterAdminSaramaConfig(saramaSecurityOption)
+	saramaConfig, err := kafka.GetSaramaConfig(saramaSecurityOption)
 	if err != nil {
 		// even in error case, we return `normal`, since we are fine with leaving the
 		// topic undeleted e.g. when we lose connection

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -427,10 +427,7 @@ func (r *Reconciler) reconcileSubscriber(ctx context.Context, kafkaClient sarama
 		return fmt.Errorf("failed to resolve subscriber config: %v", zap.Error(err))
 	}
 
-	changed := coreconfig.AddOrUpdateEgressConfigForResource(channelContractResource, subscriberConfig, subscriberIndex)
-
-	logger.Debug("Egress changes", zap.Int("changed", changed))
-
+	coreconfig.AddOrUpdateEgressConfigForResource(channelContractResource, subscriberConfig, subscriberIndex)
 	return nil
 }
 

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -450,16 +450,6 @@ func (r *Reconciler) getSubscriberConfig(ctx context.Context, channel *messaging
 	}
 	egress.EgressConfig = egressConfig
 
-	// TODO do we need such thing here?
-	//deliveryOrderAnnotationValue, ok := subscriber.Annotations[deliveryOrderAnnotation]
-	//if ok {
-	//	deliveryOrder, err := deliveryOrderFromString(deliveryOrderAnnotationValue)
-	//	if err != nil {
-	//		return nil, err
-	//	}
-	//	egress.DeliveryOrder = deliveryOrder
-	//}
-
 	return egress, nil
 }
 

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -147,7 +147,10 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 		return statusConditionManager.FailedToCreateTopic(topicName, fmt.Errorf("error getting cluster admin sarama config: %w", err))
 	}
 
-	kafkaClientSaramaConfig, err := kafka.GetClientSaramaConfig(saramaSecurityOption)
+	// Manually commit the offsets in KafkaChannel controller.
+	// That's because we want to make sure we initialize the offsets within the controller
+	// before dispatcher actually starts consuming messages.
+	kafkaClientSaramaConfig, err := kafka.GetClientSaramaConfig(saramaSecurityOption, kafka.DisableOffsetAutoCommitConfigOption)
 	if err != nil {
 		return statusConditionManager.FailedToCreateTopic(topicName, fmt.Errorf("error getting cluster admin sarama config: %w", err))
 	}

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -196,7 +196,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 		return statusConditionManager.FailedToResolveConfig(errors.New("missing channel in contract"))
 	}
 
-	err = r.reconcileSubscribers(ctx, kafkaClient, kafkaClusterAdmin, channel, statusConditionManager, ct, channelIndex, contractConfigMap)
+	err = r.reconcileSubscribers(ctx, kafkaClient, kafkaClusterAdmin, channel, ct, channelIndex, contractConfigMap)
 	if err != nil {
 		return fmt.Errorf("error reconciling subscribers %v", err)
 	}
@@ -384,7 +384,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 	return nil
 }
 
-func (r *Reconciler) reconcileSubscribers(ctx context.Context, kafkaClient sarama.Client, kafkaClusterAdmin sarama.ClusterAdmin, channel *messagingv1beta1.KafkaChannel, statusConditionManager base.StatusConditionManager, ct *contract.Contract, channelIndex int, contractConfigMap *corev1.ConfigMap) error {
+func (r *Reconciler) reconcileSubscribers(ctx context.Context, kafkaClient sarama.Client, kafkaClusterAdmin sarama.ClusterAdmin, channel *messagingv1beta1.KafkaChannel, ct *contract.Contract, channelIndex int, contractConfigMap *corev1.ConfigMap) error {
 	logger := kafkalogging.CreateReconcileMethodLogger(ctx, channel)
 
 	after := channel.DeepCopy()

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -438,7 +438,7 @@ func (r *Reconciler) reconcileInitialOffset(ctx context.Context, channel *messag
 func (r *Reconciler) getSubscriberConfig(ctx context.Context, channel *messagingv1beta1.KafkaChannel, subscriber *v1.SubscriberSpec) (*contract.Egress, error) {
 	egress := &contract.Egress{
 		Destination:   subscriber.SubscriberURI.String(),
-		ConsumerGroup: string(subscriber.UID),
+		ConsumerGroup: consumerGroup(channel, subscriber),
 		Uid:           string(subscriber.UID),
 	}
 

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -473,7 +473,7 @@ func (r *Reconciler) reconcileSubscriber(ctx context.Context, kafkaClient sarama
 		logger.Error("reconcile failed to initial offset for subscription. Marking the subscription not ready", zap.String("channel", fmt.Sprintf("%s.%s", channel.Namespace, channel.Name)), zap.Any("subscription", subscriberSpec), zap.Error(err))
 		return fmt.Errorf("initial offset cannot be committed: %v", err)
 	}
-	logger.Debug("Reconciled initial offset for subscription. ", zap.String("channel", fmt.Sprintf("%s.%s", channel.Namespace, channel.Name)), zap.Any("subscription", subscriberSpec))
+	logger.Debug("Reconciled initial offset for subscription. ", zap.Any("subscription", subscriberSpec))
 
 	subscriberIndex := coreconfig.FindEgress(ct.Resources[channelIndex].Egresses, subscriberSpec.UID)
 	subscriberConfig, err := r.getSubscriberConfig(ctx, channel, &subscriberSpec)

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -40,7 +40,6 @@ import (
 	commonsarama "knative.dev/eventing-kafka/pkg/common/kafka/sarama"
 	v1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/system"
@@ -406,7 +405,6 @@ func (r *Reconciler) reconcileSubscriber(ctx context.Context, kafkaClient sarama
 	logger.Debug("Reconciling initial offset for subscription", zap.Any("subscription", subscriberSpec), zap.Any("channel", channel))
 	err := r.reconcileInitialOffset(ctx, channel, subscriberSpec, kafkaClient, kafkaClusterAdmin)
 	if err != nil {
-		logger.Error("reconcile failed to initial offset for subscription. Marking the subscription not ready", zap.String("channel", fmt.Sprintf("%s.%s", channel.Namespace, channel.Name)), zap.Any("subscription", subscriberSpec), zap.Error(err))
 		return fmt.Errorf("initial offset cannot be committed: %v", err)
 	}
 	logger.Debug("Reconciled initial offset for subscription. ", zap.Any("subscription", subscriberSpec))
@@ -434,10 +432,6 @@ func (r *Reconciler) reconcileInitialOffset(ctx context.Context, channel *messag
 	topicName := topic(TopicPrefix, channel)
 	groupID := consumerGroup(channel, sub)
 	_, err := offset.InitOffsets(ctx, kafkaClient, kafkaClusterAdmin, []string{topicName}, groupID)
-	if err != nil {
-		logger := logging.FromContext(ctx)
-		logger.Errorw("error reconciling initial offset", zap.String("channel", fmt.Sprintf("%s.%s", channel.Namespace, channel.Name)), zap.Any("subscription", sub), zap.Error(err))
-	}
 	return err
 }
 

--- a/control-plane/pkg/reconciler/channel/controller.go
+++ b/control-plane/pkg/reconciler/channel/controller.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	messagingv1beta "knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
-	kafkachannelclient "knative.dev/eventing-kafka/pkg/client/injection/client"
 	kafkachannelinformer "knative.dev/eventing-kafka/pkg/client/injection/informers/messaging/v1beta1/kafkachannel"
 	kafkachannelreconciler "knative.dev/eventing-kafka/pkg/client/injection/reconciler/messaging/v1beta1/kafkachannel"
 
@@ -61,8 +60,6 @@ func NewController(ctx context.Context, watcher configmap.Watcher, configs *conf
 			DispatcherLabel:             base.ChannelDispatcherLabel,
 			ReceiverLabel:               base.ChannelReceiverLabel,
 		},
-		// TODO: expose, like others
-		kafkaClientSet: kafkachannelclient.Get(ctx),
 		// TODO: rename
 		KafkaClient:          sarama.NewClient,
 		NewKafkaClusterAdmin: sarama.NewClusterAdmin,

--- a/control-plane/pkg/reconciler/channel/controller.go
+++ b/control-plane/pkg/reconciler/channel/controller.go
@@ -60,8 +60,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher, configs *conf
 			DispatcherLabel:             base.ChannelDispatcherLabel,
 			ReceiverLabel:               base.ChannelReceiverLabel,
 		},
-		// TODO: rename
-		KafkaClient:          sarama.NewClient,
+		NewKafkaClient:       sarama.NewClient,
 		NewKafkaClusterAdmin: sarama.NewClusterAdmin,
 		Configs:              configs,
 		ConfigMapLister:      configmapInformer.Lister(),

--- a/control-plane/pkg/reconciler/channel/controller.go
+++ b/control-plane/pkg/reconciler/channel/controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	messagingv1beta "knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
+	kafkachannelclient "knative.dev/eventing-kafka/pkg/client/injection/client"
 	kafkachannelinformer "knative.dev/eventing-kafka/pkg/client/injection/informers/messaging/v1beta1/kafkachannel"
 	kafkachannelreconciler "knative.dev/eventing-kafka/pkg/client/injection/reconciler/messaging/v1beta1/kafkachannel"
 
@@ -60,6 +61,10 @@ func NewController(ctx context.Context, watcher configmap.Watcher, configs *conf
 			DispatcherLabel:             base.ChannelDispatcherLabel,
 			ReceiverLabel:               base.ChannelReceiverLabel,
 		},
+		// TODO: expose, like others
+		kafkaClientSet: kafkachannelclient.Get(ctx),
+		// TODO: rename
+		KafkaClient:          sarama.NewClient,
 		NewKafkaClusterAdmin: sarama.NewClusterAdmin,
 		Configs:              configs,
 		ConfigMapLister:      configmapInformer.Lister(),

--- a/control-plane/pkg/reconciler/kafka/client.go
+++ b/control-plane/pkg/reconciler/kafka/client.go
@@ -44,26 +44,11 @@ func DisableOffsetAutoCommitConfigOption(config *sarama.Config) error {
 // NewClusterAdminFunc creates new sarama.ClusterAdmin.
 type NewClusterAdminFunc func(addrs []string, config *sarama.Config) (sarama.ClusterAdmin, error)
 
-// GetClusterAdminSaramaConfig returns Kafka Admin configurations that the ConfigOptions are applied to
-func GetClusterAdminSaramaConfig(configOptions ...ConfigOption) (*sarama.Config, error) {
-	config := sarama.NewConfig()
-	config.Version = sarama.MaxVersion
-
-	err := Options(config, configOptions...)
-	if err != nil {
-		return nil, err
-	}
-
-	return config, nil
-}
-
 // NewClientFunc creates new sarama.Client.
 type NewClientFunc func(addrs []string, config *sarama.Config) (sarama.Client, error)
 
-// TODO unify once the hardcoded config below is converted to an option
-
-// GetClientSaramaConfig returns Kafka Client configurations.
-func GetClientSaramaConfig(configOptions ...ConfigOption) (*sarama.Config, error) {
+// GetSaramaConfig returns Kafka Client configuration with the given options applied.
+func GetSaramaConfig(configOptions ...ConfigOption) (*sarama.Config, error) {
 	config := sarama.NewConfig()
 	config.Version = sarama.MaxVersion
 

--- a/control-plane/pkg/reconciler/kafka/client.go
+++ b/control-plane/pkg/reconciler/kafka/client.go
@@ -40,11 +40,11 @@ func NoOpConfigOption(*sarama.Config) error {
 type NewClusterAdminFunc func(addrs []string, config *sarama.Config) (sarama.ClusterAdmin, error)
 
 // GetClusterAdminSaramaConfig returns Kafka Admin configurations that the ConfigOptions are applied to
-func GetClusterAdminSaramaConfig(configOption ConfigOption) (*sarama.Config, error) {
+func GetClusterAdminSaramaConfig(configOptions ...ConfigOption) (*sarama.Config, error) {
 	config := sarama.NewConfig()
 	config.Version = sarama.MaxVersion
 
-	err := configOption(config)
+	err := Options(config, configOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -58,11 +58,11 @@ type NewClientFunc func(addrs []string, config *sarama.Config) (sarama.Client, e
 // TODO unify once the hardcoded config below is converted to an option
 
 // GetClientSaramaConfig returns Kafka Client configurations.
-func GetClientSaramaConfig(configOption ConfigOption) (*sarama.Config, error) {
+func GetClientSaramaConfig(configOptions ...ConfigOption) (*sarama.Config, error) {
 	config := sarama.NewConfig()
 	config.Version = sarama.MaxVersion
 
-	err := configOption(config)
+	err := Options(config, configOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/control-plane/pkg/reconciler/kafka/client.go
+++ b/control-plane/pkg/reconciler/kafka/client.go
@@ -36,6 +36,11 @@ func NoOpConfigOption(*sarama.Config) error {
 	return nil
 }
 
+func DisableOffsetAutoCommitConfigOption(config *sarama.Config) error {
+	config.Consumer.Offsets.AutoCommit.Enable = false
+	return nil
+}
+
 // NewClusterAdminFunc creates new sarama.ClusterAdmin.
 type NewClusterAdminFunc func(addrs []string, config *sarama.Config) (sarama.ClusterAdmin, error)
 
@@ -66,12 +71,6 @@ func GetClientSaramaConfig(configOptions ...ConfigOption) (*sarama.Config, error
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: convert to option
-	// Manually commit the offsets in KafkaChannel controller.
-	// That's because we want to make sure we initialize the offsets within the controller
-	// before dispatcher actually starts consuming messages.
-	config.Consumer.Offsets.AutoCommit.Enable = false
 
 	return config, nil
 }

--- a/control-plane/pkg/reconciler/kafka/client.go
+++ b/control-plane/pkg/reconciler/kafka/client.go
@@ -51,3 +51,27 @@ func GetClusterAdminSaramaConfig(configOption ConfigOption) (*sarama.Config, err
 
 	return config, nil
 }
+
+// NewClientFunc creates new sarama.Client.
+type NewClientFunc func(addrs []string, config *sarama.Config) (sarama.Client, error)
+
+// TODO unify once the hardcoded config below is converted to an option
+
+// GetClientSaramaConfig returns Kafka Client configurations.
+func GetClientSaramaConfig(configOption ConfigOption) (*sarama.Config, error) {
+	config := sarama.NewConfig()
+	config.Version = sarama.MaxVersion
+
+	err := configOption(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: convert to option
+	// Manually commit the offsets in KafkaChannel controller.
+	// That's because we want to make sure we initialize the offsets within the controller
+	// before dispatcher actually starts consuming messages.
+	config.Consumer.Offsets.AutoCommit.Enable = false
+
+	return config, nil
+}

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -100,7 +100,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 		return fmt.Errorf("failed to track secret: %w", err)
 	}
 
-	saramaConfig, err := kafka.GetClusterAdminSaramaConfig(securityOption)
+	saramaConfig, err := kafka.GetSaramaConfig(securityOption)
 	if err != nil {
 		return fmt.Errorf("error getting cluster admin sarama config: %w", err)
 	}
@@ -286,7 +286,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, ks *eventing.KafkaSink) e
 		// get security option for Sarama with secret info in it
 		securityOption := security.NewSaramaSecurityOptionFromSecret(secret)
 
-		saramaConfig, err := kafka.GetClusterAdminSaramaConfig(securityOption)
+		saramaConfig, err := kafka.GetSaramaConfig(securityOption)
 		if err != nil {
 			// even in error case, we return `normal`, since we are fine with leaving the
 			// topic undeleted e.g. when we lose connection

--- a/control-plane/pkg/reconciler/source/source.go
+++ b/control-plane/pkg/reconciler/source/source.go
@@ -99,7 +99,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *sources.KafkaSource)
 		return fmt.Errorf("failed to track secrets: %w", err)
 	}
 
-	saramaConfig, err := kafka.GetClusterAdminSaramaConfig(securityOption)
+	saramaConfig, err := kafka.GetSaramaConfig(securityOption)
 	if err != nil {
 		return fmt.Errorf("error getting cluster admin sarama config: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/rickb777/date v1.14.1
 	github.com/stretchr/testify v1.7.0
 	github.com/xdg-go/scram v1.0.2
+	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.19.1
 	google.golang.org/protobuf v1.27.1
 	k8s.io/api v0.21.4

--- a/vendor/knative.dev/eventing-kafka/pkg/common/kafka/offset/offsets.go
+++ b/vendor/knative.dev/eventing-kafka/pkg/common/kafka/offset/offsets.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package offset
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Shopify/sarama"
+	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
+
+	knsarama "knative.dev/eventing-kafka/pkg/common/kafka/sarama"
+)
+
+// We want to make sure that ALL consumer group offsets are set before marking
+// the resource as ready, to avoid "losing" events in case the consumer group session
+// is closed before at least one message is consumed from ALL partitions.
+// Without InitOffsets, an event sent to a partition with an uninitialized offset
+// will not be forwarded when the session is closed (or a rebalancing is in progress).
+func InitOffsets(ctx context.Context, kafkaClient sarama.Client, kafkaAdminClient sarama.ClusterAdmin, topics []string, consumerGroup string) (int32, error) {
+	offsetManager, err := sarama.NewOffsetManagerFromClient(consumerGroup, kafkaClient)
+	if err != nil {
+		return -1, err
+	}
+
+	totalPartitions, topicPartitions, err := retrieveAllPartitions(topics, kafkaClient)
+	if err != nil {
+		return -1, err
+	}
+
+	// Fetch topic offsets
+	topicOffsets, err := knsarama.GetOffsets(kafkaClient, topicPartitions, sarama.OffsetNewest)
+	if err != nil {
+		return -1, fmt.Errorf("failed to get the topic offsets: %w", err)
+	}
+
+	// Look for uninitialized offset (-1)
+	offsets, err := kafkaAdminClient.ListConsumerGroupOffsets(consumerGroup, topicPartitions)
+	if err != nil {
+		return -1, err
+	}
+
+	dirty := false
+	for topic, partitions := range offsets.Blocks {
+		for partitionID, block := range partitions {
+			if block.Offset == -1 { // not initialized?
+				partitionsOffsets, ok := topicOffsets[topic]
+				if !ok {
+					// topic may have been deleted. ignore.
+					continue
+				}
+
+				offset, ok := partitionsOffsets[partitionID]
+				if !ok {
+					// partition may have been deleted. ignore.
+					continue
+				}
+
+				logging.FromContext(ctx).Infow("initializing offset", zap.String("topic", topic), zap.Int32("partition", partitionID), zap.Int64("offset", offset))
+
+				pm, err := offsetManager.ManagePartition(topic, partitionID)
+				if err != nil {
+					return -1, fmt.Errorf("failed to create the partition manager for topic %s and partition %d: %w", topic, partitionID, err)
+				}
+
+				pm.MarkOffset(offset, "")
+				dirty = true
+			}
+		}
+	}
+
+	if dirty {
+		offsetManager.Commit()
+		logging.FromContext(ctx).Infow("consumer group offsets committed", zap.String("consumergroup", consumerGroup))
+	}
+
+	// At this stage the resource is considered Ready
+	return int32(totalPartitions), nil
+
+}
+
+func CheckIfAllOffsetsInitialized(kafkaClient sarama.Client, kafkaAdminClient sarama.ClusterAdmin, topics []string, consumerGroup string) (bool, error) {
+	_, topicPartitions, err := retrieveAllPartitions(topics, kafkaClient)
+	if err != nil {
+		return false, err
+	}
+
+	// Look for uninitialized offset (-1)
+	offsets, err := kafkaAdminClient.ListConsumerGroupOffsets(consumerGroup, topicPartitions)
+	if err != nil {
+		return false, err
+	}
+
+	for _, partitions := range offsets.Blocks {
+		for _, block := range partitions {
+			if block.Offset == -1 { // not initialized?
+				return false, nil
+			}
+		}
+	}
+
+	return true, nil
+}
+
+func retrieveAllPartitions(topics []string, kafkaClient sarama.Client) (int, map[string][]int32, error) {
+	totalPartitions := 0
+
+	// Retrieve all partitions
+	topicPartitions := make(map[string][]int32)
+	for _, topic := range topics {
+		partitions, err := kafkaClient.Partitions(topic)
+		totalPartitions += len(partitions)
+		if err != nil {
+			return -1, nil, fmt.Errorf("failed to get partitions for topic %s: %w", topic, err)
+		}
+
+		// return a copy of the partitions array in the map
+		// Sarama is caching this array and we don't want nobody to mess with it
+		clone := make([]int32, len(partitions))
+		copy(clone, partitions)
+		topicPartitions[topic] = clone
+	}
+	return totalPartitions, topicPartitions, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -359,6 +359,7 @@ go.uber.org/automaxprocs/internal/cgroups
 go.uber.org/automaxprocs/internal/runtime
 go.uber.org/automaxprocs/maxprocs
 # go.uber.org/multierr v1.6.0
+## explicit
 go.uber.org/multierr
 # go.uber.org/zap v1.19.1
 ## explicit

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1187,6 +1187,7 @@ knative.dev/eventing-kafka/pkg/client/listers/sources/v1beta1
 knative.dev/eventing-kafka/pkg/common/client
 knative.dev/eventing-kafka/pkg/common/config
 knative.dev/eventing-kafka/pkg/common/constants
+knative.dev/eventing-kafka/pkg/common/kafka/offset
 knative.dev/eventing-kafka/pkg/common/kafka/sarama
 # knative.dev/hack v0.0.0-20211028194650-b96d65a5ff5e
 ## explicit


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Reconcile subscribers in the control plane
- Init offsets and mark subscriptions ready
- Data plane changes (the check to see if the offsets are initialized) are to be done in a separate PR. 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
