### PR TITLE
Add sarama.StdLogger implementation based on zap logger

### DIFF
--- a/control-plane/pkg/logging/sarama.go
+++ b/control-plane/pkg/logging/sarama.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+import (
+	"github.com/Shopify/sarama"
+	"go.uber.org/zap"
+)
+
+// SaramaZapLogger is an implementation of the sarama.StdLogger interface that
+// is backed by a zap logger.
+type SaramaZapLogger struct {
+	*zap.SugaredLogger
+}
+
+var _ sarama.StdLogger = (*SaramaZapLogger)(nil)
+
+// NewSaramaZapLogger returns a SaramaZapLogger initialized with the given logger.
+func NewSaramaLogger(l *zap.SugaredLogger) *SaramaZapLogger {
+	return &SaramaZapLogger{SugaredLogger: l}
+}
+
+// Print implements sarama.StdLogger.
+func (l *SaramaZapLogger) Print(v ...interface{}) {
+	l.Debug(v...)
+}
+
+// Println implements sarama.StdLogger.
+func (l *SaramaZapLogger) Println(v ...interface{}) {
+	// (*zap.SugaredLogger).Debug uses println-style formatting, so
+	// Print and Println are equivalent in this implementation.
+	l.Debug(v...)
+}
+
+// Printf implements sarama.StdLogger.
+func (l *SaramaZapLogger) Printf(format string, v ...interface{}) {
+	l.Debugf(format, v...)
+}

--- a/control-plane/pkg/logging/sarama_test.go
+++ b/control-plane/pkg/logging/sarama_test.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	. "knative.dev/eventing-kafka-broker/control-plane/pkg/logging"
+)
+
+func TestSaramaZapLogger(t *testing.T) {
+	t.Run("Print", func(t *testing.T) {
+		var logOutput bytes.Buffer
+		logger := newSaramaLogger(&logOutput)
+
+		logger.Print("test", 42)
+
+		const expect = `{"level":"debug","msg":"test42"}` + "\n"
+
+		if got := logOutput.String(); got != expect {
+			t.Errorf("Expected\n  %sgot\n  %s", expect, got)
+		}
+	})
+
+	t.Run("Println", func(t *testing.T) {
+		var logOutput bytes.Buffer
+		logger := newSaramaLogger(&logOutput)
+
+		logger.Println("test", 42)
+
+		const expect = `{"level":"debug","msg":"test42"}` + "\n"
+
+		if got := logOutput.String(); got != expect {
+			t.Errorf("Expected\n  %sgot\n  %s", expect, got)
+		}
+	})
+
+	t.Run("Printf", func(t *testing.T) {
+		var logOutput bytes.Buffer
+		logger := newSaramaLogger(&logOutput)
+
+		logger.Printf("test %d", 42)
+
+		const expect = `{"level":"debug","msg":"test 42"}` + "\n"
+
+		if got := logOutput.String(); got != expect {
+			t.Errorf("Expected\n  %sgot\n  %s", expect, got)
+		}
+	})
+}
+
+// newSaramaLogger returns a SaramaZapLogger configured with a logger that
+// writes to the given io.Writer using the JSON encoding.
+func newSaramaLogger(logOutput io.Writer, logOptions ...zap.Option) *SaramaZapLogger {
+	zapLogger := newZapLogger(logOutput, logOptions...)
+	return NewSaramaLogger(zapLogger.Sugar())
+}
+
+// newZapLogger returns a zap logger with the same configuration returned by
+// zap.NewExample(), except that it writes to the given io.Writer instead of
+// os.Stdout.
+func newZapLogger(w io.Writer, options ...zap.Option) *zap.Logger {
+	encoderCfg := zapcore.EncoderConfig{
+		MessageKey:     "msg",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+	}
+
+	core := zapcore.NewCore(zapcore.NewJSONEncoder(encoderCfg), zapcore.AddSync(w), zap.DebugLevel)
+
+	return zap.New(core).WithOptions(options...)
+}

--- a/control-plane/pkg/reconciler/sink/controller.go
+++ b/control-plane/pkg/reconciler/sink/controller.go
@@ -29,13 +29,14 @@ import (
 	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
+	pkglogging "knative.dev/pkg/logging"
 	"knative.dev/pkg/tracker"
 
 	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
 	sinkinformer "knative.dev/eventing-kafka-broker/control-plane/pkg/client/injection/informers/eventing/v1alpha1/kafkasink"
 	sinkreconciler "knative.dev/eventing-kafka-broker/control-plane/pkg/client/injection/reconciler/eventing/v1alpha1/kafkasink"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/logging"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
 )
 
@@ -43,7 +44,9 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 
 	eventing.RegisterConditionSet(base.IngressConditionSet)
 
-	logger := logging.FromContext(ctx)
+	logger := pkglogging.FromContext(ctx)
+
+	sarama.Logger = logging.NewSaramaLogger(logger)
 
 	configmapInformer := configmapinformer.Get(ctx)
 


### PR DESCRIPTION
Closes #1448

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Sets Sarama's logger to a custom StdLogger implementation backed by Knative's zap logger

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Log messages printed by the Sarama client when Knative's debug log level is enabled.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

/assign pierDipi 