### PR TITLE
Receiver handles ingress probes

### DIFF
--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticle.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticle.java
@@ -37,8 +37,8 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import static dev.knative.eventing.kafka.broker.core.utils.Logging.keyValue;
-import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ProbeRequestUtil.PROBE_HASH_HEADER_NAME;
-import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ProbeRequestUtil.isProbeRequest;
+import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ControlPlaneProbeRequestUtil.PROBE_HASH_HEADER_NAME;
+import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ControlPlaneProbeRequestUtil.isControlPlaneProbeRequest;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 
@@ -125,7 +125,7 @@ public class ReceiverVerticle extends AbstractVerticle implements Handler<HttpSe
       return;
     }
 
-    if (isProbeRequest(request)) {
+    if (isControlPlaneProbeRequest(request)) {
       request.response()
         .putHeader(PROBE_HASH_HEADER_NAME, request.getHeader(PROBE_HASH_HEADER_NAME))
         .setStatusCode(OK.code()).end();

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/ControlPlaneProbeRequestUtil.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/ControlPlaneProbeRequestUtil.java
@@ -18,15 +18,24 @@ package dev.knative.eventing.kafka.broker.receiver.impl.handler;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 
-public class ProbeRequestUtil {
+public final class ControlPlaneProbeRequestUtil {
 
+  private ControlPlaneProbeRequestUtil() {
+  }
+
+  // Control plane probing is based on the Knative Networking Data Plane Contract.
+  // For a description of what these headers are see [1].
+  //
+  // [1]: https://github.com/knative/pkg/blob/b558677ab03404ed118ba3e179a7438fe2d8509a/network/network.go#L38-L51
   public static final String PROBE_HEADER_NAME = "K-Network-Probe";
-
   public static final String PROBE_HEADER_VALUE = "probe";
-
   public static final String PROBE_HASH_HEADER_NAME = "K-Network-Hash";
 
-  public static boolean isProbeRequest(final HttpServerRequest request) {
+  /**
+   * @param request HTTP request
+   * @return true if the provided request conforms to the Knative Networking Data Plane Contract, false otherwise.
+   */
+  public static boolean isControlPlaneProbeRequest(final HttpServerRequest request) {
     final var headers = request.headers();
     return HttpMethod.GET.equals(request.method()) &&
       headers.contains(PROBE_HEADER_NAME) &&

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/MethodNotAllowedHandler.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/MethodNotAllowedHandler.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static dev.knative.eventing.kafka.broker.core.utils.Logging.keyValue;
-import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ProbeRequestUtil.*;
+import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ControlPlaneProbeRequestUtil.isControlPlaneProbeRequest;
 import static io.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
 
 /**
@@ -42,7 +42,7 @@ public class MethodNotAllowedHandler implements Handler<HttpServerRequest> {
 
   @Override
   public void handle(final HttpServerRequest request) {
-    if (HttpMethod.POST.equals(request.method()) || isProbeRequest(request)) {
+    if (HttpMethod.POST.equals(request.method()) || isControlPlaneProbeRequest(request)) {
       this.next.handle(request);
       return;
     }

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/MethodNotAllowedHandler.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/MethodNotAllowedHandler.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static dev.knative.eventing.kafka.broker.core.utils.Logging.keyValue;
+import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ProbeRequestUtil.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
 
 /**
@@ -41,14 +42,11 @@ public class MethodNotAllowedHandler implements Handler<HttpServerRequest> {
 
   @Override
   public void handle(final HttpServerRequest request) {
-    if (request.method() != HttpMethod.POST) {
-      request.response().setStatusCode(METHOD_NOT_ALLOWED.code()).end();
-
-      logger.warn("Only POST method is allowed. Method not allowed: {}",
-        keyValue("method", request.method())
-      );
+    if (HttpMethod.POST.equals(request.method()) || isProbeRequest(request)) {
+      this.next.handle(request);
       return;
     }
-    this.next.handle(request);
+    request.response().setStatusCode(METHOD_NOT_ALLOWED.code()).end();
+    logger.warn("Method not allowed: {}", keyValue("method", request.method()));
   }
 }

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/ProbeRequestUtil.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/ProbeRequestUtil.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.receiver.impl.handler;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+
+public class ProbeRequestUtil {
+
+  public static final String PROBE_HEADER_NAME = "K-Network-Probe";
+
+  public static final String PROBE_HEADER_VALUE = "probe";
+
+  public static final String PROBE_HASH_HEADER_NAME = "K-Network-Hash";
+
+  public static boolean isProbeRequest(final HttpServerRequest request) {
+    final var headers = request.headers();
+    return HttpMethod.GET.equals(request.method()) &&
+      headers.contains(PROBE_HEADER_NAME) &&
+      headers.get(PROBE_HEADER_NAME).equals(PROBE_HEADER_VALUE);
+  }
+}

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTest.java
@@ -26,7 +26,7 @@ import dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcile
 import dev.knative.eventing.kafka.broker.core.security.AuthProvider;
 import dev.knative.eventing.kafka.broker.core.testing.CloudEventSerializerMock;
 import dev.knative.eventing.kafka.broker.receiver.impl.handler.IngressRequestHandlerImpl;
-import dev.knative.eventing.kafka.broker.receiver.impl.handler.ProbeRequestUtil;
+import dev.knative.eventing.kafka.broker.receiver.impl.handler.ControlPlaneProbeRequestUtil;
 import dev.knative.eventing.kafka.broker.receiver.main.ReceiverEnv;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.v1.CloudEventBuilder;
@@ -371,7 +371,7 @@ public class ReceiverVerticleTest {
     final CloudEvent event) {
     return request -> request
       .method(HttpMethod.GET)
-      .putHeader(ProbeRequestUtil.PROBE_HEADER_NAME, ProbeRequestUtil.PROBE_HEADER_VALUE)
+      .putHeader(ControlPlaneProbeRequestUtil.PROBE_HEADER_NAME, ControlPlaneProbeRequestUtil.PROBE_HEADER_VALUE)
       .send();
   }
 

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTest.java
@@ -26,6 +26,7 @@ import dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcile
 import dev.knative.eventing.kafka.broker.core.security.AuthProvider;
 import dev.knative.eventing.kafka.broker.core.testing.CloudEventSerializerMock;
 import dev.knative.eventing.kafka.broker.receiver.impl.handler.IngressRequestHandlerImpl;
+import dev.knative.eventing.kafka.broker.receiver.impl.handler.ProbeRequestUtil;
 import dev.knative.eventing.kafka.broker.receiver.main.ReceiverEnv;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.v1.CloudEventBuilder;
@@ -36,6 +37,7 @@ import io.micrometer.core.instrument.cumulative.CumulativeCounter;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
@@ -65,6 +67,7 @@ import java.util.function.Function;
 import static io.netty.handler.codec.http.HttpResponseStatus.ACCEPTED;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -329,6 +332,32 @@ public class ReceiverVerticleTest {
           .addTopics("topic-name-42")
           .setIngress(DataPlaneContract.Ingress.newBuilder().setPath("/broker-ns/broker-name5"))
           .build()
+      ),
+      new TestCase(
+        new ProducerRecord<>(
+          "topic-name-42",
+          null,
+          null
+        ),
+        "/broker-ns/broker-name5",
+        probeRequestSender(null),
+        OK.code(),
+        DataPlaneContract.Resource.newBuilder()
+          .setUid("1")
+          .addTopics("topic-name-42")
+          .setIngress(DataPlaneContract.Ingress.newBuilder().setPath("/broker-ns/broker-name5"))
+          .build()
+      ),
+      new TestCase(
+        new ProducerRecord<>(
+          "topic-name-42",
+          null,
+          null
+        ),
+        "/broker-ns/broker-name5",
+        probeRequestSender(null),
+        NOT_FOUND.code(),
+        DataPlaneContract.Resource.newBuilder().build()
       )
     );
   }
@@ -336,6 +365,14 @@ public class ReceiverVerticleTest {
   private static Function<HttpRequest<Buffer>, Future<HttpResponse<Buffer>>> ceRequestSender(
     final CloudEvent event) {
     return request -> VertxMessageFactory.createWriter(request).writeBinary(event);
+  }
+
+  private static Function<HttpRequest<Buffer>, Future<HttpResponse<Buffer>>> probeRequestSender(
+    final CloudEvent event) {
+    return request -> request
+      .method(HttpMethod.GET)
+      .putHeader(ProbeRequestUtil.PROBE_HEADER_NAME, ProbeRequestUtil.PROBE_HEADER_VALUE)
+      .send();
   }
 
   static final class TestCase {

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/ProbeRequestUtilTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/ProbeRequestUtilTest.java
@@ -20,9 +20,9 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import org.junit.jupiter.api.Test;
 
-import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ProbeRequestUtil.PROBE_HEADER_NAME;
-import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ProbeRequestUtil.PROBE_HEADER_VALUE;
-import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ProbeRequestUtil.isProbeRequest;
+import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ControlPlaneProbeRequestUtil.PROBE_HEADER_NAME;
+import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ControlPlaneProbeRequestUtil.PROBE_HEADER_VALUE;
+import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ControlPlaneProbeRequestUtil.isControlPlaneProbeRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -37,7 +37,7 @@ public class ProbeRequestUtilTest {
     when(request.method()).thenReturn(HttpMethod.GET);
     when(request.headers()).thenReturn(headers);
 
-    assertThat(isProbeRequest(request)).isTrue();
+    assertThat(isControlPlaneProbeRequest(request)).isTrue();
   }
 
   @Test
@@ -48,7 +48,7 @@ public class ProbeRequestUtilTest {
     when(request.method()).thenReturn(HttpMethod.GET);
     when(request.headers()).thenReturn(headers);
 
-    assertThat(isProbeRequest(request)).isFalse();
+    assertThat(isControlPlaneProbeRequest(request)).isFalse();
   }
 
   @Test
@@ -58,7 +58,7 @@ public class ProbeRequestUtilTest {
     when(request.method()).thenReturn(HttpMethod.GET);
     when(request.headers()).thenReturn(headers);
 
-    assertThat(isProbeRequest(request)).isFalse();
+    assertThat(isControlPlaneProbeRequest(request)).isFalse();
   }
 
   @Test
@@ -68,6 +68,6 @@ public class ProbeRequestUtilTest {
     when(request.method()).thenReturn(HttpMethod.POST);
     when(request.headers()).thenReturn(headers);
 
-    assertThat(isProbeRequest(request)).isFalse();
+    assertThat(isControlPlaneProbeRequest(request)).isFalse();
   }
 }

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/ProbeRequestUtilTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/ProbeRequestUtilTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.receiver.impl.handler;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import org.junit.jupiter.api.Test;
+
+import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ProbeRequestUtil.PROBE_HEADER_NAME;
+import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ProbeRequestUtil.PROBE_HEADER_VALUE;
+import static dev.knative.eventing.kafka.broker.receiver.impl.handler.ProbeRequestUtil.isProbeRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ProbeRequestUtilTest {
+
+  @Test
+  public void shouldBeProbeRequest() {
+    final var headers = new HeadersMultiMap()
+      .add(PROBE_HEADER_NAME, PROBE_HEADER_VALUE);
+    final var request = mock(HttpServerRequest.class);
+    when(request.method()).thenReturn(HttpMethod.GET);
+    when(request.headers()).thenReturn(headers);
+
+    assertThat(isProbeRequest(request)).isTrue();
+  }
+
+  @Test
+  public void shouldNotBeProbeRequestWrongValue() {
+    final var headers = new HeadersMultiMap()
+      .add(PROBE_HEADER_NAME, PROBE_HEADER_VALUE + "a");
+    final var request = mock(HttpServerRequest.class);
+    when(request.method()).thenReturn(HttpMethod.GET);
+    when(request.headers()).thenReturn(headers);
+
+    assertThat(isProbeRequest(request)).isFalse();
+  }
+
+  @Test
+  public void shouldNotBeProbeRequestNoProbeHeader() {
+    final var headers = new HeadersMultiMap();
+    final var request = mock(HttpServerRequest.class);
+    when(request.method()).thenReturn(HttpMethod.GET);
+    when(request.headers()).thenReturn(headers);
+
+    assertThat(isProbeRequest(request)).isFalse();
+  }
+
+  @Test
+  public void shouldNotBeProbeRequestWrongMethod() {
+    final var headers = new HeadersMultiMap();
+    final var request = mock(HttpServerRequest.class);
+    when(request.method()).thenReturn(HttpMethod.POST);
+    when(request.headers()).thenReturn(headers);
+
+    assertThat(isProbeRequest(request)).isFalse();
+  }
+}


### PR DESCRIPTION
Probing is done using the knative/networking data-plane contract
(already implemented in Eventing through knative/pkg).
ref issue knative/eventing#3911

This is part of our work to reduce e2e tests' flakiness.

## Proposed Changes

- Receiver handles ingress probes

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
