### PR TITLE
Channel to use new configmap format for bootstrap servers

### DIFF
--- a/control-plane/config/100-channel/100-kafka-channel-configmap.yaml
+++ b/control-plane/config/100-channel/100-kafka-channel-configmap.yaml
@@ -1,0 +1,25 @@
+---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-channel-config
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
+data:
+  bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"

--- a/control-plane/config/200-controller/500-controller.yaml
+++ b/control-plane/config/200-controller/500-controller.yaml
@@ -92,7 +92,7 @@ spec:
             - name: BROKER_GENERAL_CONFIG_MAP_NAME
               value: kafka-broker-config
             - name: CHANNEL_GENERAL_CONFIG_MAP_NAME
-              value: kafka-broker-config
+              value: kafka-channel-config
             - name: SINK_GENERAL_CONFIG_MAP_NAME
               value: kafka-broker-config
             - name: SOURCE_GENERAL_CONFIG_MAP_NAME

--- a/control-plane/pkg/reconciler/kafka/topic.go
+++ b/control-plane/pkg/reconciler/kafka/topic.go
@@ -58,6 +58,26 @@ func TopicConfigFromConfigMap(logger *zap.Logger, cm *corev1.ConfigMap) (*TopicC
 	return config, nil
 }
 
+func BootstrapServersFromConfigMap(logger *zap.Logger, cm *corev1.ConfigMap) ([]string, error) {
+	topicConfig, err := buildTopicConfigFromConfigMap(cm)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse config map %s/%s: %w", cm.Namespace, cm.Name, err)
+	}
+
+	if len(topicConfig.BootstrapServers) == 0 {
+		return nil, fmt.Errorf(
+			"invalid configuration bootstrapServers: %s",
+			topicConfig.BootstrapServers,
+		)
+	}
+
+	logger.Debug("bootstrap servers from configmap",
+		zap.Any("bootstrapServers", topicConfig.BootstrapServers),
+	)
+
+	return topicConfig.BootstrapServers, nil
+}
+
 func buildTopicConfigFromConfigMap(cm *corev1.ConfigMap) (*TopicConfig, error) {
 	topicDetail := sarama.TopicDetail{}
 

--- a/control-plane/pkg/reconciler/kafka/topic.go
+++ b/control-plane/pkg/reconciler/kafka/topic.go
@@ -52,7 +52,7 @@ func TopicConfigFromConfigMap(logger *zap.Logger, cm *corev1.ConfigMap) (*TopicC
 	logger.Debug("topic config from configmap",
 		zap.Int32("numPartitions", config.TopicDetail.NumPartitions),
 		zap.Int16("replicationFactor", config.TopicDetail.ReplicationFactor),
-		zap.Any("replicationFactor", config.BootstrapServers),
+		zap.Any("bootstrapServers", config.BootstrapServers),
 	)
 
 	return config, nil

--- a/control-plane/pkg/reconciler/testing/objects_channel.go
+++ b/control-plane/pkg/reconciler/testing/objects_channel.go
@@ -40,7 +40,7 @@ const (
 	ChannelName             = "kc"
 	ChannelNamespace        = "test-nc"
 	ChannelUUID             = "c1234567-8901-2345-6789-123456789101"
-	ChannelBootstrapServers = "kafka:9092"
+	ChannelBootstrapServers = "kafka-1:9092,kafka-2:9093"
 
 	Subscription1Name     = "sub-1"
 	Subscription2Name     = "sub-2"


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Channel to use new configmap format for bootstrap servers
- Nothing else is used from configmap at this moment (no auth etc.)

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
