### PR TITLE
[release-0.26] Properly handle events without the `data` field (#1460)

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
@@ -21,19 +21,21 @@ import dev.knative.eventing.kafka.broker.dispatcher.Filter;
 import dev.knative.eventing.kafka.broker.dispatcher.RecordDispatcher;
 import dev.knative.eventing.kafka.broker.dispatcher.RecordDispatcherListener;
 import dev.knative.eventing.kafka.broker.dispatcher.ResponseHandler;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.KafkaConsumerRecordUtils;
 import io.cloudevents.CloudEvent;
+import io.cloudevents.kafka.CloudEventDeserializer;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.kafka.client.common.tracing.ConsumerTracer;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 import java.util.function.Function;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static dev.knative.eventing.kafka.broker.core.utils.Logging.keyValue;
 
@@ -46,6 +48,8 @@ import static dev.knative.eventing.kafka.broker.core.utils.Logging.keyValue;
 public class RecordDispatcherImpl implements RecordDispatcher {
 
   private static final Logger logger = LoggerFactory.getLogger(RecordDispatcherImpl.class);
+
+  private static final CloudEventDeserializer cloudEventDeserializer = new CloudEventDeserializer();
 
   private final Filter filter;
   private final Function<KafkaConsumerRecord<String, CloudEvent>, Future<Void>> subscriberSender;
@@ -92,8 +96,6 @@ public class RecordDispatcherImpl implements RecordDispatcher {
    */
   @Override
   public Future<Void> dispatch(KafkaConsumerRecord<String, CloudEvent> record) {
-    Promise<Void> promise = Promise.promise();
-
     /*
     That's pretty much what happens here:
 
@@ -116,9 +118,23 @@ public class RecordDispatcherImpl implements RecordDispatcher {
       +->end<--+
      */
 
-    onRecordReceived(record, promise);
-
-    return promise.future();
+    try {
+      Promise<Void> promise = Promise.promise();
+      onRecordReceived(maybeDeserializeValueFromHeaders(record), promise);
+      return promise.future();
+    } catch (final Exception ex) {
+      // This is a fatal exception that shouldn't happen in normal cases.
+      //
+      // It might happen if folks send bad records to a topic that is
+      // managed by our system.
+      //
+      // So discard record if we can't deal with the record, so that we can
+      // make progress in the partition.
+      logError("Exception occurred, discarding the record", record, ex);
+      recordDispatcherListener.recordReceived(record);
+      recordDispatcherListener.recordDiscarded(record);
+      return Future.failedFuture(ex);
+    }
   }
 
   private void onRecordReceived(final KafkaConsumerRecord<String, CloudEvent> record, Promise<Void> finalProm) {
@@ -190,6 +206,23 @@ public class RecordDispatcherImpl implements RecordDispatcher {
                                        final Promise<Void> finalProm) {
     recordDispatcherListener.failedToSendToDeadLetterSink(record, exception);
     finalProm.complete();
+  }
+
+  private static KafkaConsumerRecord<String, CloudEvent> maybeDeserializeValueFromHeaders(KafkaConsumerRecord<String, CloudEvent> record) {
+    if (record.value() != null) {
+      return record;
+    }
+    // A valid CloudEvent in the CE binary protocol binding of Kafka
+    // might be composed by only Headers.
+    //
+    // KafkaConsumer doesn't call the deserializer if the value
+    // is null.
+    //
+    // That means that we get a record with a null value and some CE
+    // headers even though the record is a valid CloudEvent.
+    logDebug("Value is null", record);
+    final var value = cloudEventDeserializer.deserialize(record.record().topic(), record.record().headers(), null);
+    return new KafkaConsumerRecordImpl<>(KafkaConsumerRecordUtils.copyRecordAssigningValue(record.record(), value));
   }
 
   private static Function<KafkaConsumerRecord<String, CloudEvent>, Future<Void>> composeSenderAndSinkHandler(

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/KafkaConsumerRecordUtils.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/KafkaConsumerRecordUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.dispatcher.impl.consumer;
+
+import io.cloudevents.CloudEvent;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public final class KafkaConsumerRecordUtils {
+
+  private KafkaConsumerRecordUtils() {
+  }
+
+  public static <T> ConsumerRecord<T, CloudEvent> copyRecordAssigningValue(final ConsumerRecord<T, CloudEvent> record,
+                                                                           final CloudEvent value) {
+    return new ConsumerRecord<>(
+      record.topic(),
+      record.partition(),
+      record.offset(),
+      record.timestamp(),
+      record.timestampType(),
+      record.checksum(),
+      record.serializedKeySize(),
+      record.serializedValueSize(),
+      record.key(),
+      value,
+      record.headers(),
+      record.leaderEpoch()
+    );
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/knative-sandbox/eventing-kafka-broker/pull/1460

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Properly handle events without the `data` field.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
/kind bug