### PR TITLE
[main] Use Broker's own configmap for Kafka

### DIFF
--- a/test/pkg/broker/broker.go
+++ b/test/pkg/broker/broker.go
@@ -17,13 +17,20 @@
 package broker
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	eventingtestlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/resources"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/broker"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
+	testingpkg "knative.dev/eventing-kafka-broker/test/pkg/testing"
 )
 
 func Creator(client *eventingtestlib.Client, version string) string {
@@ -33,9 +40,32 @@ func Creator(client *eventingtestlib.Client, version string) string {
 
 	switch version {
 	case "v1":
+		namespace := client.Namespace
+		// Create Broker's own ConfigMap to prevent using defaults.
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kafka-broker-upgrade-config",
+				Namespace: namespace,
+			},
+			Data: map[string]string{
+				broker.BootstrapServersConfigMapKey:              testingpkg.BootstrapServersPlaintext,
+				broker.DefaultTopicNumPartitionConfigMapKey:      fmt.Sprintf("%d", testingpkg.NumPartitions),
+				broker.DefaultTopicReplicationFactorConfigMapKey: fmt.Sprintf("%d", testingpkg.ReplicationFactor),
+			},
+		}
+		cm, err := client.Kube.CoreV1().ConfigMaps(namespace).Create(context.Background(), cm, metav1.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			client.T.Fatalf("Failed to create ConfigMap %s/%s: %v", namespace, cm.GetName(), err)
+		}
 		client.CreateBrokerOrFail(
 			name,
 			resources.WithBrokerClassForBroker(kafka.BrokerClass),
+			resources.WithConfigForBroker(&duckv1.KReference{
+				Kind:       "ConfigMap",
+				Namespace:  cm.GetNamespace(),
+				Name:       cm.GetName(),
+				APIVersion: "v1",
+			}),
 		)
 	default:
 		panic(fmt.Sprintf("Unsupported version of Broker: %q", version))

--- a/test/pkg/testing/run.go
+++ b/test/pkg/testing/run.go
@@ -31,6 +31,9 @@ const (
 	BootstrapServersSaslPlaintext = "my-cluster-kafka-bootstrap.kafka:9095"
 	BootstrapServersSslSaslScram  = "my-cluster-kafka-bootstrap.kafka:9094"
 
+	NumPartitions     = 10
+	ReplicationFactor = 3
+
 	KafkaClusterNamespace = "kafka"
 	TlsUserSecretName     = "my-tls-user"
 	SaslUserSecretName    = "my-sasl-user"


### PR DESCRIPTION
Fixes an issue with using wrong default values when `config-br-defaults` configmap points to another cluster-default configmap that might not include configuration for Kafka. It might include for example MTChannelBasedBroker configuration in which case the Broker creation fails with an error like this
```
invalid configuration - numPartitions: 0 - replicationFactor: 0 - bootstrapServers:  - ConfigMap data: map[channelTemplateSpec:apiVersion: messaging.knative.dev/v1
        kind: InMemoryChannel
        ]
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Creation a new ConfigMap in the test namespace that will be used by the Brokers.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
