### PR TITLE
Remove unicode control characters in Strimzi operator YAML

### DIFF
--- a/test/kafka/strimzi-cluster-operator.yaml
+++ b/test/kafka/strimzi-cluster-operator.yaml
@@ -11094,7 +11094,7 @@ spec:
               bootstrapServers:
                 type: string
                 description: Bootstrap servers to connect to. This should be given
-                  as a comma separated list of _<hostname>_:‍_<port>_ pairs.
+                  as a comma separated list of _<hostname>_:_<port>_ pairs.
               tls:
                 type: object
                 properties:
@@ -12984,7 +12984,7 @@ spec:
               bootstrapServers:
                 type: string
                 description: Bootstrap servers to connect to. This should be given
-                  as a comma separated list of _<hostname>_:‍_<port>_ pairs.
+                  as a comma separated list of _<hostname>_:_<port>_ pairs.
               tls:
                 type: object
                 properties:


### PR DESCRIPTION
The diff won't make sense but there is a non-visible character in
between `_<hostname>_:` and `_<port>_`.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove unicode control characters in Strimzi operator YAML

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
None
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```