### PR TITLE
Fix deleting the Broker ConfigMap prevents the Broker from being finalized

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -403,7 +403,7 @@ func (r *Reconciler) reconcilerBrokerResource(ctx context.Context, topic string,
 }
 
 func (r *Reconciler) addFinalizerCM(ctx context.Context, finalizer string, cm *corev1.ConfigMap) error {
-	if !hasFinalizer(cm, finalizer) {
+	if !containsFinalizerCM(cm, finalizer) {
 		cm := cm.DeepCopy() // Do not modify informer copy.
 		cm.Finalizers = append(cm.Finalizers, finalizer)
 		_, err := r.KubeClient.CoreV1().ConfigMaps(cm.GetNamespace()).Update(ctx, cm, metav1.UpdateOptions{})
@@ -414,7 +414,7 @@ func (r *Reconciler) addFinalizerCM(ctx context.Context, finalizer string, cm *c
 	return nil
 }
 
-func hasFinalizer(cm *corev1.ConfigMap, finalizer string) bool {
+func containsFinalizerCM(cm *corev1.ConfigMap, finalizer string) bool {
 	if cm == nil {
 		return false
 	}

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -23,6 +23,8 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/retry"
@@ -87,7 +89,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 	}
 	statusConditionManager.DataPlaneAvailable()
 
-	topicConfig, brokerConfig, err := r.topicConfig(logger, broker)
+	topicConfig, brokerConfig, err := r.topicConfig(ctx, logger, broker)
 	if err != nil {
 		return statusConditionManager.FailedToResolveConfig(err)
 	}
@@ -288,7 +290,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 	// 	- https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181306446
 	// 	- https://cwiki.apache.org/confluence/display/KAFKA/KIP-286%3A+producer.send%28%29+should+not+block+on+metadata+update
 
-	topicConfig, brokerConfig, err := r.topicConfig(logger, broker)
+	topicConfig, brokerConfig, err := r.topicConfig(ctx, logger, broker)
 	if err != nil {
 		return fmt.Errorf("failed to resolve broker config: %w", err)
 	}
@@ -331,10 +333,14 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 
 	logger.Debug("Topic deleted", zap.String("topic", topic))
 
+	if err := r.removeFinalizerCM(ctx, finalizerCM(broker), brokerConfig); err != nil {
+		return err
+	}
+
 	return nil
 }
 
-func (r *Reconciler) topicConfig(logger *zap.Logger, broker *eventing.Broker) (*kafka.TopicConfig, *corev1.ConfigMap, error) {
+func (r *Reconciler) topicConfig(ctx context.Context, logger *zap.Logger, broker *eventing.Broker) (*kafka.TopicConfig, *corev1.ConfigMap, error) {
 
 	logger.Debug("broker config", zap.Any("broker.spec.config", broker.Spec.Config))
 
@@ -350,6 +356,10 @@ func (r *Reconciler) topicConfig(logger *zap.Logger, broker *eventing.Broker) (*
 	cm, err := r.ConfigMapLister.ConfigMaps(namespace).Get(broker.Spec.Config.Name)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get configmap %s/%s: %w", namespace, broker.Spec.Config.Name, err)
+	}
+
+	if err := r.addFinalizerCM(ctx, finalizerCM(broker), cm); err != nil {
+		return nil, nil, err
 	}
 
 	topicConfig, err := kafka.TopicConfigFromConfigMap(logger, cm)
@@ -390,4 +400,50 @@ func (r *Reconciler) reconcilerBrokerResource(ctx context.Context, topic string,
 	resource.EgressConfig = egressConfig
 
 	return resource, nil
+}
+
+func (r *Reconciler) addFinalizerCM(ctx context.Context, finalizer string, cm *corev1.ConfigMap) error {
+	if !hasFinalizer(cm, finalizer) {
+		cm := cm.DeepCopy() // Do not modify informer copy.
+		cm.Finalizers = append(cm.Finalizers, finalizer)
+		_, err := r.KubeClient.CoreV1().ConfigMaps(cm.GetNamespace()).Update(ctx, cm, metav1.UpdateOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to add finalizer to ConfigMap %s/%s: %w", cm.GetNamespace(), cm.GetName(), err)
+		}
+	}
+	return nil
+}
+
+func hasFinalizer(cm *corev1.ConfigMap, finalizer string) bool {
+	if cm == nil {
+		return false
+	}
+	for _, f := range cm.Finalizers {
+		if f == finalizer {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Reconciler) removeFinalizerCM(ctx context.Context, finalizer string, cm *corev1.ConfigMap) error {
+	newFinalizers := make([]string, 0, len(cm.Finalizers))
+	for _, f := range cm.Finalizers {
+		if f != finalizer {
+			newFinalizers = append(newFinalizers, f)
+		}
+	}
+	if len(newFinalizers) != len(cm.Finalizers) {
+		cm := cm.DeepCopy() // Do not modify informer copy.
+		cm.Finalizers = newFinalizers
+		_, err := r.KubeClient.CoreV1().ConfigMaps(cm.GetNamespace()).Update(ctx, cm, metav1.UpdateOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to remove finalizer %s to ConfigMap %s/%s: %w", finalizer, cm.GetNamespace(), cm.GetName(), err)
+		}
+	}
+	return nil
+}
+
+func finalizerCM(object metav1.Object) string {
+	return fmt.Sprintf("%s/%s-%s", "kafka.brokers.eventing.knative.dev", object.GetNamespace(), object.GetName())
 }

--- a/control-plane/pkg/reconciler/broker/broker_test.go
+++ b/control-plane/pkg/reconciler/broker/broker_test.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/pointer"
 	"knative.dev/pkg/network"
 
@@ -135,6 +136,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -193,6 +195,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -253,6 +256,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -311,6 +315,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -368,6 +373,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -425,6 +431,9 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 					BrokerTopic(), createTopicError,
 				),
 			},
+			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
+			},
 			WantPatches: []clientgotesting.PatchActionImpl{
 				patchFinalizers(),
 			},
@@ -468,6 +477,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				NewConfigMapWithBinaryData(&env, nil),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -523,6 +533,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -591,6 +602,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -681,6 +693,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -771,6 +784,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -849,6 +863,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -927,6 +942,9 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 			},
 			Key:     testKey,
 			WantErr: true,
+			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
+			},
 			WantEvents: []string{
 				finalizerUpdatedEvent,
 				Eventf(
@@ -969,6 +987,11 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 			},
 			Key:     testKey,
 			WantErr: true,
+			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName, func(cm *corev1.ConfigMap) {
+					cm.Data["bootstrap.servers"] = ""
+				}),
+			},
 			WantEvents: []string{
 				finalizerUpdatedEvent,
 				Eventf(
@@ -1015,6 +1038,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -1085,6 +1109,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName, BrokerAuthConfig("secret-1")),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -1279,6 +1304,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -1388,6 +1414,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -1452,6 +1479,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -1516,6 +1544,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -1577,6 +1606,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				ConfigMapUpdate(&env, &contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -1648,7 +1678,9 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 			WantEvents: []string{
 				finalizerUpdatedEvent,
 			},
-			WantUpdates: []clientgotesting.UpdateActionImpl{},
+			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
+			},
 			WantPatches: []clientgotesting.PatchActionImpl{
 				patchFinalizers(),
 			},
@@ -1696,6 +1728,7 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				finalizerUpdatedEvent,
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdate(ConfigMapFinalizerName),
 				BrokerReceiverPodUpdate(env.SystemNamespace, map[string]string{base.VolumeGenerationAnnotationKey: "1"}),
 				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{base.VolumeGenerationAnnotationKey: "1"}),
 			},
