### PR TITLE
Better naming and consistency for config.Env and broker.Config

### DIFF
--- a/control-plane/cmd/kafka-controller/main.go
+++ b/control-plane/cmd/kafka-controller/main.go
@@ -57,7 +57,7 @@ func main() {
 
 		// Broker controller
 		func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
-			return broker.NewController(ctx, watcher, &broker.Configs{Env: *brokerEnv})
+			return broker.NewController(ctx, watcher, brokerEnv, "")
 		},
 
 		// Trigger controller

--- a/control-plane/pkg/reconciler/base/receiver_condition_set.go
+++ b/control-plane/pkg/reconciler/base/receiver_condition_set.go
@@ -74,7 +74,8 @@ type StatusConditionManager struct {
 
 	SetAddress func(u *apis.URL)
 
-	Configs *config.Env
+	Env              *config.Env
+	BootstrapServers string
 
 	Recorder record.EventRecorder
 }
@@ -100,13 +101,13 @@ func (manager *StatusConditionManager) FailedToGetConfigMap(err error) reconcile
 		ConditionConfigMapUpdated,
 		fmt.Sprintf(
 			"Failed to get ConfigMap: %s",
-			manager.Configs.DataPlaneConfigMapAsString(),
+			manager.Env.DataPlaneConfigMapAsString(),
 		),
 		"%v",
 		err,
 	)
 
-	return fmt.Errorf("failed to get contract config map %s: %w", manager.Configs.DataPlaneConfigMapAsString(), err)
+	return fmt.Errorf("failed to get contract config map %s: %w", manager.Env.DataPlaneConfigMapAsString(), err)
 }
 
 func (manager *StatusConditionManager) FailedToGetDataFromConfigMap(err error) reconciler.Event {
@@ -115,32 +116,32 @@ func (manager *StatusConditionManager) FailedToGetDataFromConfigMap(err error) r
 		ConditionConfigMapUpdated,
 		fmt.Sprintf(
 			"Failed to get contract data from ConfigMap: %s",
-			manager.Configs.DataPlaneConfigMapAsString(),
+			manager.Env.DataPlaneConfigMapAsString(),
 		),
 		"%v",
 		err,
 	)
 
-	return fmt.Errorf("failed to get broker and triggers data from config map %s: %w", manager.Configs.DataPlaneConfigMapAsString(), err)
+	return fmt.Errorf("failed to get broker and triggers data from config map %s: %w", manager.Env.DataPlaneConfigMapAsString(), err)
 }
 
 func (manager *StatusConditionManager) FailedToUpdateConfigMap(err error) reconciler.Event {
 
 	manager.Object.GetConditionSet().Manage(manager.Object.GetStatus()).MarkFalse(
 		ConditionConfigMapUpdated,
-		fmt.Sprintf("Failed to update ConfigMap: %s", manager.Configs.DataPlaneConfigMapAsString()),
+		fmt.Sprintf("Failed to update ConfigMap: %s", manager.Env.DataPlaneConfigMapAsString()),
 		"%s",
 		err,
 	)
 
-	return fmt.Errorf("failed to update contract config map %s: %w", manager.Configs.DataPlaneConfigMapAsString(), err)
+	return fmt.Errorf("failed to update contract config map %s: %w", manager.Env.DataPlaneConfigMapAsString(), err)
 }
 
 func (manager *StatusConditionManager) ConfigMapUpdated() {
 
 	manager.Object.GetConditionSet().Manage(manager.Object.GetStatus()).MarkTrueWithReason(
 		ConditionConfigMapUpdated,
-		fmt.Sprintf("Config map %s updated", manager.Configs.DataPlaneConfigMapAsString()),
+		fmt.Sprintf("Config map %s updated", manager.Env.DataPlaneConfigMapAsString()),
 		"",
 	)
 }
@@ -183,7 +184,7 @@ func (manager *StatusConditionManager) Reconciled() reconciler.Event {
 
 		manager.SetAddress(&apis.URL{
 			Scheme: "http",
-			Host:   network.GetServiceHostname(manager.Configs.IngressName, manager.Configs.SystemNamespace),
+			Host:   network.GetServiceHostname(manager.Env.IngressName, manager.Env.SystemNamespace),
 			Path:   fmt.Sprintf("/%s/%s", object.GetNamespace(), object.GetName()),
 		})
 		object.GetConditionSet().Manage(object.GetStatus()).MarkTrue(ConditionAddressable)

--- a/control-plane/pkg/reconciler/broker/controller_test.go
+++ b/control-plane/pkg/reconciler/broker/controller_test.go
@@ -40,19 +40,17 @@ import (
 func TestNewController(t *testing.T) {
 	ctx, _ := reconcilertesting.SetupFakeContext(t)
 
-	configs := &Configs{
-		Env: config.Env{
-			SystemNamespace:      "cm",
-			GeneralConfigMapName: "cm",
-		},
+	env := &config.Env{
+		SystemNamespace:      "cm",
+		GeneralConfigMapName: "cm",
 	}
 
 	ctx, _ = fakekubeclient.With(
 		ctx,
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configs.Env.GeneralConfigMapName,
-				Namespace: configs.Env.SystemNamespace,
+				Name:      env.GeneralConfigMapName,
+				Namespace: env.SystemNamespace,
 			},
 		},
 	)
@@ -68,7 +66,8 @@ func TestNewController(t *testing.T) {
 				Name: "cm",
 			},
 		}),
