### PR TITLE
Remove egresses copy when comparing resources for change detection

### DIFF
--- a/control-plane/pkg/core/config/resource.go
+++ b/control-plane/pkg/core/config/resource.go
@@ -46,6 +46,12 @@ const (
 	ResourceUnchanged
 )
 
+func SetResourceEgressesFromContract(contract *contract.Contract, resource *contract.Resource, index int) {
+	if index != NoResource {
+		resource.Egresses = contract.Resources[index].Egresses
+	}
+}
+
 // AddOrUpdateResourceConfig adds or updates the given resourceConfig to the given resources at the specified index.
 func AddOrUpdateResourceConfig(contract *contract.Contract, resource *contract.Resource, index int, logger *zap.Logger) int {
 
@@ -53,7 +59,6 @@ func AddOrUpdateResourceConfig(contract *contract.Contract, resource *contract.R
 		logger.Debug("Resource exists", zap.Int("index", index))
 
 		prev := contract.Resources[index]
-		resource.Egresses = contract.Resources[index].Egresses
 		contract.Resources[index] = resource
 
 		if proto.Equal(prev, resource) {

--- a/control-plane/pkg/core/config/resource_test.go
+++ b/control-plane/pkg/core/config/resource_test.go
@@ -233,7 +233,7 @@ func TestAddOrUpdateResourcesConfig(t *testing.T) {
 					{
 						Filter: &contract.Filter{
 							Attributes: map[string]string{
-								"source": "source2",
+								"source": "source1",
 							},
 						},
 						Destination:   "http://localhost:8080",
@@ -485,6 +485,32 @@ func TestDeleteResource(t *testing.T) {
 			DeleteResource(tests[i].ct, tests[i].index)
 
 			assert.Equal(t, tests[i].ct, &tests[i].want)
+		})
+	}
+}
+
+func TestSetResourceEgressesFromContract(t *testing.T) {
+	tests := []struct {
+		name         string
+		contract     *contract.Contract
+		resource     *contract.Resource
+		wantResource *contract.Resource
+		index        int
+	}{
+		{
+			name:         "copy egresses",
+			contract:     &contract.Contract{Resources: []*contract.Resource{{Uid: "aaa", Egresses: []*contract.Egress{{Uid: "bbb"}}}}},
+			resource:     &contract.Resource{Uid: "aaa"},
+			wantResource: &contract.Resource{Uid: "aaa", Egresses: []*contract.Egress{{Uid: "bbb"}}},
+			index:        0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetResourceEgressesFromContract(tt.contract, tt.resource, tt.index)
+			if diff := cmp.Diff(tt.wantResource, tt.resource, protocmp.Transform()); diff != "" {
+				t.Error("(-want, +got)", diff)
+			}
 		})
 	}
 }

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -171,6 +171,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 
 	brokerIndex := coreconfig.FindResource(ct, broker.UID)
 	// Update contract data with the new contract configuration
+	coreconfig.SetResourceEgressesFromContract(ct, brokerResource, brokerIndex)
 	changed := coreconfig.AddOrUpdateResourceConfig(ct, brokerResource, brokerIndex, logger)
 
 	logger.Debug("Change detector", zap.Int("changed", changed))

--- a/control-plane/pkg/reconciler/source/source.go
+++ b/control-plane/pkg/reconciler/source/source.go
@@ -141,9 +141,9 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *sources.KafkaSource)
 		return statusConditionManager.FailedToGetConfig(err)
 	}
 
-	brokerIndex := coreconfig.FindResource(ct, ks.GetUID())
+	sourceIndex := coreconfig.FindResource(ct, ks.GetUID())
 	// Update contract data with the new contract configuration
-	changed := coreconfig.AddOrUpdateResourceConfig(ct, resource, brokerIndex, logger)
+	changed := coreconfig.AddOrUpdateResourceConfig(ct, resource, sourceIndex, logger)
 
 	logger.Debug("Change detector", zap.Int("changed", changed))
 


### PR DESCRIPTION
The assumption that `contract.resources[*].egreeses` don't change
when we update a resource in the contract is not true anymore
(and it is not really needed for most of our resources,
only Broker needs that),
so removing the copy.

Part of #312

## Proposed Changes

- Remove egresses copy when comparing resources

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
None
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```
