### PR TITLE
Add probes cache

### DIFF
--- a/control-plane/pkg/prober/cache.go
+++ b/control-plane/pkg/prober/cache.go
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prober
+
+import (
+	"container/list"
+	"context"
+	"sync"
+	"time"
+)
+
+const (
+	// StatusReady signals that a given object is ready.
+	StatusReady Status = iota
+	// StatusUnknown signals that a given object is not ready and its state is unknown.
+	StatusUnknown
+	// StatusNotReady signals that a given object is not ready.
+	StatusNotReady
+)
+
+// Status represents the resource status.
+type Status int
+
+// Cache is a key-status store.
+type Cache interface {
+	// GetStatus retries the status associated with the given key.
+	GetStatus(key string) Status
+	// UpsertStatus add or updates the status associated with the given key.
+	// Once the given key expires the onExpired callback will be called passing the arg parameter.
+	UpsertStatus(key string, status Status, arg interface{}, onExpired ExpiredFunc)
+}
+
+// ExpiredFunc is a callback called once an entry in the cache is expired.
+type ExpiredFunc func(key string, arg interface{})
+
+type inMemoryLocalCache struct {
+	// mu protects targets and entries
+	mu sync.RWMutex
+	// targets is a map of key-pointer to an element in the entries list.
+	targets map[string]*list.Element
+	// entries is a doubly-linked list of all entries present in the cache.
+	// This allows fast deletion of expired entries.
+	entries *list.List
+
+	expireDuration time.Duration
+}
+
+type value struct {
+	status     Status
+	lastUpsert time.Time
+	key        string
+	arg        interface{}
+	onExpired  ExpiredFunc
+}
+
+func NewInMemoryLocalCache(ctx context.Context, expireDuration time.Duration) Cache {
+	c := &inMemoryLocalCache{
+		mu:             sync.RWMutex{},
+		targets:        make(map[string]*list.Element, 64),
+		entries:        list.New().Init(),
+		expireDuration: expireDuration,
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(expireDuration):
+				c.removeExpiredEntries(time.Now())
+			}
+		}
+	}()
+	return c
+}
+
+func (c *inMemoryLocalCache) GetStatus(key string) Status {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if v, ok := c.targets[key]; ok {
+		value := v.Value.(*value)
+		if !c.isExpired(value, time.Now()) {
+			return value.status
+		}
+	}
+	return StatusUnknown
+}
+
+func (c *inMemoryLocalCache) UpsertStatus(key string, status Status, arg interface{}, onExpired ExpiredFunc) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if v, ok := c.targets[key]; ok {
+		delete(c.targets, key)
+		c.entries.Remove(v)
+	}
+
+	value := &value{status: status, lastUpsert: time.Now(), key: key, arg: arg, onExpired: onExpired}
+	element := c.entries.PushBack(value)
+	c.targets[key] = element
+}
+
+func (c *inMemoryLocalCache) removeExpiredEntries(now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for curr := c.entries.Front(); curr != nil && c.isExpired(curr.Value.(*value), now); {
+		v := curr.Value.(*value)
+		delete(c.targets, v.key)
+		prev := curr
+		curr = curr.Next()
+		c.entries.Remove(prev)
+
+		v.onExpired(v.key, v.arg)
+	}
+}
+
+func (c *inMemoryLocalCache) isExpired(v *value, now time.Time) bool {
+	return v.lastUpsert.Add(c.expireDuration).Before(now)
+}

--- a/control-plane/pkg/prober/cache_test.go
+++ b/control-plane/pkg/prober/cache_test.go
@@ -31,7 +31,7 @@ func TestInMemoryLocalCache(t *testing.T) {
 	d := time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), d*2)
 	defer cancel()
-	c := NewInMemoryLocalCache(ctx, d)
+	c := NewLocalExpiringCache(ctx, d)
 	testCache(t, ctx, c, d)
 }
 

--- a/control-plane/pkg/prober/cache_test.go
+++ b/control-plane/pkg/prober/cache_test.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prober
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func TestInMemoryLocalCache(t *testing.T) {
+	d := time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), d*2)
+	defer cancel()
+	c := NewInMemoryLocalCache(ctx, d)
+	testCache(t, ctx, c, d)
+}
+
+func testCache(t *testing.T, ctx context.Context, c Cache, d time.Duration) {
+	var wg sync.WaitGroup
+	errors := make(chan error, 1)
+
+	wg.Add(2)
+
+	c.UpsertStatus("key1", StatusUnknown, 4, verifyNoExpired(errors))
+	require.Equal(t, StatusUnknown, c.GetStatus("key1"))
+
+	c.UpsertStatus("key2", StatusNotReady, 42, verifyNoExpired(errors))
+	require.Equal(t, StatusNotReady, c.GetStatus("key2"))
+
+	c.UpsertStatus("key1", StatusReady, 41, verifyOnExpired("key1", 41, &wg, errors))
+	require.Equal(t, StatusReady, c.GetStatus("key1"))
+
+	c.UpsertStatus("key2", StatusReady, 43, verifyOnExpired("key2", 43, &wg, errors))
+	require.Equal(t, StatusReady, c.GetStatus("key2"))
+
+	ctx, cancel := context.WithTimeout(ctx, d*2)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-ctx.Done():
+		t.Errorf("Timeout waiting for wait group to be done")
+	case err := <-errors:
+		t.Errorf(err.Error())
+	case <-done:
+		// Wait expiration
+		require.Nil(t, wait.PollImmediate(d, d*2, func() (done bool, err error) { return StatusUnknown == c.GetStatus("key1"), nil }))
+		require.Nil(t, wait.PollImmediate(d, d*2, func() (done bool, err error) { return StatusUnknown == c.GetStatus("key2"), nil }))
+	}
+}
+
+func verifyNoExpired(errors chan<- error) func(key string, arg interface{}) {
+	return func(key string, arg interface{}) {
+		errors <- fmt.Errorf("unexpected call to onExpired callback")
+	}
+}
+
+func verifyOnExpired(expectedKey string, expectedArg interface{}, wg *sync.WaitGroup, errors chan<- error) func(key string, arg interface{}) {
+	return func(key string, arg interface{}) {
+		if expectedKey != key {
+			errors <- fmt.Errorf("expected key to be %v got %v", expectedKey, key)
+		}
+		if expectedArg != arg {
+			errors <- fmt.Errorf("expected arg for key %v to be %v got %v", key, expectedArg, arg)
+		}
+		wg.Done()
+	}
+}


### PR DESCRIPTION
This patch adds a probe cache that allows to associate a `Status`
to a given key.

The cache prunes expired entries and calls a callback when
an entry is expired, so that controllers can re-queue associated
resources.

This is part of our work to reduce e2e tests' flakiness.

## Proposed Changes

- Add probes cache

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
None
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```