-		configs,
+		env,
+		"",
 	)
 	if controller == nil {
 		t.Error("failed to create controller: <nil>")

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -57,6 +57,7 @@ const (
 
 type Reconciler struct {
 	*base.Reconciler
+	*config.Env
 
 	Resolver *resolver.URIResolver
 
@@ -69,8 +70,6 @@ type Reconciler struct {
 	NewKafkaClient kafka.NewClientFunc
 
 	ConfigMapLister corelisters.ConfigMapLister
-
-	Configs *config.Env
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, channel *messagingv1beta1.KafkaChannel) reconciler.Event {
@@ -85,7 +84,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 	statusConditionManager := base.StatusConditionManager{
 		Object:     channel,
 		SetAddress: channel.Status.SetAddress,
-		Env:        r.Configs,
+		Env:        r.Env,
 		Recorder:   controller.GetEventRecorder(ctx),
 	}
 
@@ -273,7 +272,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 	// Get contract config map.
 	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get contract config map %s: %w", r.Configs.DataPlaneConfigMapAsString(), err)
+		return fmt.Errorf("failed to get contract config map %s: %w", r.DataPlaneConfigMapAsString(), err)
 	}
 	logger.Debug("Got contract config map")
 
@@ -451,11 +450,11 @@ func (r *Reconciler) getSubscriberConfig(ctx context.Context, channel *messaging
 		Uid:           string(subscriber.UID),
 	}
 
-	subscriptionEgressConfig, err := coreconfig.EgressConfigFromDelivery(ctx, r.Resolver, channel, subscriber.Delivery, r.Configs.DefaultBackoffDelayMs)
+	subscriptionEgressConfig, err := coreconfig.EgressConfigFromDelivery(ctx, r.Resolver, channel, subscriber.Delivery, r.DefaultBackoffDelayMs)
 	if err != nil {
 		return nil, err
 	}
-	channelEgressConfig, err := coreconfig.EgressConfigFromDelivery(ctx, r.Resolver, channel, channel.Spec.Delivery, r.Configs.DefaultBackoffDelayMs)
+	channelEgressConfig, err := coreconfig.EgressConfigFromDelivery(ctx, r.Resolver, channel, channel.Spec.Delivery, r.DefaultBackoffDelayMs)
 	if err != nil {
 		return nil, err
 	}
@@ -527,7 +526,7 @@ func (r *Reconciler) getChannelContractResource(ctx context.Context, topic strin
 		}
 	}
 
-	egressConfig, err := coreconfig.EgressConfigFromDelivery(ctx, r.Resolver, channel, channel.Spec.Delivery, r.Configs.DefaultBackoffDelayMs)
+	egressConfig, err := coreconfig.EgressConfigFromDelivery(ctx, r.Resolver, channel, channel.Spec.Delivery, r.DefaultBackoffDelayMs)
 	if err != nil {
 		return nil, err
 	}

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -85,7 +85,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 	statusConditionManager := base.StatusConditionManager{
 		Object:     channel,
 		SetAddress: channel.Status.SetAddress,
-		Configs:    r.Configs,
+		Env:        r.Configs,
 		Recorder:   controller.GetEventRecorder(ctx),
 	}
 

--- a/control-plane/pkg/reconciler/channel/controller.go
+++ b/control-plane/pkg/reconciler/channel/controller.go
@@ -62,7 +62,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher, configs *conf
 		},
 		NewKafkaClient:             sarama.NewClient,
 		NewKafkaClusterAdminClient: sarama.NewClusterAdmin,
-		Configs:                    configs,
+		Env:                        configs,
 		ConfigMapLister:            configmapInformer.Lister(),
 	}
 

--- a/control-plane/pkg/reconciler/sink/controller.go
+++ b/control-plane/pkg/reconciler/sink/controller.go
@@ -60,7 +60,7 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 		},
 		ConfigMapLister:            configmapInformer.Lister(),
 		NewKafkaClusterAdminClient: sarama.NewClusterAdmin,
