### PR TITLE
Add secret tracker for KafkaNetSpec

### DIFF
--- a/control-plane/pkg/reconciler/source/source.go
+++ b/control-plane/pkg/reconciler/source/source.go
@@ -88,20 +88,12 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *sources.KafkaSource)
 	if err != nil {
 		return fmt.Errorf("failed to get secret: %w", err)
 	}
-	if secret != nil {
-		logger.Debug("Secret reference",
-			zap.String("apiVersion", secret.APIVersion),
-			zap.String("name", secret.Name),
-			zap.String("namespace", secret.Namespace),
-			zap.String("kind", secret.Kind),
-		)
-	}
 
 	// get security option for Sarama with secret info in it
 	securityOption := security.NewSaramaSecurityOptionFromSecret(secret)
 
-	if err := r.TrackSecret(secret, ks); err != nil {
-		return fmt.Errorf("failed to track secret: %w", err)
+	if err := security.TrackNetSpecSecrets(r.SecretTracker, ks.Spec.Net, ks); err != nil {
+		return fmt.Errorf("failed to track secrets: %w", err)
 	}
 
 	saramaConfig, err := kafka.GetClusterAdminSaramaConfig(securityOption)

--- a/control-plane/pkg/security/secrets_tracker.go
+++ b/control-plane/pkg/security/secrets_tracker.go
@@ -39,7 +39,7 @@ func TrackNetSpecSecrets(secretsTracker tracker.Interface, netSpec bindings.Kafk
 				APIVersion: "v1",
 				Kind:       "Secret",
 				Namespace:  parent.GetNamespace(),
-				Name:       parent.GetName(),
+				Name:       s.SecretKeyRef.Name,
 			}
 			if err := secretsTracker.TrackReference(ref, parent); err != nil {
 				return err

--- a/control-plane/pkg/security/secrets_tracker.go
+++ b/control-plane/pkg/security/secrets_tracker.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package security
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	bindings "knative.dev/eventing-kafka/pkg/apis/bindings/v1beta1"
+	"knative.dev/pkg/tracker"
+)
+
+// TrackNetSpecSecrets tracks all secrets referenced by a provided bindings.KafkaNetSpec.
+// parent is the object that is tracking changes to those secrets.
+func TrackNetSpecSecrets(secretsTracker tracker.Interface, netSpec bindings.KafkaNetSpec, parent metav1.Object) error {
+	secrets := []bindings.SecretValueFromSource{
+		netSpec.TLS.Key,
+		netSpec.TLS.Cert,
+		netSpec.TLS.CACert,
+		netSpec.SASL.Password,
+		netSpec.SASL.User,
+		netSpec.SASL.Type,
+	}
+	for _, s := range secrets {
+		if s.SecretKeyRef != nil && s.SecretKeyRef.Name != "" {
+			ref := tracker.Reference{
+				APIVersion: "v1",
+				Kind:       "Secret",
+				Namespace:  parent.GetNamespace(),
+				Name:       parent.GetName(),
+			}
+			if err := secretsTracker.TrackReference(ref, parent); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/control-plane/pkg/security/secrets_tracker_test.go
+++ b/control-plane/pkg/security/secrets_tracker_test.go
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package security
+
+import (
+	"io"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	bindings "knative.dev/eventing-kafka/pkg/apis/bindings/v1beta1"
+	sources "knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
+	"knative.dev/pkg/tracker"
+)
+
+func TestTrackNetSpecSecrets(t *testing.T) {
+	tests := []struct {
+		name                        string
+		secretsTracker              *mockTracker
+		netSpec                     bindings.KafkaNetSpec
+		expectedTrackReferenceCalls int
+		parent                      metav1.Object
+		wantErr                     bool
+	}{
+		{
+			name:           "track all",
+			secretsTracker: &mockTracker{},
+			parent: &sources.KafkaSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "s",
+					Namespace: "ns",
+				},
+			},
+			netSpec: bindings.KafkaNetSpec{
+				SASL: bindings.KafkaSASLSpec{
+					Enable: true,
+					User: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "user"},
+							Key:                  "key",
+						},
+					},
+					Password: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "password"},
+							Key:                  "key",
+						},
+					},
+					Type: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "type"},
+							Key:                  "key",
+						},
+					},
+				},
+				TLS: bindings.KafkaTLSSpec{
+					Enable: true,
+					Cert: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "cert"},
+							Key:                  "key",
+						},
+					},
+					Key: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "key"},
+							Key:                  "key",
+						},
+					},
+					CACert: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "cacert"},
+							Key:                  "key",
+						},
+					},
+				},
+			},
+			expectedTrackReferenceCalls: 6,
+			wantErr:                     false,
+		},
+		{
+			name:           "track error",
+			secretsTracker: &mockTracker{trackReferenceErr: io.EOF},
+			parent: &sources.KafkaSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "s",
+					Namespace: "ns",
+				},
+			},
+			netSpec: bindings.KafkaNetSpec{
+				SASL: bindings.KafkaSASLSpec{
+					Enable: true,
+					User: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "user"},
+							Key:                  "key",
+						},
+					},
+					Password: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "password"},
+							Key:                  "key",
+						},
+					},
+					Type: bindings.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "type"},
+							Key:                  "key",
+						},
+					},
+				},
+			},
+			expectedTrackReferenceCalls: 1,
+			wantErr:                     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := TrackNetSpecSecrets(tt.secretsTracker, tt.netSpec, tt.parent); (err != nil) != tt.wantErr {
+				t.Errorf("TrackNetSpecSecrets() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.secretsTracker.trackReferenceCalls != tt.expectedTrackReferenceCalls {
+				t.Errorf("Expected %d calls to TrackReference, got %d", tt.expectedTrackReferenceCalls, tt.secretsTracker.trackReferenceCalls)
+			}
+		})
+	}
+}
+
+type mockTracker struct {
+	trackReferenceCalls int
+	trackReferenceErr   error
+}
+
+func (m mockTracker) Track(corev1.ObjectReference, interface{}) error {
+	panic("implement me")
+}
+
+func (m *mockTracker) TrackReference(tracker.Reference, interface{}) error {
+	m.trackReferenceCalls++
+	return m.trackReferenceErr
+}
+
+func (m mockTracker) OnChanged(interface{}) {
+	panic("implement me")
+}
+
+func (m mockTracker) GetObservers(interface{}) []types.NamespacedName {
+	panic("implement me")
+}
+
+func (m mockTracker) OnDeletedObserver(interface{}) {
+	panic("implement me")
+}


### PR DESCRIPTION
This PR adds a function `TrackNetSpecSecrets` that contains the
logic to track secrets referenced by a `KafkaNetSpec` (the type
that is embedded in `KafkaSource` and has all the secret
references)

Part of #312

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add secret tracker for KafkaNetSpec

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
None
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```
