### PR TITLE
Probe resource ingress for readiness

### DIFF
--- a/control-plane/config/200-controller/500-controller.yaml
+++ b/control-plane/config/200-controller/500-controller.yaml
@@ -98,6 +98,13 @@ spec:
             - name: SOURCE_GENERAL_CONFIG_MAP_NAME
               value: kafka-broker-config
 
+            - name: BROKER_INGRESS_POD_PORT
+              value: "8080"
+            - name: CHANNEL_INGRESS_POD_PORT
+              value: "8080"
+            - name: SINK_INGRESS_POD_PORT
+              value: "8080"
+
             - name: BROKER_SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/control-plane/pkg/config/env_config.go
+++ b/control-plane/pkg/config/env_config.go
@@ -27,6 +27,7 @@ type Env struct {
 	DataPlaneConfigMapName      string `required:"true" split_words:"true"`
 	GeneralConfigMapName        string `required:"true" split_words:"true"`
 	IngressName                 string `required:"true" split_words:"true"`
+	IngressPodPort              string `required:"false" split_words:"true"`
 	SystemNamespace             string `required:"true" split_words:"true"`
 	DataPlaneConfigFormat       string `required:"true" split_words:"true"`
 	DefaultBackoffDelayMs       uint64 `required:"false" split_words:"true"`

--- a/control-plane/pkg/prober/async_prober.go
+++ b/control-plane/pkg/prober/async_prober.go
@@ -18,7 +18,6 @@ package prober
 
 import (
 	"context"
-	"net/url"
 	"sync"
 	"time"
 
@@ -90,18 +89,8 @@ func (a *asyncProber) Probe(ctx context.Context, addressable Addressable) Status
 	var enqueueOnce sync.Once
 
 	for _, p := range pods {
-		podUrl := &url.URL{
-			Scheme:      address.Scheme,
-			Opaque:      address.Opaque,
-			User:        address.User,
-			Host:        p.Status.PodIP + ":" + a.port,
-			Path:        address.Path,
-			RawPath:     address.RawPath,
-			ForceQuery:  address.ForceQuery,
-			RawQuery:    address.RawQuery,
-			Fragment:    address.Fragment,
-			RawFragment: address.RawFragment,
-		}
+		podUrl := *address
+		podUrl.Host = p.Status.PodIP + ":" + a.port
 		address := podUrl.String()
 
 		logger := a.logger.

--- a/control-plane/pkg/prober/async_prober.go
+++ b/control-plane/pkg/prober/async_prober.go
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prober
+
+import (
+	"context"
+	"net/url"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	podinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod"
+	"knative.dev/pkg/logging"
+)
+
+type asyncProber struct {
+	client    httpClient
+	enqueue   EnqueueFunc
+	logger    *zap.Logger
+	cache     Cache
+	podLister func() ([]*corev1.Pod, error)
+	port      string
+}
+
+// NewAsync creates an async Prober.
+//
+// It reports status changes using the provided EnqueueFunc.
+func NewAsync(ctx context.Context, client httpClient, port string, podsLabelsSelector labels.Selector, enqueue EnqueueFunc) Prober {
+	logger := logging.FromContext(ctx).Desugar().
+		With(zap.String("scope", "prober"))
+
+	if len(port) == 0 {
+		logger.Fatal("Port is required")
+	}
+	podLister := podinformer.Get(ctx).Lister()
+	return &asyncProber{
+		client:    client,
+		enqueue:   enqueue,
+		logger:    logger,
+		cache:     NewLocalExpiringCache(ctx, 30*time.Minute),
+		podLister: func() ([]*corev1.Pod, error) { return podLister.List(podsLabelsSelector) },
+		port:      port,
+	}
+}
+
+func (a *asyncProber) Probe(ctx context.Context, addressable Addressable) Status {
+	address := addressable.Address
+	pods, err := a.podLister()
+	if err != nil {
+		a.logger.Error("Failed to list pods", zap.Error(err))
+		return StatusUnknown
+	}
+	// Return `StatusNotReady` when there are no pods.
+	if len(pods) == 0 {
+		return StatusNotReady
+	}
+
+	// aggregatedCurrentKnownStatus keeps track of the current status in the cache excluding `StatusReady`
+	// since we just skip pods that have `StatusReady`.
+	//
+	// If there is a status that is `StatusUnknown` the final status  we want to return is `StatusUnknown`,
+	// while we return `StatusNotReady` when the status is known and all probes returned `StatusNotReady`.
+	var aggregatedCurrentKnownStatus *Status
+
+	// wg keeps track of each request probe status.
+	//
+	// It goes to done once we have all probe request results regardless of whether they are coming from
+	// the cache or from an actual request.
+	var wg sync.WaitGroup
+	wg.Add(len(pods))
+
+	// enqueueOnce allows requeuing the resource only once, when we have all probe request results.
+	var enqueueOnce sync.Once
+
+	for _, p := range pods {
+		podUrl := &url.URL{
+			Scheme:      address.Scheme,
+			Opaque:      address.Opaque,
+			User:        address.User,
+			Host:        p.Status.PodIP + ":" + a.port,
+			Path:        address.Path,
+			RawPath:     address.RawPath,
+			ForceQuery:  address.ForceQuery,
+			RawQuery:    address.RawQuery,
+			Fragment:    address.Fragment,
+			RawFragment: address.RawFragment,
+		}
+		address := podUrl.String()
+
+		logger := a.logger.
+			With(zap.String("pod.metadata.name", p.Name)).
+			With(zap.String("address", address))
+
+		currentStatus := a.cache.GetStatus(address)
+		if currentStatus == StatusReady {
+			logger.Debug("Skip probing", zap.String("status", "ready"))
+			wg.Done()
+			continue
+		}
+		if aggregatedCurrentKnownStatus == nil || *aggregatedCurrentKnownStatus > currentStatus {
+			aggregatedCurrentKnownStatus = &currentStatus
+		}
+
+		resourceKey := addressable.ResourceKey
+
+		// We want to requeue the resource only once when we have all probe request
+		// results.
+		enqueueOnce.Do(func() {
+			// Wait in a separate gorouting.
+			go func() {
+				// Wait for all the prober request results and then requeue the
+				// resource.
+				wg.Wait()
+				a.enqueue(resourceKey)
+			}()
+		})
+
+		go func() {
+			defer wg.Done()
+			// Probe the pod.
+			status := probe(ctx, a.client, logger, address)
+			logger.Debug("Probe status", zap.Stringer("status", status))
+			// Update the status in the cache.
+			a.cache.UpsertStatus(address, status, resourceKey, a.enqueueArg)
+		}()
+	}
+
+	if aggregatedCurrentKnownStatus == nil {
+		// Every status is ready, return ready.
+		return StatusReady
+	}
+	return *aggregatedCurrentKnownStatus
+}
+
+func (a *asyncProber) enqueueArg(_ string, arg interface{}) {
+	a.enqueue(arg.(types.NamespacedName))
+}

--- a/control-plane/pkg/prober/async_prober_test.go
+++ b/control-plane/pkg/prober/async_prober_test.go
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prober
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	podinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
+	"knative.dev/pkg/network"
+	reconcilertesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestAsyncProber(t *testing.T) {
+
+	tt := []struct {
+		name                string
+		pods                []*corev1.Pod
+		podsLabelsSelector  labels.Selector
+		addressable         Addressable
+		responseStatusCode  int
+		wantStatus          Status
+		wantRequeueCountMin int
+		wantRequestCountMin int
+	}{
+		{
+			name:               "no pods",
+			pods:               []*corev1.Pod{},
+			podsLabelsSelector: labels.SelectorFromSet(map[string]string{"app": "p"}),
+			addressable: Addressable{
+				Address:     &url.URL{Scheme: "http", Path: "/b1/b1"},
+				ResourceKey: types.NamespacedName{Namespace: "b1", Name: "b1"},
+			},
+			responseStatusCode:  http.StatusOK,
+			wantStatus:          StatusNotReady,
+			wantRequeueCountMin: 0,
+		},
+		{
+			name: "single pod",
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "p1",
+						Labels:    map[string]string{"app": "p"},
+					},
+					Status: corev1.PodStatus{PodIP: "127.0.0.1"},
+				},
+			},
+			podsLabelsSelector: labels.SelectorFromSet(map[string]string{"app": "p"}),
+			addressable: Addressable{
+				Address:     &url.URL{Scheme: "http", Path: "/b1/b1"},
+				ResourceKey: types.NamespacedName{Namespace: "b1", Name: "b1"},
+			},
+			responseStatusCode:  http.StatusOK,
+			wantStatus:          StatusReady,
+			wantRequeueCountMin: 1,
+			wantRequestCountMin: 1,
+		},
+		{
+			name: "single pod - 404",
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Name:      "p1",
+						Labels:    map[string]string{"app": "p"},
+					},
+					Status: corev1.PodStatus{PodIP: "127.0.0.1"},
+				},
+			},
+			podsLabelsSelector: labels.SelectorFromSet(map[string]string{"app": "p"}),
+			addressable: Addressable{
+				Address:     &url.URL{Scheme: "http", Path: "/b1/b1"},
+				ResourceKey: types.NamespacedName{Namespace: "b1", Name: "b1"},
+			},
+			responseStatusCode:  http.StatusNotFound,
+			wantStatus:          StatusNotReady,
+			wantRequeueCountMin: 1,
+			wantRequestCountMin: 1,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, _ := reconcilertesting.SetupFakeContext(t)
+			ctx, cacel := context.WithCancel(ctx)
+			defer func() {
+				time.Sleep(time.Second)
+				cacel()
+			}()
+			wantRequestCountMin := atomic.NewInt64(int64(tc.wantRequestCountMin))
+			h := http.HandlerFunc(func(writer http.ResponseWriter, r *http.Request) {
+				wantRequestCountMin.Dec()
+				require.Equal(t, network.ProbeHeaderValue, r.Header.Get(network.ProbeHeaderName))
+				writer.WriteHeader(tc.responseStatusCode)
+			})
+			s := httptest.NewUnstartedServer(h)
+			s.Start()
+			time.Sleep(time.Second) // Wait for the server time to start.
+			defer s.Close()
+
+			for _, p := range tc.pods {
+				_ = podinformer.Get(ctx).Informer().GetStore().Add(p)
+			}
+			tc.addressable.Address.Host = s.URL
+			u, _ := url.Parse(s.URL)
+
+			wantRequeueCountMin := atomic.NewInt64(int64(tc.wantRequeueCountMin))
+			prober := NewAsync(ctx, s.Client(), u.Port(), tc.podsLabelsSelector, func(key types.NamespacedName) {
+				wantRequeueCountMin.Dec()
+			})
+			probeFunc := func() bool {
+				status := prober.Probe(ctx, tc.addressable)
+				return status == tc.wantStatus
+			}
+
+			require.Eventuallyf(t, probeFunc, time.Second, 10*time.Millisecond, "")
+			require.GreaterOrEqual(t, int64(0), wantRequeueCountMin.Load())
+			require.GreaterOrEqual(t, int64(0), wantRequestCountMin.Load())
+		})
+	}
+}