-		Configs:                    configs,
+		Env:                        configs,
 	}
 
 	_, err := reconciler.GetOrCreateDataPlaneConfigMap(ctx)

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -45,14 +45,13 @@ const (
 
 type Reconciler struct {
 	*base.Reconciler
+	*config.Env
 
 	ConfigMapLister corelisters.ConfigMapLister
 
 	// NewKafkaClusterAdminClient creates new sarama ClusterAdmin. It's convenient to add this as Reconciler field so that we can
 	// mock the function used during the reconciliation loop.
 	NewKafkaClusterAdminClient kafka.NewClusterAdminClientFunc
-
-	Env *config.Env
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, ks *eventing.KafkaSink) reconciler.Event {
@@ -232,7 +231,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, ks *eventing.KafkaSink) e
 	// Get contract config map.
 	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get contract config map %s: %w", r.Env.DataPlaneConfigMapAsString(), err)
+		return fmt.Errorf("failed to get contract config map %s: %w", r.DataPlaneConfigMapAsString(), err)
 	}
 
 	logger.Debug("Got contract config map")

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -52,7 +52,7 @@ type Reconciler struct {
 	// mock the function used during the reconciliation loop.
 	NewKafkaClusterAdminClient kafka.NewClusterAdminClientFunc
 
-	Configs *config.Env
+	Env *config.Env
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, ks *eventing.KafkaSink) reconciler.Event {
@@ -67,7 +67,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 	statusConditionManager := base.StatusConditionManager{
 		Object:     ks,
 		SetAddress: ks.Status.SetAddress,
-		Configs:    r.Configs,
+		Env:        r.Env,
 		Recorder:   controller.GetEventRecorder(ctx),
 	}
 
@@ -232,7 +232,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, ks *eventing.KafkaSink) e
 	// Get contract config map.
 	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get contract config map %s: %w", r.Configs.DataPlaneConfigMapAsString(), err)
+		return fmt.Errorf("failed to get contract config map %s: %w", r.Env.DataPlaneConfigMapAsString(), err)
 	}
 
 	logger.Debug("Got contract config map")

--- a/control-plane/pkg/reconciler/source/source.go
+++ b/control-plane/pkg/reconciler/source/source.go
@@ -81,7 +81,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *sources.KafkaSource)
 
 	statusConditionManager := base.StatusConditionManager{
 		Object:   ks,
-		Configs:  r.Env,
+		Env:      r.Env,
 		Recorder: controller.GetEventRecorder(ctx),
 	}
 

