### PR TITLE
Add Source Observer ClusterRole

### DIFF
--- a/control-plane/config/100-source/200-sources-observer-aggregated-clusterrole.yaml
+++ b/control-plane/config/100-source/200-sources-observer-aggregated-clusterrole.yaml
@@ -1,0 +1,31 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eventing-kafka-source-observer
+  labels:
+    kafka.eventing.knative.dev/release: devel
+    duck.knative.dev/source: "true"
+rules:
+  - apiGroups:
+      - "sources.knative.dev"
+    resources:
+      - "kafkasources"
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
Eventing controller error:
```
kafkasources.sources.knative.dev is forbidden:
User \"system:serviceaccount:knative-eventing:eventing-controller\"
cannot list resource \"kafkasources\" in API group
\"sources.knative.dev\" at the cluster scope
```

/assign @aliok 