### PR TITLE
Remove broker.spec.config defaulting magic

### DIFF
--- a/control-plane/cmd/kafka-controller/main.go
+++ b/control-plane/cmd/kafka-controller/main.go
@@ -57,7 +57,7 @@ func main() {
 
 		// Broker controller
 		func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
-			return broker.NewController(ctx, watcher, brokerEnv, "")
+			return broker.NewController(ctx, watcher, brokerEnv)
 		},
 
 		// Trigger controller

--- a/control-plane/cmd/webhook-kafka/main.go
+++ b/control-plane/cmd/webhook-kafka/main.go
@@ -31,7 +31,9 @@ import (
 	"knative.dev/pkg/webhook/resourcesemantics/validation"
 
 	sourcesv1beta1 "knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
+	eventingcorev1beta1 "knative.dev/eventing/pkg/apis/eventing/v1"
 
+	eventingv1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1"
 	eventingv1alpha1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
 )
 
@@ -44,7 +46,9 @@ var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 	sourcesv1beta1.SchemeGroupVersion.WithKind("KafkaSource"): &sourcesv1beta1.KafkaSource{},
 }
 
-var callbacks = map[schema.GroupVersionKind]validation.Callback{}
+var callbacks = map[schema.GroupVersionKind]validation.Callback{
+	eventingcorev1beta1.SchemeGroupVersion.WithKind("Broker"): eventingv1.BrokerValidationCallback(),
+}
 
 func NewDefaultingAdmissionController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 

--- a/control-plane/config/200-webhook/100-webhook-cluster-role.yaml
+++ b/control-plane/config/200-webhook/100-webhook-cluster-role.yaml
@@ -90,3 +90,11 @@ rules:
     verbs:
       - "update"
 
+  # Eventing resources care about
+  - apiGroups:
+      - "eventing.knative.dev"
+    resources:
+      - "brokers"
+    verbs:
+      - list
+      - get

--- a/control-plane/pkg/apis/eventing/v1/broker_validation.go
+++ b/control-plane/pkg/apis/eventing/v1/broker_validation.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1
+
+import (
+	"context"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/webhook"
+	"knative.dev/pkg/webhook/resourcesemantics/validation"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
+)
+
+type BrokerPartial struct {
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	// Spec defines the desired state of the Broker.
+	Spec BrokerPartialSpec `json:"spec,omitempty"`
+}
+
+type BrokerPartialSpec struct {
+	// Config is a KReference to the configuration that specifies
+	// configuration options for this Broker. For example, this could be
+	// a pointer to a ConfigMap.
+	// +optional
+	Config *duckv1.KReference `json:"config,omitempty"`
+}
+
+func (b BrokerPartialSpec) Validate(context.Context) error {
+	if b.Config == nil {
+		return apis.ErrMissingField("config").ViaField("spec")
+	}
+	if strings.ToLower(b.Config.Kind) != "configmap" {
+		return apis.ErrInvalidValue(b.Config.Kind, "kind", "Expected ConfigMap").ViaField("config").ViaField("spec")
+	}
+	return nil
+}
+
+func validateBrokerFromUnstructured(ctx context.Context, unstructured *unstructured.Unstructured) error {
+	broker := BrokerPartial{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.UnstructuredContent(), &broker); err != nil {
+		return err
+	}
+	if class, ok := broker.Annotations[eventing.BrokerClassAnnotationKey]; !ok || class != kafka.BrokerClass {
+		return nil
+	}
+	return broker.Spec.Validate(ctx)
+}
+
+func BrokerValidationCallback() validation.Callback {
+	return validation.NewCallback(validateBrokerFromUnstructured, webhook.Create, webhook.Update)
+}

--- a/control-plane/pkg/apis/eventing/v1/broker_validation_test.go
+++ b/control-plane/pkg/apis/eventing/v1/broker_validation_test.go
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestValidateBrokerFromUnstructured(t *testing.T) {
+	tests := []struct {
+		name         string
+		ctx          context.Context
+		unstructured *unstructured.Unstructured
+		wantErr      bool
+	}{
+		{
+			name: "no kafka broker",
+			ctx:  context.Background(),
+			unstructured: &unstructured.Unstructured{
+				Object: map[string]interface{}{"spec": map[string]interface{}{}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing config",
+			ctx:  context.Background(),
+			unstructured: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]string{
+							"eventing.knative.dev/broker.class": "Kafka",
+						},
+					},
+					"spec": map[string]interface{}{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown kind",
+			ctx:  context.Background(),
+			unstructured: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]string{
+							"eventing.knative.dev/broker.class": "Kafka",
+						},
+					},
+					"spec": map[string]interface{}{
+						"config": map[string]string{
+							"apiVersion": "eventing.knative.dev/v1",
+							"kind":       "Broker",
+							"namespace":  "ns",
+							"name":       "name",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "ConfigMap in config",
+			ctx:  context.Background(),
+			unstructured: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]string{
+							"eventing.knative.dev/broker.class": "Kafka",
+						},
+					},
+					"spec": map[string]interface{}{
+						"config": map[string]string{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"namespace":  "ns",
+							"name":       "name",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateBrokerFromUnstructured(tt.ctx, tt.unstructured); (err != nil) != tt.wantErr {
+				t.Errorf("validateBrokerFromUnstructured() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/control-plane/pkg/reconciler/broker/broker_test.go
+++ b/control-plane/pkg/reconciler/broker/broker_test.go
@@ -171,9 +171,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 					),
 				},
 			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-			},
 		},
 		{
 			Name: "Reconciled failed - probe " + prober.StatusNotReady.String(),
@@ -232,8 +229,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				},
 			},
 			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-				testProber:                         probertesting.MockProber(prober.StatusNotReady),
+				testProber: probertesting.MockProber(prober.StatusNotReady),
 			},
 		},
 		{
@@ -293,8 +289,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				},
 			},
 			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-				testProber:                         probertesting.MockProber(prober.StatusUnknown),