--- a/control-plane/pkg/reconciler/testing/factory.go
+++ b/control-plane/pkg/reconciler/testing/factory.go
@@ -40,7 +40,6 @@ import (
 	fakeeventingkafkabrokerclient "knative.dev/eventing-kafka-broker/control-plane/pkg/client/injection/client/fake"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/broker"
 )
 
 const (
@@ -49,24 +48,19 @@ const (
 	recorderBufferSize = 20
 )
 
-var DefaultConfigs = &broker.Configs{
-
-	Env: config.Env{
-		DataPlaneConfigMapNamespace: "knative-eventing",
-		DataPlaneConfigMapName:      "kafka-broker-brokers-triggers",
-		IngressName:                 "kafka-broker-receiver",
-		SystemNamespace:             "knative-eventing",
-		DataPlaneConfigFormat:       base.Json,
-		DefaultBackoffDelayMs:       1000,
-	},
-
-	BootstrapServers: "",
+var DefaultEnv = &config.Env{
+	DataPlaneConfigMapNamespace: "knative-eventing",
+	DataPlaneConfigMapName:      "kafka-broker-brokers-triggers",
+	IngressName:                 "kafka-broker-receiver",
+	SystemNamespace:             "knative-eventing",
+	DataPlaneConfigFormat:       base.Json,
+	DefaultBackoffDelayMs:       1000,
 }
 
 // Ctor functions create a k8s controller with given params.
-type Ctor func(ctx context.Context, listers *Listers, configs *broker.Configs, row *TableRow) pkgcontroller.Reconciler
+type Ctor func(ctx context.Context, listers *Listers, env *config.Env, row *TableRow) pkgcontroller.Reconciler
 
-func NewFactory(configs *broker.Configs, ctor Ctor) Factory {
+func NewFactory(env *config.Env, ctor Ctor) Factory {
 	return func(t *testing.T, row *TableRow) (pkgcontroller.Reconciler, ActionRecorderList, EventList) {
 
 		listers := newListers(row.Objects)
@@ -99,7 +93,7 @@ func NewFactory(configs *broker.Configs, ctor Ctor) Factory {
 
 		ctx = addressable.WithDuck(ctx)
 
-		controller := ctor(ctx, listers, configs, row)
+		controller := ctor(ctx, listers, env, row)
 
 		if la, ok := controller.(reconciler.LeaderAware); ok {
 			_ = la.Promote(reconciler.UniversalBucket(), func(reconciler.Bucket, types.NamespacedName) {})

--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgotesting "k8s.io/client-go/testing"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
 	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
 	reconcilertesting "knative.dev/eventing/pkg/reconciler/testing/v1"
@@ -168,11 +169,11 @@ func BrokerReady(broker *eventing.Broker) {
 	}
 }
 
-func BrokerConfigMapUpdatedReady(configs *Configs) func(broker *eventing.Broker) {
+func BrokerConfigMapUpdatedReady(env *config.Env) func(broker *eventing.Broker) {
 	return func(broker *eventing.Broker) {
 		broker.GetConditionSet().Manage(broker.GetStatus()).MarkTrueWithReason(
 			base.ConditionConfigMapUpdated,
-			fmt.Sprintf("Config map %s updated", configs.DataPlaneConfigMapAsString()),
+			fmt.Sprintf("Config map %s updated", env.DataPlaneConfigMapAsString()),
 			"",
 		)
 	}
@@ -208,13 +209,13 @@ func BrokerConfigNotParsed(reason string) func(broker *eventing.Broker) {
 	}
 }
 
-func BrokerAddressable(configs *Configs) func(broker *eventing.Broker) {
+func BrokerAddressable(env *config.Env) func(broker *eventing.Broker) {
 
 	return func(broker *eventing.Broker) {
 
 		broker.Status.Address.URL = &apis.URL{
 			Scheme: "http",
-			Host:   network.GetServiceHostname(configs.IngressName, configs.SystemNamespace),
+			Host:   network.GetServiceHostname(env.IngressName, env.SystemNamespace),
 			Path:   fmt.Sprintf("/%s/%s", broker.Namespace, broker.Name),
 		}
 
@@ -239,7 +240,7 @@ func BrokerFailedToCreateTopic(broker *eventing.Broker) {
 
 }
 
-func BrokerFailedToGetConfigMap(configs *Configs) func(broker *eventing.Broker) {
+func BrokerFailedToGetConfigMap(env *config.Env) func(broker *eventing.Broker) {
 
 	return func(broker *eventing.Broker) {
 
@@ -247,7 +248,7 @@ func BrokerFailedToGetConfigMap(configs *Configs) func(broker *eventing.Broker) 
 			base.ConditionConfigMapUpdated,
 			fmt.Sprintf(
 				"Failed to get ConfigMap: %s",
-				configs.DataPlaneConfigMapAsString(),
+				env.DataPlaneConfigMapAsString(),
 			),
 			`configmaps "knative-eventing" not found`,
 		)

--- a/control-plane/pkg/reconciler/testing/objects_common.go
+++ b/control-plane/pkg/reconciler/testing/objects_common.go
@@ -34,7 +34,6 @@ import (
 	reconcilertesting "knative.dev/eventing/pkg/reconciler/testing/v1"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
-	. "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/broker"
 )
 
 const (

--- a/control-plane/pkg/reconciler/testing/objects_common.go
+++ b/control-plane/pkg/reconciler/testing/objects_common.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/security"
 
@@ -82,10 +83,10 @@ func ServiceURLFrom(ns, name string) string {
 	return fmt.Sprintf("http://%s.%s.svc.cluster.local", name, ns)
 }
 
-func NewConfigMap(configs *Configs, data []byte) runtime.Object {
+func NewConfigMap(env *config.Env, data []byte) runtime.Object {
 	return reconcilertesting.NewConfigMap(
-		configs.DataPlaneConfigMapName,
-		configs.DataPlaneConfigMapNamespace,
+		env.DataPlaneConfigMapName,
+		env.DataPlaneConfigMapNamespace,
 		func(configMap *corev1.ConfigMap) {
 			if configMap.BinaryData == nil {
 				configMap.BinaryData = make(map[string][]byte, 1)
@@ -98,10 +99,10 @@ func NewConfigMap(configs *Configs, data []byte) runtime.Object {
 	)
 }
 
-func NewConfigMapFromContract(contract *contract.Contract, configs *Configs) runtime.Object {
+func NewConfigMapFromContract(contract *contract.Contract, env *config.Env) runtime.Object {
 	var data []byte
 	var err error
-	if configs.DataPlaneConfigFormat == base.Protobuf {
+	if env.DataPlaneConfigFormat == base.Protobuf {
 		data, err = proto.Marshal(contract)
 	} else {
 		data, err = protojson.Marshal(contract)
@@ -110,18 +111,18 @@ func NewConfigMapFromContract(contract *contract.Contract, configs *Configs) run
 		panic(err)
 	}
 
-	return NewConfigMap(configs, data)
+	return NewConfigMap(env, data)
 }
 
-func ConfigMapUpdate(configs *Configs, contract *contract.Contract) clientgotesting.UpdateActionImpl {
+func ConfigMapUpdate(env *config.Env, contract *contract.Contract) clientgotesting.UpdateActionImpl {
 	return clientgotesting.NewUpdateAction(
 		schema.GroupVersionResource{
 			Group:    "*",
 			Version:  "v1",
 			Resource: "ConfigMap",
 		},
-		configs.DataPlaneConfigMapNamespace,
-		NewConfigMapFromContract(contract, configs),
+		env.DataPlaneConfigMapNamespace,
+		NewConfigMapFromContract(contract, env),
 	)
 }
 

--- a/control-plane/pkg/reconciler/testing/objects_source.go
+++ b/control-plane/pkg/reconciler/testing/objects_source.go
@@ -30,7 +30,6 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
-	. "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/broker"
 )
 
 const (

--- a/control-plane/pkg/reconciler/testing/objects_source.go
+++ b/control-plane/pkg/reconciler/testing/objects_source.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	"knative.dev/eventing-kafka/pkg/apis/bindings/v1beta1"
 	sources "knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -113,11 +114,11 @@ func NewSourceSinkReference() duckv1.Destination {
 	}
 }
 
-func SourceConfigMapUpdatedReady(configs *Configs) func(source *sources.KafkaSource) {
+func SourceConfigMapUpdatedReady(env *config.Env) func(source *sources.KafkaSource) {
 	return func(source *sources.KafkaSource) {
 		source.GetConditionSet().Manage(source.GetStatus()).MarkTrueWithReason(
 			base.ConditionConfigMapUpdated,
-			fmt.Sprintf("Config map %s updated", configs.DataPlaneConfigMapAsString()),
+			fmt.Sprintf("Config map %s updated", env.DataPlaneConfigMapAsString()),
 			"",
 		)
 	}

--- a/control-plane/pkg/reconciler/trigger/controller.go
+++ b/control-plane/pkg/reconciler/trigger/controller.go
@@ -73,7 +73,7 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 		},
 		BrokerLister:   brokerInformer.Lister(),
 		EventingClient: eventingclient.Get(ctx),
-		Configs:        configs,
+		Env:            configs,
 	}
 
 	impl := triggerreconciler.NewImpl(ctx, reconciler, func(impl *controller.Impl) controller.Options {

--- a/control-plane/pkg/reconciler/trigger/trigger.go
+++ b/control-plane/pkg/reconciler/trigger/trigger.go
@@ -54,7 +54,7 @@ type Reconciler struct {
 	EventingClient eventingclientset.Interface
 	Resolver       *resolver.URIResolver
 
-	Configs *config.Env
+	Env *config.Env
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, trigger *eventing.Trigger) reconciler.Event {
@@ -68,7 +68,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, trigger *eventing.Trigge
 
 	statusConditionManager := statusConditionManager{
 		Trigger:  trigger,
-		Configs:  r.Configs,
+		Configs:  r.Env,
 		Recorder: controller.GetEventRecorder(ctx),
 	}
 
@@ -201,7 +201,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, trigger *eventing.Trigger
 	// Get data plane config map.
 	dataPlaneConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get data plane config map %s: %w", r.Configs.DataPlaneConfigMapAsString(), err)
+		return fmt.Errorf("failed to get data plane config map %s: %w", r.Env.DataPlaneConfigMapAsString(), err)
 	}
 
 	logger.Debug("Got data plane config map")
@@ -248,7 +248,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, trigger *eventing.Trigger
 		return err
 	}
 
-	logger.Debug("Updated data plane config map", zap.String("configmap", r.Configs.DataPlaneConfigMapAsString()))
+	logger.Debug("Updated data plane config map", zap.String("configmap", r.Env.DataPlaneConfigMapAsString()))
 
 	// Update volume generation annotation of dispatcher pods
 	if err := r.UpdateDispatcherPodsAnnotation(ctx, logger, ct.Generation); err != nil {
@@ -285,11 +285,11 @@ func (r *Reconciler) reconcileTriggerEgress(ctx context.Context, broker *eventin
 		}
 	}
 
-	triggerEgressConfig, err := coreconfig.EgressConfigFromDelivery(ctx, r.Resolver, trigger, trigger.Spec.Delivery, r.Configs.DefaultBackoffDelayMs)
+	triggerEgressConfig, err := coreconfig.EgressConfigFromDelivery(ctx, r.Resolver, trigger, trigger.Spec.Delivery, r.Env.DefaultBackoffDelayMs)
 	if err != nil {
 		return nil, fmt.Errorf("[trigger] %w", err)
 	}
-	brokerEgressConfig, err := coreconfig.EgressConfigFromDelivery(ctx, r.Resolver, broker, broker.Spec.Delivery, r.Configs.DefaultBackoffDelayMs)
+	brokerEgressConfig, err := coreconfig.EgressConfigFromDelivery(ctx, r.Resolver, broker, broker.Spec.Delivery, r.Env.DefaultBackoffDelayMs)
 	if err != nil {
 		return nil, fmt.Errorf("[broker] %w", err)
 	}

--- a/control-plane/pkg/reconciler/trigger/trigger_test.go
+++ b/control-plane/pkg/reconciler/trigger/trigger_test.go
@@ -24,6 +24,7 @@ import (
 
 	"google.golang.org/protobuf/testing/protocmp"
 	"k8s.io/utils/pointer"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/tracker"
@@ -49,7 +50,6 @@ import (
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/receiver"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/broker"
 	. "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/testing"
 )
 
@@ -82,15 +82,15 @@ func TestTriggerReconciler(t *testing.T) {
 	t.Parallel()
 
 	for _, f := range Formats {
-		triggerReconciliation(t, f, *DefaultConfigs)
+		triggerReconciliation(t, f, *DefaultEnv)
 	}
 }
 
-func triggerReconciliation(t *testing.T, format string, configs broker.Configs) {
+func triggerReconciliation(t *testing.T, format string, env config.Env) {
 
 	testKey := fmt.Sprintf("%s/%s", triggerNamespace, triggerName)
 
-	configs.DataPlaneConfigFormat = format
+	env.DataPlaneConfigFormat = format
 
 	table := TableTest{
 		{
@@ -109,8 +109,8 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 							Ingress: &contract.Ingress{IngressType: &contract.Ingress_Path{Path: receiver.Path(BrokerNamespace, BrokerName)}},
 						},
 					},
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			Key: testKey,
 			WantEvents: []string{
@@ -120,7 +120,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 				patchFinalizers(),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
+				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
 							Uid:     BrokerUUID,
@@ -137,7 +137,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 					},
 					Generation: 1,
 				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
 					base.VolumeGenerationAnnotationKey: "1",
 				}),
 			},
@@ -172,8 +172,8 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 							Ingress: &contract.Ingress{IngressType: &contract.Ingress_Path{Path: receiver.Path(BrokerNamespace, BrokerName)}},
 						},
 					},
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			Key: testKey,
 			WantEvents: []string{
@@ -183,7 +183,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 				patchFinalizers(),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
+				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
 							Uid:     BrokerUUID,
@@ -201,7 +201,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 					},
 					Generation: 1,
 				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
 					base.VolumeGenerationAnnotationKey: "1",
 				}),
 			},
@@ -235,8 +235,8 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 							Ingress: &contract.Ingress{IngressType: &contract.Ingress_Path{Path: receiver.Path(BrokerNamespace, BrokerName)}},
 						},
 					},
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			Key: testKey,
 			WantEvents: []string{
@@ -246,7 +246,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 				patchFinalizers(),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
+				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
 							Uid:     BrokerUUID,
@@ -270,7 +270,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 					},
 					Generation: 1,
 				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
 					base.VolumeGenerationAnnotationKey: "1",
 				}),
 			},
@@ -305,8 +305,8 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 							Ingress: &contract.Ingress{IngressType: &contract.Ingress_Path{Path: receiver.Path(BrokerNamespace, BrokerName)}},
 						},
 					},
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			Key: testKey,
 			WantEvents: []string{
@@ -316,7 +316,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 				patchFinalizers(),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
+				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
 							Uid:     BrokerUUID,
@@ -334,7 +334,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 					},
 					Generation: 1,
 				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
 					base.VolumeGenerationAnnotationKey: "1",
 				}),
 			},
@@ -369,8 +369,8 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 							Ingress: &contract.Ingress{IngressType: &contract.Ingress_Path{Path: receiver.Path(BrokerNamespace, BrokerName)}},
 						},
 					},
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			Key: testKey,
 			WantEvents: []string{
@@ -380,7 +380,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 				patchFinalizers(),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
+				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
 							Uid:     BrokerUUID,
@@ -398,7 +398,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 					},
 					Generation: 1,
 				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
 					base.VolumeGenerationAnnotationKey: "1",
 				}),
 			},
