### PR TITLE
Verify Trigger finalizer isn't set on Triggers of another class

### DIFF
--- a/test/e2e_new/run.go
+++ b/test/e2e_new/run.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2e_new
+
+import (
+	"fmt"
+	"testing"
+)
+
+const (
+	// Number of times to run a test function.
+	rerunTimes = 5
+)
+
+// RunMultiple run test function f `rerunTimes` times.
+func RunMultiple(t *testing.T, f func(t *testing.T)) {
+	RunMultipleN(t, rerunTimes, f)
+}
+
+// RunMultipleN run test function f n times.
+func RunMultipleN(t *testing.T, n int, f func(t *testing.T)) {
+	t.Parallel()
+
+	if testing.Short() {
+		n = 1
+	}
+
+	for i := 0; i < n; i++ {
+		t.Run(fmt.Sprintf("%d", i), f)
+	}
+}

--- a/test/e2e_new/trigger_finalizer_test.go
+++ b/test/e2e_new/trigger_finalizer_test.go
@@ -24,10 +24,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/reconciler-test/pkg/environment"
 
-	"github.com/stretchr/testify/assert"
-	triggerreconciler "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/trigger"
 	triggerfeatures "knative.dev/eventing/test/rekt/features/trigger"
 	"knative.dev/eventing/test/rekt/resources/trigger"
 	"knative.dev/pkg/system"
@@ -36,56 +36,72 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 	"knative.dev/reconciler-test/resources/svc"
+
+	triggerreconciler "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/trigger"
 )
 
-func TestTriggerNoFinalizerOnBrokerNotFound(t *testing.T) {
+func TestTriggerNoFinalizer(t *testing.T) {
+	RunMultiple(t, func(t *testing.T) {
+		ctx, env := global.Environment(
+			knative.WithKnativeNamespace(system.Namespace()),
+			knative.WithLoggingConfig,
+			knative.WithTracingConfig,
+			k8s.WithEventListener,
+			environment.Managed(t),
+		)
 
-	t.Skip("Flaky https://github.com/knative-sandbox/eventing-kafka-broker/issues/885")
-	t.Parallel()
+		t.Logf("Namespace is %s", env.Namespace())
 
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-	)
-
-	t.Logf("Namespace is %s", env.Namespace())
-
-	env.Test(ctx, t, triggerNoFinalizerOnBrokerNotFound())
+		env.Test(ctx, t, triggerNoFinalizerOnBrokerNotFound())
+		env.Test(ctx, t, unknownBrokerClass("Unknown"))
+		env.Test(ctx, t, unknownBrokerClass("MTChannelBasedBroker"))
+	})
 }
 
-//nolint:golint,unused
 func triggerNoFinalizerOnBrokerNotFound() *feature.Feature {
 
 	f := feature.NewFeature()
 
-	const responseWaitTime = 100 * time.Millisecond
-
+	brokerName := feature.MakeRandomK8sName("broker")
 	triggerName := feature.MakeRandomK8sName("trigger")
 	sinkName := feature.MakeRandomK8sName("sink")
 
-	f.Setup("install sink", eventshub.Install(
-		sinkName,
-		eventshub.StartReceiver,
-		eventshub.ResponseWaitTime(responseWaitTime),
-	))
-
-	f.Setup("install trigger", trigger.Install(
-		triggerName,
-		"broker",
+	f.Setup("install sink", eventshub.Install(sinkName, eventshub.StartReceiver))
+	f.Setup("install trigger", trigger.Install(triggerName, brokerName,
 		trigger.WithSubscriber(svc.AsKReference(sinkName), ""),
 	))
-
 	f.Setup("set trigger name", triggerfeatures.SetTriggerName(triggerName))
 
-	f.Assert("eventually trigger has no finalizer", func(ctx context.Context, t feature.T) {
-		time.Sleep(time.Second * 20) // "eventually"
-		for _, f := range triggerfeatures.GetTrigger(ctx, t).Finalizers {
-			assert.NotEqual(t, f, triggerreconciler.FinalizerName)
-		}
-	})
+	f.Assert("eventually trigger has no finalizer", hasNoKafkaBrokerFinalizer())
 
 	return f
+}
+
+func unknownBrokerClass(brokerClass string) *feature.Feature {
+	f := feature.NewFeatureNamed("Unknown Broker Class - " + brokerClass)
+
+	brokerName := feature.MakeRandomK8sName("broker")
+	triggerName := feature.MakeRandomK8sName("trigger")
+	sink := feature.MakeRandomK8sName("sink")
+
+	f.Setup("Install Broker", broker.Install(brokerName, broker.WithBrokerClass(brokerClass)))
+	f.Setup("Install events hub", eventshub.Install(sink, eventshub.StartReceiver))
+	f.Setup("Install Trigger", trigger.Install(triggerName, brokerName,
+		trigger.WithSubscriber(svc.AsKReference(sink), ""),
+	))
+	f.Setup("set trigger name", triggerfeatures.SetTriggerName(triggerName))
+
+	f.Assert("eventually trigger has no finalizer", hasNoKafkaBrokerFinalizer())
+
+	return f
+}
+
+func hasNoKafkaBrokerFinalizer() func(ctx context.Context, t feature.T) {
+	return func(ctx context.Context, t feature.T) {
+		time.Sleep(time.Second * 20) // "eventually"
+		tr := triggerfeatures.GetTrigger(ctx, t)
+		for _, f := range tr.Finalizers {
+			require.NotEqual(t, f, triggerreconciler.FinalizerName, "%+v", tr)
+		}
+	}
 }


### PR DESCRIPTION
Enabling Kafka Broker while running channel-based Broker with
Kafka sets incorrect finalizer.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Verify Trigger finalizer isn't set on Triggers of another class

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
None
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```