+				testProber: probertesting.MockProber(prober.StatusUnknown),
 			},
 		},
 		{
@@ -353,9 +348,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 					),
 				},
 			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-			},
 		},
 		{
 			Name: "Reconciled normal - with DLS - no DLS ref namespace",
@@ -413,9 +405,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 					),
 				},
 			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-			},
 		},
 		{
 			Name: "Failed to create topic",
@@ -450,8 +439,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				},
 			},
 			OtherTestData: map[string]interface{}{
-				wantErrorOnCreateTopic:             createTopicError,
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
+				wantErrorOnCreateTopic: createTopicError,
 			},
 		},
 		{
@@ -517,9 +505,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 					),
 				},
 			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-			},
 		},
 		{
 			Name: "Reconciled normal - config map not readable",
@@ -571,9 +556,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 						StatusBrokerProbeSucceeded,
 					),
 				},
-			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
 			},
 		},
 		{
@@ -653,9 +635,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 						StatusBrokerProbeSucceeded,
 					),
 				},
-			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
 			},
 		},
 		{
@@ -753,9 +732,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 					),
 				},
 			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-			},
 		},
 		{
 			Name: "Reconciled normal - remove existing broker DLS while preserving others",
@@ -838,9 +814,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 					),
 				},
 			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-			},
 		},
 		{
 			Name: "Reconciled normal - increment volume generation",
@@ -916,9 +889,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 					),
 				},
 			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-			},
 		},
 		{
 			Name: "Failed to resolve DLS",
@@ -983,9 +953,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 						StatusBrokerTopicReady,
 					),
 				},
-			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
 			},
 		},
 		{
@@ -1088,7 +1055,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				},
 			},
 			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
 				ExpectedTopicDetail: sarama.TopicDetail{
 					NumPartitions:     20,
 					ReplicationFactor: 5,
@@ -1167,7 +1133,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				},
 			},
 			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
 				ExpectedTopicDetail: sarama.TopicDetail{
 					NumPartitions:     20,
 					ReplicationFactor: 5,
@@ -1209,9 +1174,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 						StatusBrokerConfigNotParsed(fmt.Sprintf(`failed to get configmap %s/%s: configmap %q not found`, ConfigMapNamespace, ConfigMapName, ConfigMapName)),
 					),
 				},
-			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
 			},
 		},
 		{
@@ -1265,9 +1227,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 						StatusBrokerConfigNotParsed(`supported config Kind: ConfigMap - got Pod`),
 					),
 				},
-			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
 			},
 		},
 		{
@@ -1380,9 +1339,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 					),
 				},
 			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-			},
 		},
 		{
 			Name: "no data plane pods running",
@@ -1475,9 +1431,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 					),
 				},
 			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-			},
 		},
 		{
 			Name: "Reconciled normal - with retry config - linear",
@@ -1542,9 +1495,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 					),
 				},
 			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-			},
 		},
 		{
 			Name: "Reconciled normal - with no retry num",
@@ -1605,9 +1555,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 						BrokerDLSResolved(ServiceURL),
 					),
 				},
-			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
 			},
 		},
 		{
@@ -1673,9 +1620,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 					),
 				},
 			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-			},
 		},
 		{
 			Name: "Reconciled normal - unchanged",
@@ -1722,9 +1666,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 						BrokerDLSResolved(ServiceURL),
 					),
 				},
-			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
 			},
 		},
 		{
@@ -1776,9 +1717,6 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 					),
 				},
 			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-			},
 		},
 	}
 
@@ -1827,9 +1765,6 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 					Generation: 2,
 				}),
 			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-			},
 		},
 		{
 			Name: "Reconciled normal - with DLS",
@@ -1855,9 +1790,6 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 				ConfigMapUpdate(&env, &contract.Contract{
 					Generation: 2,
 				}),
-			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
 			},
 		},
 		{
@@ -1892,8 +1824,7 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 				}),
 			},
 			OtherTestData: map[string]interface{}{
-				wantErrorOnDeleteTopic:             deleteTopicError,
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
+				wantErrorOnDeleteTopic: deleteTopicError,
 			},
 		},
 		{
@@ -1910,9 +1841,6 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 				NewConfigMapWithBinaryData(&env, nil),
 			},
 			SkipNamespaceValidation: true, // WantCreates compare the broker namespace with configmap namespace, so skip it
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-			},
 		},
 		{
 			Name: "Reconciled normal - preserve config map previous state",
@@ -1947,9 +1875,6 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 					},
 					Generation: 6,
 				}),