@@ -433,8 +433,8 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 							Ingress: &contract.Ingress{IngressType: &contract.Ingress_Path{Path: receiver.Path(BrokerNamespace, BrokerName)}},
 						},
 					},
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			Key: testKey,
 			WantEvents: []string{
@@ -444,7 +444,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 				patchFinalizers(),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
+				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
 							Uid:     BrokerUUID,
@@ -468,7 +468,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 					},
 					Generation: 1,
 				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
 					base.VolumeGenerationAnnotationKey: "1",
 				}),
 			},
@@ -535,8 +535,8 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 						},
 					},
 					Generation: 2,
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			Key: testKey,
 			WantEvents: []string{
@@ -546,7 +546,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 				patchFinalizers(),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
+				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
 							Uid:     BrokerUUID + "z",
@@ -583,7 +583,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 					},
 					Generation: 3,
 				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
 					base.VolumeGenerationAnnotationKey: "3",
 				}),
 			},
@@ -617,7 +617,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 			WantErr:                 true,
 			SkipNamespaceValidation: true, // WantCreates compare the broker namespace with configmap namespace, so skip it
 			WantCreates: []runtime.Object{
-				NewConfigMap(&configs, nil),
+				NewConfigMap(&env, nil),
 			},
 			WantEvents: []string{
 				finalizerUpdatedEvent,
@@ -626,7 +626,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 					"InternalError",
 					fmt.Sprintf(
 						"broker not found in data plane config map %s",
-						configs.DataPlaneConfigMapAsString(),
+						env.DataPlaneConfigMapAsString(),
 					),
 				),
 			},