@@ -1727,6 +1760,40 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 	useTable(t, table, &env)
 }
 
+func ConfigMapFinalizerUpdate(name string, opts ...CMOption) clientgotesting.UpdateActionImpl {
+	return clientgotesting.NewUpdateAction(
+		schema.GroupVersionResource{
+			Group:    "*",
+			Version:  "v1",
+			Resource: "ConfigMap",
+		},
+		ConfigMapNamespace,
+		BrokerConfig(bootstrapServers, 20, 5,
+			append(
+				[]CMOption{BrokerConfigFinalizer(name)},
+				opts...,
+			)...,
+		),
+	)
+}
+
+func ConfigMapFinalizerUpdateRemove(name string, opts ...CMOption) clientgotesting.UpdateActionImpl {
+	return clientgotesting.NewUpdateAction(
+		schema.GroupVersionResource{
+			Group:    "*",
+			Version:  "v1",
+			Resource: "ConfigMap",
+		},
+		ConfigMapNamespace,
+		BrokerConfig(bootstrapServers, 20, 5,
+			append(
+				[]CMOption{BrokerConfigFinalizerRemove(name)},
+				opts...,
+			)...,
+		),
+	)
+}
+
 func TestBrokerFinalizer(t *testing.T) {
 	t.Parallel()
 
@@ -1746,7 +1813,9 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 			Name: "Reconciled normal - no DLS",
 			Objects: []runtime.Object{
 				NewDeletedBroker(),
-				BrokerConfig(bootstrapServers, 20, 5),
+				BrokerConfig(bootstrapServers, 20, 5,
+					BrokerConfigFinalizer(ConfigMapFinalizerName),
+				),
 				NewConfigMapFromContract(&contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -1764,6 +1833,7 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 					Resources:  []*contract.Resource{},
 					Generation: 2,
 				}),
+				ConfigMapFinalizerUpdateRemove(ConfigMapFinalizerName),
 			},
 		},
 		{
@@ -1772,7 +1842,9 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 				NewDeletedBroker(
 					WithDelivery(),
 				),
-				BrokerConfig(bootstrapServers, 20, 5),
+				BrokerConfig(bootstrapServers, 20, 5,
+					BrokerConfigFinalizer(ConfigMapFinalizerName),
+				),
 				NewConfigMapFromContract(&contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -1790,13 +1862,16 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 				ConfigMapUpdate(&env, &contract.Contract{
 					Generation: 2,
 				}),
+				ConfigMapFinalizerUpdateRemove(ConfigMapFinalizerName),
 			},
 		},
 		{
 			Name: "Failed to delete topic",
 			Objects: []runtime.Object{
 				NewDeletedBroker(),
-				BrokerConfig(bootstrapServers, 20, 5),
+				BrokerConfig(bootstrapServers, 20, 5,
+					BrokerConfigFinalizer(ConfigMapFinalizerName),
+				),
 				NewConfigMapFromContract(&contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -1833,10 +1908,15 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 				NewDeletedBroker(
 					WithDelivery(),
 				),
-				BrokerConfig(bootstrapServers, 20, 5),
+				BrokerConfig(bootstrapServers, 20, 5,
+					BrokerConfigFinalizer(ConfigMapFinalizerName),
+				),
 				NewService(),
 			},
 			Key: testKey,
+			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdateRemove(ConfigMapFinalizerName),
+			},
 			WantCreates: []runtime.Object{
 				NewConfigMapWithBinaryData(&env, nil),
 			},
@@ -1846,7 +1926,9 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 			Name: "Reconciled normal - preserve config map previous state",
 			Objects: []runtime.Object{
 				NewDeletedBroker(),
-				BrokerConfig(bootstrapServers, 20, 5),
+				BrokerConfig(bootstrapServers, 20, 5,
+					BrokerConfigFinalizer(ConfigMapFinalizerName),
+				),
 				NewConfigMapFromContract(&contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -1875,13 +1957,16 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 					},
 					Generation: 6,
 				}),
