### PR TITLE
Add security provider for KafkaNetSpec

### DIFF
--- a/control-plane/pkg/security/secrets_provider_net_spec.go
+++ b/control-plane/pkg/security/secrets_provider_net_spec.go
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package security
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	bindings "knative.dev/eventing-kafka/pkg/apis/bindings/v1beta1"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
+)
+
+// NetSpecSecretProviderFunc creates a SecretProviderFunc that creates an in-memory (virtual) secret with the format
+// expected by the NewSaramaSecurityOptionFromSecret function.
+func NetSpecSecretProviderFunc(authContext *NetSpecAuthContext) SecretProviderFunc {
+	return func(_ context.Context, _, _ string) (*corev1.Secret, error) { return authContext.VirtualSecret, nil }
+}
+
+type NetSpecAuthContext struct {
+	VirtualSecret        *corev1.Secret
+	MultiSecretReference *contract.MultiSecretReference
+}
+
+// ResolveAuthContextFromNetSpec creates a NetSpecAuthContext from a provided bindings.KafkaNetSpec.
+func ResolveAuthContextFromNetSpec(lister corelisters.SecretLister, namespace string, netSpec bindings.KafkaNetSpec) (*NetSpecAuthContext, error) {
+	securityFields := []*securityField{
+		{ref: netSpec.TLS.Cert, field: contract.SecretField_USER_CRT, virtualSecretKey: UserCertificate},
+		{ref: netSpec.TLS.Key, field: contract.SecretField_USER_KEY, virtualSecretKey: UserKey},
+		{ref: netSpec.TLS.CACert, field: contract.SecretField_CA_CRT, virtualSecretKey: CaCertificateKey},
+		{ref: netSpec.SASL.Type, field: contract.SecretField_SASL_MECHANISM, virtualSecretKey: SaslMechanismKey},
+		{ref: netSpec.SASL.User, field: contract.SecretField_USER, virtualSecretKey: SaslUserKey},
+		{ref: netSpec.SASL.Password, field: contract.SecretField_PASSWORD, virtualSecretKey: SaslPasswordKey},
+	}
+	for _, b := range securityFields {
+		if err := b.resolveSecret(lister, namespace); err != nil {
+			return nil, err
+		}
+	}
+	references, virtualSecretData := toContract(securityFields)
+	multiSecretReference := &contract.MultiSecretReference{
+		Protocol:   getProtocolContractFromNetSpec(netSpec),
+		References: references,
+	}
+	virtualSecretData[ProtocolKey] = []byte(getProtocolFromNetSpec(netSpec))
+
+	authContext := &NetSpecAuthContext{
+		VirtualSecret:        &corev1.Secret{Data: virtualSecretData},
+		MultiSecretReference: multiSecretReference,
+	}
+	return authContext, nil
+}
+
+func toContract(securityFields []*securityField) ([]*contract.SecretReference, map[string][]byte) {
+	virtualSecretData := make(map[string][]byte)
+	bySecretName := make(map[string][]securityField)
+	for _, f := range securityFields {
+		if f.secret == nil || f.value == nil || len(f.value) == 0 {
+			continue
+		}
+		virtualSecretData[f.virtualSecretKey] = f.value
+		bySecretName[f.secret.Name] = append(bySecretName[f.secret.Name], *f)
+	}
+
+	refs := make([]*contract.SecretReference, 0, 6 /* max number of secrets */)
+	for secretName, securityFields := range bySecretName {
+		keyFieldReferences := make([]*contract.KeyFieldReference, 0, len(securityFields))
+		for _, f := range securityFields {
+			keyFieldReferences = append(keyFieldReferences, &contract.KeyFieldReference{
+				SecretKey: f.ref.SecretKeyRef.Key,
+				Field:     f.field,
+			})
+		}
+		any := securityFields[0]
+		refs = append(refs, &contract.SecretReference{
+			Reference: &contract.Reference{
+				Uuid:      string(any.secret.GetUID()),
+				Namespace: any.secret.GetNamespace(),
+				Name:      secretName,
+				Version:   any.secret.GetResourceVersion(),
+			},
+			KeyFieldReferences: keyFieldReferences,
+		})
+	}
+	return refs, virtualSecretData
+}
+
+type securityField struct {
+	ref              bindings.SecretValueFromSource
+	field            contract.SecretField
+	virtualSecretKey string
+
+	secret *corev1.Secret
+	value  []byte
+}
+
+func (b *securityField) resolveSecret(lister corelisters.SecretLister, namespace string) error {
+	value, secret, err := resolveSecret(lister, namespace, b.ref.SecretKeyRef)
+	if err != nil {
+		return err
+	}
+	b.value = value
+	b.secret = secret
+	return nil
+}
+
+func getProtocolFromNetSpec(netSpec bindings.KafkaNetSpec) string {
+	protocol := ProtocolPlaintext
+	if netSpec.SASL.Enable && netSpec.TLS.Enable {
+		protocol = ProtocolSASLSSL
+	} else if netSpec.SASL.Enable {
+		protocol = ProtocolSASLPlaintext
+	} else if netSpec.TLS.Enable {
+		protocol = ProtocolSSL
+	}
+	return protocol
+}
+
+func getProtocolContractFromNetSpec(netSpec bindings.KafkaNetSpec) contract.Protocol {
+	protocol := contract.Protocol_PLAINTEXT
+	if netSpec.SASL.Enable && netSpec.TLS.Enable {
+		protocol = contract.Protocol_SASL_SSL
+	} else if netSpec.SASL.Enable {
+		protocol = contract.Protocol_SASL_PLAINTEXT
+	} else if netSpec.TLS.Enable {
+		protocol = contract.Protocol_SSL
+	}
+	return protocol
+}
+
+// resolveSecret resolves the secret reference
+func resolveSecret(lister corelisters.SecretLister, ns string, ref *corev1.SecretKeySelector) ([]byte, *corev1.Secret, error) {
+	if ref == nil || ref.Name == "" {
+		return nil, nil, nil
+	}
+	secret, err := lister.Secrets(ns).Get(ref.Name)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read secret %s/%s: %w", ns, ref.Name, err)
+	}
+
+	value, ok := secret.Data[ref.Key]
+	if !ok || len(value) == 0 {
+		return nil, nil, fmt.Errorf("missing secret key or empty secret value (%s/%s.%s)", ns, ref.Name, ref.Key)
+	}
+	return value, secret, nil
+}