@@ -636,7 +636,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 						reconcilertesting.WithInitTriggerConditions,
 						reconcilertesting.WithTriggerBrokerFailed(
 							"Broker not found in data plane map",
-							fmt.Sprintf("config map: %s", configs.DataPlaneConfigMapAsString()),
+							fmt.Sprintf("config map: %s", env.DataPlaneConfigMapAsString()),
 						),
 					),
 				},
@@ -648,7 +648,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 				NewBroker(BrokerReady),
 				newTrigger(),
 				NewService(),
-				NewConfigMap(&configs, nil),
+				NewConfigMap(&env, nil),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
 				patchFinalizers(),
@@ -662,7 +662,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 					"InternalError",
 					fmt.Sprintf(
 						"broker not found in data plane config map %s",
-						configs.DataPlaneConfigMapAsString(),
+						env.DataPlaneConfigMapAsString(),
 					),
 				),
 			},
@@ -672,7 +672,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 						reconcilertesting.WithInitTriggerConditions,
 						reconcilertesting.WithTriggerBrokerFailed(
 							"Broker not found in data plane map",
-							fmt.Sprintf("config map: %s", configs.DataPlaneConfigMapAsString()),
+							fmt.Sprintf("config map: %s", env.DataPlaneConfigMapAsString()),
 						),
 					),
 				},
