### PR TITLE
Commit offset on consumer close

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/AsyncCloseable.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/AsyncCloseable.java
@@ -21,6 +21,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -54,7 +55,10 @@ public interface AsyncCloseable extends Closeable {
   }
 
   /**
-   * Compose several {@link AsyncCloseable} into a single {@link AsyncCloseable}. One close failure will cause the whole close to fail.
+   * Compose several {@link AsyncCloseable}s into a single {@link AsyncCloseable}.
+   * One close failure will cause the whole close to fail.
+   * <p>
+   * It filters null futures returned by individual {@link AsyncCloseable} on close.
    *
    * @param closeables the closeables to compose
    * @return the composed closeables

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/AsyncCloseable.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/AsyncCloseable.java
@@ -22,6 +22,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -61,7 +62,9 @@ public interface AsyncCloseable extends Closeable {
   static AsyncCloseable compose(AsyncCloseable... closeables) {
     return () -> CompositeFuture.all(
       Arrays.stream(closeables)
+        .filter(Objects::nonNull)
         .map(AsyncCloseable::close)
+        .filter(Objects::nonNull)
         .collect(Collectors.toList())
     ).mapEmpty();
   }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/RecordDispatcherListener.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/RecordDispatcherListener.java
@@ -15,13 +15,13 @@
  */
 package dev.knative.eventing.kafka.broker.dispatcher;
 
-import io.vertx.core.Future;
+import dev.knative.eventing.kafka.broker.core.AsyncCloseable;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 
 /**
  * This class contains hooks for listening events through the {@link dev.knative.eventing.kafka.broker.dispatcher.RecordDispatcher} lifecycle.
  */
-public interface RecordDispatcherListener {
+public interface RecordDispatcherListener extends AsyncCloseable {
 
   /**
    * The given record has been received.

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
@@ -81,7 +81,7 @@ public class RecordDispatcherImpl implements RecordDispatcher {
     this.subscriberSender = composeSenderAndSinkHandler(subscriberSender, responseHandler, "subscriber");
     this.dlsSender = composeSenderAndSinkHandler(deadLetterSinkSender, responseHandler, "dead letter sink");
     this.recordDispatcherListener = recordDispatcherListener;
-    this.closeable = AsyncCloseable.compose(responseHandler, deadLetterSinkSender, subscriberSender);
+    this.closeable = AsyncCloseable.compose(responseHandler, deadLetterSinkSender, subscriberSender, recordDispatcherListener);
     this.consumerTracer = consumerTracer;
   }
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OffsetManager.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OffsetManager.java
@@ -139,6 +139,11 @@ public final class OffsetManager implements RecordDispatcherListener {
     return null;
   }
 
+  /**
+   * Commit all tracked offsets by colling commit on every offsetTracker entry.
+   *
+   * @return succeeded or failed future.
+   */
   private Future<Void> commitAll() {
     return CompositeFuture.all(
       this.offsetTrackers.entrySet()

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
@@ -111,6 +111,9 @@ public class OrderedConsumerVerticle extends BaseConsumerVerticle {
   }
 
   void recordsHandler(KafkaConsumerRecords<Object, CloudEvent> records) {
+    if (records == null) {
+      return;
+    }
     // Put records in queues
     // I assume the records are ordered per topic-partition
     for (int i = 0; i < records.size(); i++) {

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/AbstractOffsetManagerTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/AbstractOffsetManagerTest.java
@@ -100,13 +100,15 @@ public abstract class AbstractOffsetManagerTest {
       .when(vertxConsumer)
       .commit(any(Map.class));
 
-    testExecutor.accept(createOffsetManager(Vertx.vertx(), vertxConsumer), failureFlag);
+    final var offsetManager = createOffsetManager(Vertx.vertx(), vertxConsumer);
+    testExecutor.accept(offsetManager, failureFlag);
 
     try {
       Thread.sleep(1000);
     } catch (final InterruptedException e) {
       throw new RuntimeException(e);
     }
+    assertThat(offsetManager.close().succeeded()).isTrue();
 
     final var committed = mockConsumer.committed(Set.copyOf(partitionsConsumed));
     return assertThat(


### PR DESCRIPTION
When a consumer is closed, we want to commit the offsets for all
owned partitions.

Fixes (some flaky tests)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Commit offset on consumer close

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Commit offset on consumer close.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```