+				ConfigMapFinalizerUpdateRemove(ConfigMapFinalizerName),
 			},
 		},
 		{
 			Name: "Reconciled normal - topic doesn't exist",
 			Objects: []runtime.Object{
 				NewDeletedBroker(),
-				BrokerConfig(bootstrapServers, 20, 5),
+				BrokerConfig(bootstrapServers, 20, 5,
+					BrokerConfigFinalizer(ConfigMapFinalizerName),
+				),
 				NewConfigMapFromContract(&contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -1910,6 +1995,7 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 					},
 					Generation: 6,
 				}),
+				ConfigMapFinalizerUpdateRemove(ConfigMapFinalizerName),
 			},
 			OtherTestData: map[string]interface{}{
 				wantErrorOnDeleteTopic: sarama.ErrUnknownTopicOrPartition,
@@ -1919,7 +2005,9 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 			Name: "Reconciled normal - no broker found in config map",
 			Objects: []runtime.Object{
 				NewDeletedBroker(),
-				BrokerConfig(bootstrapServers, 20, 5),
+				BrokerConfig(bootstrapServers, 20, 5,
+					BrokerConfigFinalizer(ConfigMapFinalizerName),
+				),
 				NewConfigMapFromContract(&contract.Contract{
 					Resources: []*contract.Resource{
 						{
@@ -1932,6 +2020,9 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 				}, &env),
 			},
 			Key: testKey,
+			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapFinalizerUpdateRemove(ConfigMapFinalizerName),
+			},
 		},
 	}
 

--- a/test/e2e_new/broker_test.go
+++ b/test/e2e_new/broker_test.go
@@ -43,3 +43,17 @@ func TestBrokerDeletedRecreated(t *testing.T) {
 
 	env.Test(ctx, t, features.BrokerDeletedRecreated())
 }
+
+func TestBrokerConfigMapDeletedFirst(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, features.BrokerConfigMapDeletedFirst())
+}

--- a/test/e2e_new/resources/configmap/copy.go
+++ b/test/e2e_new/resources/configmap/copy.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package configmap
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
+)
+
+func Copy(from types.NamespacedName, toName string) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		cm, err := kubeclient.Get(ctx).CoreV1().
+			ConfigMaps(from.Namespace).
+			Get(ctx, from.Name, metav1.GetOptions{})
+		require.Nil(t, err)
+
+		ns := environment.FromContext(ctx).Namespace()
+		toCm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      toName,
+			},
+			Data:       cm.Data,
+			BinaryData: cm.BinaryData,
+		}
+
+		_, err = kubeclient.Get(ctx).CoreV1().
+			ConfigMaps(toCm.GetNamespace()).
+			Create(ctx, toCm, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			return
+		}
+		require.Nil(t, err)
+	}
+}


### PR DESCRIPTION
Deleting the Broker ConfigMap prevents the Broker from being finalized
since we can't get Kafka cluster URL and credentials to remove topics.

In this patch, we're adding a finalizer to the ConfigMap associated
with the Broker and then remove it once the broker is properly
finalized.

Fixes #1580 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fix deleting the Broker ConfigMap prevents the Broker from being finalized

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Fix deleting the Broker ConfigMap prevents the Broker from being finalized
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