-			},
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
 			},
 		},
 		{
@@ -1987,8 +1912,7 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 				}),
 			},
 			OtherTestData: map[string]interface{}{
-				wantErrorOnDeleteTopic:             sarama.ErrUnknownTopicOrPartition,
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
+				wantErrorOnDeleteTopic: sarama.ErrUnknownTopicOrPartition,
 			},
 		},
 		{
@@ -2008,9 +1932,6 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 				}, &env),
 			},
 			Key: testKey,
-			OtherTestData: map[string]interface{}{
-				kafka.BootstrapServersConfigMapKey: bootstrapServers,
-			},
 		},
 	}
 

--- a/control-plane/pkg/reconciler/broker/controller.go
+++ b/control-plane/pkg/reconciler/broker/controller.go
@@ -19,13 +19,11 @@ package broker
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/Shopify/sarama"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -48,11 +46,11 @@ import (
 )
 
 const (
-	DefaultNumPartitions     = 10
-	DefaultReplicationFactor = 1
+	DefaultNumPartitions     = 20
+	DefaultReplicationFactor = 5
 )
 
-func NewController(ctx context.Context, watcher configmap.Watcher, env *config.Env, bootstrapServers string) *controller.Impl {
+func NewController(ctx context.Context, watcher configmap.Watcher, env *config.Env) *controller.Impl {
 
 	eventing.RegisterAlternateBrokerConditionSet(base.IngressConditionSet)
 
@@ -71,12 +69,8 @@ func NewController(ctx context.Context, watcher configmap.Watcher, env *config.E
 			ReceiverLabel:               base.BrokerReceiverLabel,
 		},
 		NewKafkaClusterAdminClient: sarama.NewClusterAdmin,
-		KafkaDefaultTopicDetails: sarama.TopicDetail{
-			NumPartitions:     DefaultNumPartitions,
-			ReplicationFactor: DefaultReplicationFactor,
-		},
-		ConfigMapLister: configmapInformer.Lister(),
-		Env:             env,
+		ConfigMapLister:            configmapInformer.Lister(),
+		Env:                        env,
 	}
 
 	logger := logging.FromContext(ctx)
@@ -87,10 +81,6 @@ func NewController(ctx context.Context, watcher configmap.Watcher, env *config.E
 			zap.String("configmap", env.DataPlaneConfigMapAsString()),
 			zap.Error(err),
 		)
-	}
-
-	if bootstrapServers != "" {
-		reconciler.SetBootstrapServers(bootstrapServers)
 	}
 
 	impl := brokerreconciler.NewImpl(ctx, reconciler, kafka.BrokerClass)
@@ -142,15 +132,6 @@ func NewController(ctx context.Context, watcher configmap.Watcher, env *config.E
 			DeleteFunc: reconciler.OnDeleteObserver,
 		},
 	})
-
-	cm, err := reconciler.KubeClient.CoreV1().ConfigMaps(env.SystemNamespace).Get(ctx, env.GeneralConfigMapName, metav1.GetOptions{})
-	if err != nil {
-		panic(fmt.Errorf("failed to get config map %s/%s: %w", env.SystemNamespace, env.GeneralConfigMapName, err))
-	}
-
-	reconciler.ConfigMapUpdated(ctx)(cm)
-
-	watcher.Watch(env.GeneralConfigMapName, reconciler.ConfigMapUpdated(ctx))
 
 	return impl
 }

--- a/control-plane/pkg/reconciler/broker/controller_test.go
+++ b/control-plane/pkg/reconciler/broker/controller_test.go
@@ -68,7 +68,6 @@ func TestNewController(t *testing.T) {
 			},
 		}),
 		env,
-		"",
 	)
 	if controller == nil {
 		t.Error("failed to create controller: <nil>")

--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -59,6 +59,9 @@ func NewBroker(options ...reconcilertesting.BrokerOption) runtime.Object {
 		append(
 			[]reconcilertesting.BrokerOption{
 				reconcilertesting.WithBrokerClass(kafka.BrokerClass),
+				WithBrokerConfig(
+					KReference(BrokerConfig("", 20, 5)),
+				),
 				func(broker *eventing.Broker) {
 					broker.UID = BrokerUUID
 				},


### PR DESCRIPTION
## Proposed Changes

- Remove broker.spec.config defaulting magic
- Add webhook validation (i think we're better off rejecting invalid Brokers from the start)

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
`broker.spec.config` is now required.
```

**Docs**

- I'll check if docs mentions this feature (I don't thing it does)

/assign @aliok 