--- a/control-plane/pkg/security/secrets_provider_net_spec_test.go
+++ b/control-plane/pkg/security/secrets_provider_net_spec_test.go
@@ -1,0 +1,613 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package security
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	bindings "knative.dev/eventing-kafka/pkg/apis/bindings/v1beta1"
+	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
+	reconcilertesting "knative.dev/pkg/reconciler/testing"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
+)
+
+func TestResolveAuthContextFromNetSpec(t *testing.T) {
+	tests := []struct {
+		name                   string
+		secrets                []*corev1.Secret
+		namespace              string
+		netSpec                bindings.KafkaNetSpec
+		wantNetSpecAuthContext *NetSpecAuthContext
+		wantErr                bool
+	}{
+		{
+			name: "SASL_SSL - SCRAM-SHA-512",
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "user"},
+					StringData: map[string]string{"key": "key"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "password"},
+					StringData: map[string]string{"key": "key"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "type"},
+					StringData: map[string]string{"key": "SCRAM-SHA-512"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cert"},
+					StringData: map[string]string{"key": "key"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "key"},
+					StringData: map[string]string{"key": "key"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cacert"},
+					StringData: map[string]string{"key": "key"},
+				},
+			},
+			namespace: "ns",
+			netSpec: bindings.KafkaNetSpec{
+				SASL: bindings.KafkaSASLSpec{
+					Enable: true,
+					User: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "user"},
+							Key:                  "key",
+						},
+					},
+					Password: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "password"},
+							Key:                  "key",
+						},
+					},
+					Type: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "type"},
+							Key:                  "key",
+						},
+					},
+				},
+				TLS: bindings.KafkaTLSSpec{
+					Enable: true,
+					Cert: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "cert"},
+							Key:                  "key",
+						},
+					},
+					Key: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "key"},
+							Key:                  "key",
+						},
+					},
+					CACert: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "cacert"},
+							Key:                  "key",
+						},
+					},
+				},
+			},
+			wantNetSpecAuthContext: &NetSpecAuthContext{
+				VirtualSecret: &corev1.Secret{StringData: map[string]string{
+					ProtocolKey:      ProtocolSASLSSL,
+					CaCertificateKey: "key",
+					UserCertificate:  "key",
+					UserKey:          "key",
+					SaslMechanismKey: SaslScramSha512,
+					SaslUserKey:      "key",
+					SaslPasswordKey:  "key",
+				}},
+				MultiSecretReference: &contract.MultiSecretReference{
+					Protocol: contract.Protocol_SASL_SSL,
+					References: []*contract.SecretReference{
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "cert"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_USER_CRT},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "key"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_USER_KEY},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "cacert"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_CA_CRT},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "type"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_SASL_MECHANISM},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "user"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_USER},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "password"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_PASSWORD},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SASL_SSL - SCRAM-SHA-256",
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "user"},
+					StringData: map[string]string{"key": "key"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "password"},
+					StringData: map[string]string{"key": "key"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "type"},
+					StringData: map[string]string{"key": "SCRAM-SHA-256"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cert"},
+					StringData: map[string]string{"key": "key"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "key"},
+					StringData: map[string]string{"key": "key"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cacert"},
+					StringData: map[string]string{"key": "key"},
+				},
+			},
+			namespace: "ns",
+			netSpec: bindings.KafkaNetSpec{
+				SASL: bindings.KafkaSASLSpec{
+					Enable: true,
+					User: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "user"},
+							Key:                  "key",
+						},
+					},
+					Password: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "password"},
+							Key:                  "key",
+						},
+					},
+					Type: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "type"},
+							Key:                  "key",
+						},
+					},
+				},
+				TLS: bindings.KafkaTLSSpec{
+					Enable: true,
+					Cert: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "cert"},
+							Key:                  "key",
+						},
+					},
+					Key: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "key"},
+							Key:                  "key",
+						},
+					},
+					CACert: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "cacert"},
+							Key:                  "key",
+						},
+					},
+				},
+			},
+			wantNetSpecAuthContext: &NetSpecAuthContext{
+				VirtualSecret: &corev1.Secret{StringData: map[string]string{
+					ProtocolKey:      ProtocolSASLSSL,
+					CaCertificateKey: "key",
+					UserCertificate:  "key",
+					UserKey:          "key",
+					SaslMechanismKey: SaslScramSha256,
+					SaslUserKey:      "key",
+					SaslPasswordKey:  "key",
+				}},
+				MultiSecretReference: &contract.MultiSecretReference{
+					Protocol: contract.Protocol_SASL_SSL,
+					References: []*contract.SecretReference{
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "cert"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_USER_CRT},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "key"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_USER_KEY},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "cacert"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_CA_CRT},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "type"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_SASL_MECHANISM},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "user"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_USER},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "password"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_PASSWORD},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SSL",
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cert"},
+					StringData: map[string]string{"key": "key"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "key"},
+					StringData: map[string]string{"key": "key"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cacert"},
+					StringData: map[string]string{"key": "key"},
+				},
+			},
+			namespace: "ns",
+			netSpec: bindings.KafkaNetSpec{
+				TLS: bindings.KafkaTLSSpec{
+					Enable: true,
+					Cert: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "cert"},
+							Key:                  "key",
+						},
+					},
+					Key: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "key"},
+							Key:                  "key",
+						},
+					},
+					CACert: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "cacert"},
+							Key:                  "key",
+						},
+					},
+				},
+			},
+			wantNetSpecAuthContext: &NetSpecAuthContext{
+				VirtualSecret: &corev1.Secret{StringData: map[string]string{
+					ProtocolKey:      ProtocolSSL,
+					CaCertificateKey: "key",
+					UserCertificate:  "key",
+					UserKey:          "key",
+				}},
+				MultiSecretReference: &contract.MultiSecretReference{
+					Protocol: contract.Protocol_SSL,
+					References: []*contract.SecretReference{
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "cert"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_USER_CRT},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "key"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_USER_KEY},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "cacert"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_CA_CRT},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SSL - no CA",
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cert"},
+					StringData: map[string]string{"key": "key"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "key"},
+					StringData: map[string]string{"key": "key"},
+				},
+			},
+			namespace: "ns",
+			netSpec: bindings.KafkaNetSpec{
+				TLS: bindings.KafkaTLSSpec{
+					Enable: true,
+					Cert: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "cert"},
+							Key:                  "key",
+						},
+					},
+					Key: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "key"},
+							Key:                  "key",
+						},
+					},
+				},
+			},
+			wantNetSpecAuthContext: &NetSpecAuthContext{
+				VirtualSecret: &corev1.Secret{StringData: map[string]string{
+					ProtocolKey:     ProtocolSSL,
+					UserCertificate: "key",
+					UserKey:         "key",
+				}},
+				MultiSecretReference: &contract.MultiSecretReference{
+					Protocol: contract.Protocol_SSL,
+					References: []*contract.SecretReference{
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "cert"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_USER_CRT},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "key"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_USER_KEY},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SASL_PLAINTEXT - SCRAM-SHA-256",
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "user"},
+					StringData: map[string]string{"key": "key"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "password"},
+					StringData: map[string]string{"key": "key"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "type"},
+					StringData: map[string]string{"key": "SCRAM-SHA-256"},
+				},
+			},
+			namespace: "ns",
+			netSpec: bindings.KafkaNetSpec{
+				SASL: bindings.KafkaSASLSpec{
+					Enable: true,
+					User: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "user"},
+							Key:                  "key",
+						},
+					},
+					Password: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "password"},
+							Key:                  "key",
+						},
+					},
+					Type: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "type"},
+							Key:                  "key",
+						},
+					},
+				},
+			},
+			wantNetSpecAuthContext: &NetSpecAuthContext{
+				VirtualSecret: &corev1.Secret{StringData: map[string]string{
+					ProtocolKey:      ProtocolSASLPlaintext,
+					SaslMechanismKey: SaslScramSha256,
+					SaslUserKey:      "key",
+					SaslPasswordKey:  "key",
+				}},
+				MultiSecretReference: &contract.MultiSecretReference{
+					Protocol: contract.Protocol_SASL_PLAINTEXT,
+					References: []*contract.SecretReference{
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "type"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_SASL_MECHANISM},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "user"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_USER},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "password"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_PASSWORD},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SASL_PLAINTEXT - SCRAM-SHA-512",
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "user"},
+					StringData: map[string]string{"key": "key"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "password"},
+					StringData: map[string]string{"key": "key"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "type"},
+					StringData: map[string]string{"key": "SCRAM-SHA-512"},
+				},
+			},
+			namespace: "ns",
+			netSpec: bindings.KafkaNetSpec{
+				SASL: bindings.KafkaSASLSpec{
+					Enable: true,
+					User: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "user"},
+							Key:                  "key",
+						},
+					},
+					Password: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "password"},
+							Key:                  "key",
+						},
+					},
+					Type: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "type"},
+							Key:                  "key",
+						},
+					},
+				},
+			},
+			wantNetSpecAuthContext: &NetSpecAuthContext{
+				VirtualSecret: &corev1.Secret{StringData: map[string]string{
+					ProtocolKey:      ProtocolSASLPlaintext,
+					SaslMechanismKey: SaslScramSha512,
+					SaslUserKey:      "key",
+					SaslPasswordKey:  "key",
+				}},
+				MultiSecretReference: &contract.MultiSecretReference{
+					Protocol: contract.Protocol_SASL_PLAINTEXT,
+					References: []*contract.SecretReference{
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "type"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_SASL_MECHANISM},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "user"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_USER},
+							},
+						},
+						{
+							Reference: &contract.Reference{Namespace: "ns", Name: "password"},
+							KeyFieldReferences: []*contract.KeyFieldReference{
+								{SecretKey: "key", Field: contract.SecretField_PASSWORD},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := reconcilertesting.SetupFakeContext(t)
+			lister := secretinformer.Get(ctx)
+			for _, s := range tt.secrets {
+				cp := copySecretDataToData(s)
+				_ = lister.Informer().GetStore().Add(cp)
+			}
+
+			got, err := ResolveAuthContextFromNetSpec(lister.Lister(), tt.namespace, tt.netSpec)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			wantSecret := copySecretDataToData(tt.wantNetSpecAuthContext.VirtualSecret)
+			wantSecret.StringData = nil
+			tt.wantNetSpecAuthContext.VirtualSecret = wantSecret
+
+			if diff := cmp.Diff(tt.wantNetSpecAuthContext.VirtualSecret, got.VirtualSecret); diff != "" {
+				t.Error("(-want, +got)", diff)
+			}
+			wantMS := tt.wantNetSpecAuthContext.MultiSecretReference
+			sort.Slice(wantMS.References, func(i, j int) bool {
+				return strings.Compare(wantMS.References[i].Reference.Name, wantMS.References[j].Reference.Name) < 0
+			})
+			gotMS := got.MultiSecretReference
+			sort.Slice(gotMS.References, func(i, j int) bool {
+				return strings.Compare(gotMS.References[i].Reference.Name, gotMS.References[j].Reference.Name) < 0
+			})
+			if diff := cmp.Diff(wantMS, gotMS, protocmp.Transform()); diff != "" {
+				t.Error("(-want, +got)", diff)
+			}
+		})
+	}
+}
+
+func copySecretDataToData(s *corev1.Secret) *corev1.Secret {
+	cp := s.DeepCopy()
+	if cp.Data == nil {
+		cp.Data = map[string][]byte{}
+	}
+	for k, v := range cp.StringData {
+		cp.Data[k] = []byte(v)
+	}
+	return cp
+}

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KubernetesAuthProvider.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KubernetesAuthProvider.java
@@ -104,8 +104,7 @@ class KubernetesAuthProvider implements AuthProvider {
     return kubernetesClient.secrets()
       .inNamespace(secretReference.getNamespace())
       .withName(secretReference.getName())
-      .withResourceVersion(secretReference.getVersion())
-      .waitUntilReady(5, TimeUnit.SECONDS);
+      .get();
   }
 
   private static String protocolContractToSecurityProtocol(final DataPlaneContract.Protocol protocol) {


### PR DESCRIPTION
This PR adds a `SecurityProviderFunc` for `KafkaNetSpec` (the type
that holds references to secrets and their keys)

To avoid resolving secrets in 2 different places, I'm creating a
struct `NetSpecAuthContext` to hold the authentication context
that we need.
`NetSpecAuthContext` holds a `VirtualSecret` which is a non-existing
secret (in-memory only) so that we can reuse the existing security logic
that we have for Broker and KafkaSink and `MultiSecretReference` which
is what the contract expects.

Part of #312

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add security provider for KafkaNetSpec

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
None
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```