@@ -730,7 +730,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 				NewDeletedBroker(),
 				NewConfigMapFromContract(&contract.Contract{
 					Generation: 8,
-				}, &configs),
+				}, &env),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
 				patchFinalizers(),
@@ -760,7 +760,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 						},
 					},
 					Generation: 8,
-				}, &configs),
+				}, &env),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
 				patchFinalizers(),
@@ -802,8 +802,8 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 						},
 					},
 					Generation: 8,
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
 				patchFinalizers(),
@@ -813,7 +813,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
+				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
 							Uid:    BrokerUUID,
@@ -829,7 +829,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 					},
 					Generation: 9,
 				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
 					base.VolumeGenerationAnnotationKey: "9",
 				}),
 			},
@@ -871,8 +871,8 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 							},
 						},
 					},
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			Key: testKey,
 			WantEvents: []string{
@@ -980,8 +980,8 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 							},
 						},
 					},
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			Key: testKey,
 			WantEvents: []string{
@@ -991,7 +991,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 				patchFinalizers(),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
+				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
 							Uid:     BrokerUUID,
@@ -1065,7 +1065,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 					},
 					Generation: 1,
 				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
 					base.VolumeGenerationAnnotationKey: "1",
 				}),
 			},
@@ -1162,8 +1162,8 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 							},
 						},
 					},
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			Key: testKey,
 			WantEvents: []string{
@@ -1173,7 +1173,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 				patchFinalizers(),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
+				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
 							Uid:     BrokerUUID + "a",
@@ -1247,7 +1247,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 					},
 					Generation: 1,
 				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
 					base.VolumeGenerationAnnotationKey: "1",
 				}),
 			},
@@ -1381,8 +1381,8 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 							},
 						},
 					},
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			Key: testKey,
 			WantEvents: []string{
@@ -1392,7 +1392,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 				patchFinalizers(),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
+				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
 							Uid:     BrokerUUID + "a",
@@ -1496,7 +1496,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 					},
 					Generation: 1,
 				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
 					base.VolumeGenerationAnnotationKey: "1",
 				}),
 			},
@@ -1545,7 +1545,7 @@ func triggerReconciliation(t *testing.T, format string, configs broker.Configs) 
 		table[i].Name = table[i].Name + " - " + format
 	}
 
-	useTable(t, table, &configs)
+	useTable(t, table, &env)
 }
 
 func withDelivery(trigger *eventing.Trigger) {
@@ -1563,16 +1563,16 @@ func TestTriggerFinalizer(t *testing.T) {
 	t.Parallel()
 
 	for _, f := range Formats {
-		triggerFinalizer(t, f, *DefaultConfigs)
+		triggerFinalizer(t, f, *DefaultEnv)
 	}
 
 }
 
-func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
+func triggerFinalizer(t *testing.T, format string, env config.Env) {
 
 	testKey := fmt.Sprintf("%s/%s", triggerNamespace, triggerName)
 
-	configs.DataPlaneConfigFormat = format
+	env.DataPlaneConfigFormat = format
 
 	table := TableTest{
 		{
@@ -1600,8 +1600,8 @@ func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
 						},
 					},
 					Generation: 8,
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
 				patchFinalizers(),
@@ -1611,7 +1611,7 @@ func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
+				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
 							Uid:    BrokerUUID,
@@ -1627,7 +1627,7 @@ func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
 					},
 					Generation: 9,
 				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
 					base.VolumeGenerationAnnotationKey: "9",
 				}),
 			},