--- a/control-plane/pkg/prober/cache.go
+++ b/control-plane/pkg/prober/cache.go
@@ -35,6 +35,17 @@ const (
 // Status represents the resource status.
 type Status int
 
+func (s Status) String() string {
+	switch s {
+	case StatusReady:
+		return "Ready"
+	case StatusNotReady:
+		return "NotReady"
+	default:
+		return "Unknown"
+	}
+}
+
 // Cache is a key-status store.
 type Cache interface {
 	// GetStatus retries the status associated with the given key.

--- a/control-plane/pkg/prober/prober.go
+++ b/control-plane/pkg/prober/prober.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prober
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/network"
+)
+
+// Addressable contains addressable resource data for the prober.
+type Addressable struct {
+	// Addressable address.
+	Address *url.URL
+	// Resource key.
+	ResourceKey types.NamespacedName
+}
+
+// EnqueueFunc enqueues the given provided resource key.
+type EnqueueFunc func(key types.NamespacedName)
+
+// Prober probes an addressable resource.
+type Prober interface {
+	// Probe probes the provided Addressable resource and returns its Status.
+	Probe(ctx context.Context, addressable Addressable) Status
+}
+
+// Func type is an adapter to allow the use of
+// ordinary functions as Prober. If f is a function
+// with the appropriate signature, Func(f) is a
+// Prober that calls f.
+type Func func(ctx context.Context, addressable Addressable) Status
+
+// Probe implements the Prober interface for Func.
+func (p Func) Probe(ctx context.Context, addressable Addressable) Status {
+	return p(ctx, addressable)
+}
+
+// httpClient interface is an interface for an HTTP client.
+type httpClient interface {
+	Do(r *http.Request) (*http.Response, error)
+}
+
+func probe(ctx context.Context, client httpClient, logger *zap.Logger, address string) Status {
+	logger.Debug("Sending probe request")
+
+	r, err := http.NewRequestWithContext(ctx, http.MethodGet, address, nil)
+	if err != nil {
+		logger.Error("Failed to create request", zap.Error(err))
+		return StatusUnknown
+	}
+	r.Header.Add(network.ProbeHeaderName, network.ProbeHeaderValue)
+	r.Header.Add(network.HashHeaderName, "probe")
+
+	select {
+	case <-ctx.Done():
+		return StatusUnknown
+	default:
+	}
+
+	response, err := client.Do(r)
+	if err != nil {
+		logger.Error("Failed probe", zap.Error(err))
+		return StatusUnknown
+	}
+
+	if response.StatusCode != http.StatusOK {
+		logger.Info("Resource not ready", zap.Int("statusCode", response.StatusCode))
+		return StatusNotReady
+	}
+
+	return StatusReady
+}

--- a/control-plane/pkg/prober/prober_test.go
+++ b/control-plane/pkg/prober/prober_test.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prober
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestFuncProbe(t *testing.T) {
+
+	calls := atomic.NewInt32(0)
+	status := StatusReady
+	p := Func(func(ctx context.Context, addressable Addressable) Status {
+		calls.Inc()
+		return status
+	})
+
+	s := p.Probe(context.Background(), Addressable{})
+
+	require.Equal(t, status, s, s.String())
+	require.Equal(t, int32(1), calls.Load())
+}

--- a/control-plane/pkg/prober/probertesting/mock_prober.go
+++ b/control-plane/pkg/prober/probertesting/mock_prober.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package probertesting
+
+import (
+	"context"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
+)
+
+// MockProber returns a prober that always returns the provided status.
+func MockProber(status prober.Status) prober.Prober {
+	return prober.Func(func(ctx context.Context, addressable prober.Addressable) prober.Status {
+		return status
+	})
+}

--- a/control-plane/pkg/prober/probertesting/mock_prober_test.go
+++ b/control-plane/pkg/prober/probertesting/mock_prober_test.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package probertesting
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
+)
+
+func TestMockProber(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      prober.Status
+		ctx         context.Context
+		addressable prober.Addressable
+	}{
+		{
+			name:        "unknown",
+			status:      prober.StatusUnknown,
+			ctx:         context.Background(),
+			addressable: prober.Addressable{},
+		},
+		{
+			name:        "ready",
+			status:      prober.StatusReady,
+			ctx:         context.Background(),
+			addressable: prober.Addressable{},
+		},
+		{
+			name:        "notReady",
+			status:      prober.StatusNotReady,
+			ctx:         context.Background(),
+			addressable: prober.Addressable{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MockProber(tt.status).Probe(tt.ctx, tt.addressable)
+			if diff := cmp.Diff(tt.status, got); diff != "" {
+				t.Error("(-want, got)", diff)
+			}
+		})
+	}
+}

