### PR TITLE
Add promote filter function to Broker and Trigger reconciler

### DIFF
--- a/control-plane/pkg/reconciler/broker/controller.go
+++ b/control-plane/pkg/reconciler/broker/controller.go
@@ -83,7 +83,9 @@ func NewController(ctx context.Context, watcher configmap.Watcher, env *config.E
 		)
 	}
 
-	impl := brokerreconciler.NewImpl(ctx, reconciler, kafka.BrokerClass)
+	impl := brokerreconciler.NewImpl(ctx, reconciler, kafka.BrokerClass, func(impl *controller.Impl) controller.Options {
+		return controller.Options{PromoteFilterFunc: kafka.BrokerClassFilter()}
+	})
 
 	reconciler.Resolver = resolver.NewURIResolverFromTracker(ctx, impl.Tracker)
 	reconciler.Prober = prober.NewAsync(ctx, http.DefaultClient, env.IngressPodPort, reconciler.ReceiverSelector(), impl.EnqueueKey)

--- a/control-plane/pkg/reconciler/trigger/controller.go
+++ b/control-plane/pkg/reconciler/trigger/controller.go
@@ -81,6 +81,7 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 			FinalizerName:     FinalizerName,
 			AgentName:         ControllerAgentName,
 			SkipStatusUpdates: false,
+			PromoteFilterFunc: filterTriggers(reconciler.BrokerLister),
 		}
 	})
 

--- a/control-plane/pkg/reconciler/trigger/v2/controllerv2.go
+++ b/control-plane/pkg/reconciler/trigger/v2/controllerv2.go
@@ -72,6 +72,7 @@ func NewControllerV2(ctx context.Context, configs *config.Env) *controller.Impl 
 			FinalizerName:     FinalizerName,
 			AgentName:         ControllerAgentName,
 			SkipStatusUpdates: false,
+			PromoteFilterFunc: filterTriggers(reconciler.BrokerLister),
 		}
 	})
 


### PR DESCRIPTION
When a reconciler gets promoted to be the leader, every object
gets re-queued even if it shouldn't be.

Tested in #1612

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add promote filter function to Broker and Trigger reconciler

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
None
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

```
None
```