@@ -1652,7 +1652,7 @@ func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
 						},
 					},
 					Generation: 8,
-				}, &configs),
+				}, &env),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
 				patchFinalizers(),
@@ -1676,7 +1676,7 @@ func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
 				NewDeletedBroker(),
 				NewConfigMapFromContract(&contract.Contract{
 					Generation: 8,
-				}, &configs),
+				}, &env),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
 				patchFinalizers(),
@@ -1770,8 +1770,8 @@ func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
 							},
 						},
 					},
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			Key: testKey,
 			WantEvents: []string{
@@ -1781,7 +1781,7 @@ func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
 				patchFinalizers(),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
+				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
 							Uid:     BrokerUUID,
@@ -1847,7 +1847,7 @@ func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
 					},
 					Generation: 1,
 				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
 					base.VolumeGenerationAnnotationKey: "1",
 				}),
 			},
@@ -1936,8 +1936,8 @@ func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
 							},
 						},
 					},
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			Key: testKey,
 			WantEvents: []string{
@@ -1947,7 +1947,7 @@ func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
 				patchFinalizers(),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
+				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
 							Uid:     BrokerUUID + "a",
@@ -2013,7 +2013,7 @@ func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
 					},
 					Generation: 1,
 				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
 					base.VolumeGenerationAnnotationKey: "1",
 				}),
 			},
@@ -2135,8 +2135,8 @@ func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
 							},
 						},
 					},
-				}, &configs),
-				BrokerDispatcherPod(configs.SystemNamespace, nil),
+				}, &env),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
 			},
 			Key: testKey,
 			WantEvents: []string{
@@ -2146,7 +2146,7 @@ func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
 				patchFinalizers(),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
-				ConfigMapUpdate(&configs, &contract.Contract{
+				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
 							Uid:     BrokerUUID + "a",
@@ -2245,7 +2245,7 @@ func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
 					},
 					Generation: 1,
 				}),
-				BrokerDispatcherPodUpdate(configs.SystemNamespace, map[string]string{
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
 					base.VolumeGenerationAnnotationKey: "1",
 				}),
 			},
@@ -2259,12 +2259,12 @@ func triggerFinalizer(t *testing.T, format string, configs broker.Configs) {
 		},
 	}
 
-	useTable(t, table, &configs)
+	useTable(t, table, &env)
 }
 
-func useTable(t *testing.T, table TableTest, configs *broker.Configs) {
+func useTable(t *testing.T, table TableTest, env *config.Env) {
 
-	table.Test(t, NewFactory(configs, func(ctx context.Context, listers *Listers, configs *broker.Configs, row *TableRow) controller.Reconciler {
+	table.Test(t, NewFactory(env, func(ctx context.Context, listers *Listers, env *config.Env, row *TableRow) controller.Reconciler {
 
 		logger := logging.FromContext(ctx)
 
@@ -2273,17 +2273,17 @@ func useTable(t *testing.T, table TableTest, configs *broker.Configs) {
 				KubeClient:                  kubeclient.Get(ctx),
 				PodLister:                   listers.GetPodLister(),
 				SecretLister:                listers.GetSecretLister(),
-				DataPlaneConfigMapNamespace: configs.DataPlaneConfigMapNamespace,
-				DataPlaneConfigMapName:      configs.DataPlaneConfigMapName,
-				DataPlaneConfigFormat:       configs.DataPlaneConfigFormat,
-				SystemNamespace:             configs.SystemNamespace,
+				DataPlaneConfigMapNamespace: env.DataPlaneConfigMapNamespace,
+				DataPlaneConfigMapName:      env.DataPlaneConfigMapName,
+				DataPlaneConfigFormat:       env.DataPlaneConfigFormat,
+				SystemNamespace:             env.SystemNamespace,
 				DispatcherLabel:             base.BrokerDispatcherLabel,
 				ReceiverLabel:               base.BrokerReceiverLabel,
 			},
 			BrokerLister:   listers.GetBrokerLister(),
 			EventingClient: eventingclient.Get(ctx),
 			Resolver:       nil,
-			Configs:        &configs.Env,
+			Env:            env,
 		}
 
 		reconciler.Resolver = resolver.NewURIResolverFromTracker(ctx, tracker.New(func(name types.NamespacedName) {}, 0))


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Better naming and consistency for `config.Env`
- Got rid of `broker.Config` which only had 1 additional field. That `broker.Config` thing was used in source, channel and sink. Changed those usages to `config.Env`.
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