--- a/control-plane/pkg/receiver/address.go
+++ b/control-plane/pkg/receiver/address.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package receiver
+
+import (
+	"fmt"
+	"net/url"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Address(host string, object metav1.Object) *url.URL {
+	return &url.URL{
+		Scheme: "http",
+		Host:   host,
+		Path:   fmt.Sprintf("/%s/%s", object.GetNamespace(), object.GetName()),
+	}
+}

--- a/control-plane/pkg/reconciler/base/reconciler.go
+++ b/control-plane/pkg/reconciler/base/reconciler.go
@@ -88,7 +88,7 @@ type Reconciler struct {
 }
 
 func (r *Reconciler) IsReceiverRunning() bool {
-	pods, err := r.PodLister.List(r.receiverSelector())
+	pods, err := r.PodLister.List(r.ReceiverSelector())
 	return err == nil && len(pods) > 0 && isAtLeastOneRunning(pods)
 }
 
@@ -215,7 +215,7 @@ func (r *Reconciler) UpdateDispatcherPodsAnnotation(ctx context.Context, logger 
 }
 
 func (r *Reconciler) UpdateReceiverPodsAnnotation(ctx context.Context, logger *zap.Logger, volumeGeneration uint64) error {
-	pods, errors := r.PodLister.Pods(r.SystemNamespace).List(r.receiverSelector())
+	pods, errors := r.PodLister.Pods(r.SystemNamespace).List(r.ReceiverSelector())
 	if errors != nil {
 		return fmt.Errorf("failed to list receiver pods in namespace %s: %w", r.SystemNamespace, errors)
 	}
@@ -262,7 +262,7 @@ func (r *Reconciler) updatePodsAnnotation(ctx context.Context, logger *zap.Logge
 	return errors
 }
 
-func (r *Reconciler) receiverSelector() labels.Selector {
+func (r *Reconciler) ReceiverSelector() labels.Selector {
 	return labels.SelectorFromSet(map[string]string{"app": r.ReceiverLabel})
 }
 

--- a/control-plane/pkg/reconciler/broker/controller_test.go
+++ b/control-plane/pkg/reconciler/broker/controller_test.go
@@ -43,6 +43,7 @@ func TestNewController(t *testing.T) {
 	env := &config.Env{
 		SystemNamespace:      "cm",
 		GeneralConfigMapName: "cm",
+		IngressPodPort:       "8080",
 	}
 
 	ctx, _ = fakekubeclient.With(

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -48,6 +48,7 @@ import (
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
 	coreconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/core/config"
 	kafkalogging "knative.dev/eventing-kafka-broker/control-plane/pkg/logging"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/receiver"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
@@ -79,6 +80,10 @@ type Reconciler struct {
 	InitOffsetsFunc kafka.InitOffsetsFunc
 
 	ConfigMapLister corelisters.ConfigMapLister
+
+	Prober prober.Prober
+
+	IngressHost string
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, channel *messagingv1beta1.KafkaChannel) reconciler.Event {
@@ -266,7 +271,22 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 		return subscriptionError
 	}
 
-	return statusConditionManager.Reconciled()
+	address := receiver.Address(r.IngressHost, channel)
+	proberAddressable := prober.Addressable{
+		Address: address,
+		ResourceKey: types.NamespacedName{
+			Namespace: channel.GetNamespace(),
+			Name:      channel.GetName(),
+		},
+	}
+
+	if status := r.Prober.Probe(ctx, proberAddressable); status != prober.StatusReady {
+		statusConditionManager.ProbesStatusNotReady(status)
+		return nil // Object will get re-queued once probe status changes.
+	}
+	statusConditionManager.Addressable(address)
+
+	return nil
 }
 
 func (r *Reconciler) FinalizeKind(ctx context.Context, channel *messagingv1beta1.KafkaChannel) reconciler.Event {

--- a/control-plane/pkg/reconciler/channel/controller_test.go
+++ b/control-plane/pkg/reconciler/channel/controller_test.go
@@ -42,6 +42,7 @@ func TestNewController(t *testing.T) {
 	configs := &config.Env{
 		SystemNamespace:      "cm",
 		GeneralConfigMapName: "cm",
+		IngressPodPort:       "8080",
 	}
 
 	ctx, _ = fakekubeclient.With(

--- a/control-plane/pkg/reconciler/sink/controller_test.go
+++ b/control-plane/pkg/reconciler/sink/controller_test.go
@@ -35,7 +35,9 @@ func TestNewController(t *testing.T) {
 
 	ctx, _ := reconcilertesting.SetupFakeContext(t)
 
-	controller := NewController(ctx, nil, &config.Env{})
+	controller := NewController(ctx, nil, &config.Env{
+		IngressPodPort: "8080",
+	})
 
 	assert.NotNil(t, controller, "controller is nil")
 }

--- a/control-plane/pkg/reconciler/source/source.go
+++ b/control-plane/pkg/reconciler/source/source.go
@@ -208,7 +208,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *sources.KafkaSource)
 		logger.Debug("Updated dispatcher pod annotation")
 	}
 
-	return statusConditionManager.Reconciled()
+	return nil
 }
 
 func (r *Reconciler) FinalizeKind(ctx context.Context, ks *sources.KafkaSource) reconciler.Event {

--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -24,13 +24,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgotesting "k8s.io/client-go/testing"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
 	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
 	reconcilertesting "knative.dev/eventing/pkg/reconciler/testing/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/network"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
 	. "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/broker"
@@ -284,4 +286,14 @@ func BrokerReceiverPodUpdate(namespace string, annotations map[string]string) cl
 		namespace,
 		BrokerReceiverPod(namespace, annotations),
 	)
+}
+
+func StatusBrokerProbeSucceeded(broker *eventing.Broker) {
+	StatusProbeSucceeded(broker)
+}
+
+func StatusBrokerProbeFailed(status prober.Status) reconcilertesting.BrokerOption {
+	return func(broker *eventing.Broker) {
+		StatusProbeFailed(status)(broker)
+	}
 }

--- a/control-plane/pkg/reconciler/testing/objects_common.go
+++ b/control-plane/pkg/reconciler/testing/objects_common.go
@@ -28,11 +28,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgotesting "k8s.io/client-go/testing"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/security"
 	reconcilertesting "knative.dev/eventing/pkg/reconciler/testing/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/security"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
 )
@@ -262,6 +264,20 @@ func StatusDataPlaneNotAvailable(obj duckv1.KRShaped) {
 		base.ReasonDataPlaneNotAvailable,
 		base.MessageDataPlaneNotAvailable,
 	)
+}
+
+func StatusProbeSucceeded(obj duckv1.KRShaped) {
+	obj.GetConditionSet().Manage(obj.GetStatus()).MarkTrue(base.ConditionProbeSucceeded)
+}
+
+func StatusProbeFailed(status prober.Status) func(obj duckv1.KRShaped) {
+	return func(obj duckv1.KRShaped) {
+		obj.GetConditionSet().Manage(obj.GetStatus()).MarkFalse(
+			base.ConditionProbeSucceeded,
+			"ProbeStatus",
+			fmt.Sprintf("status: %s", status.String()),
+		)
+	}
 }
 
 func allocateStatusAnnotations(obj duckv1.KRShaped) {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/rickb777/date v1.14.1
 	github.com/stretchr/testify v1.7.0
 	github.com/xdg-go/scram v1.0.2
+	go.uber.org/atomic v1.9.0
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -382,6 +382,7 @@ go.opentelemetry.io/otel/label
 go.opentelemetry.io/otel/propagation
 go.opentelemetry.io/otel/trace
 # go.uber.org/atomic v1.9.0
+## explicit
 go.uber.org/atomic
 # go.uber.org/automaxprocs v1.4.0
 go.uber.org/automaxprocs


### PR DESCRIPTION
This patch adds the `Prober` that probes the receiver for readiness.

It uses the cache introduced in https://github.com/knative-sandbox/eventing-kafka-broker/pull/1401 and the data plane
probe handling introduced in https://github.com/knative-sandbox/eventing-kafka-broker/pull/1431.

## Proposed Changes

- Probe resource ingress for readiness

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
The kafka-controller deployment emits probe requests against the data plane (kafka-sink-receiver and kafka-broker-receiver) to determine Kafka Broker and KafkaSink readiness.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```

/kind enhancement