### PR TITLE
Bump k8s versions in KinD workflows and remove verbose logging

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -150,7 +150,7 @@ jobs:
           export CLUSTER_DOMAIN=${CLUSTER_SUFFIX}
 
           # Run the tests tagged as e2e on the KinD cluster.
-          go test -race -count=1 -timeout=1h -v -short -tags=e2e,cloudevents \
+          go test -race -count=1 -timeout=1h -short -tags=e2e,cloudevents \
              ${{ matrix.test-suite }} ${{ matrix.extra-test-flags }}
 
       - name: Collect system diagnostics

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - v1.21.1
-          - v1.22.2
+          - v1.22.5
+          - v1.23.3
 
         eventing-config:
           - "./third_party/eventing-latest/"
@@ -40,12 +40,12 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0
         include:
-          - k8s-version: v1.21.1
+          - k8s-version: v1.22.5
             kind-version: v0.11.1
-            kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
-          - k8s-version: v1.22.2
+            kind-image-sha: sha256:d409e1b1b04d3290195e0263e12606e1b83d5289e1f80e54914f60cd1237499d
+          - k8s-version: v1.23.3
             kind-version: v0.11.1
-            kind-image-sha: sha256:f638a08c1f68fe2a99e724ace6df233a546eaf6713019a0b310130a4f91ebe7f
+            kind-image-sha: sha256:0df8215895129c0d3221cda19847d1296c4f29ec93487339149333bd9d899e5a
           - test-suite: ./test/e2e_channel
             extra-test-flags: -channels=messaging.knative.dev/v1beta1:KafkaChannel
 

--- a/hack/create-kind-cluster.sh
+++ b/hack/create-kind-cluster.sh
@@ -20,8 +20,8 @@ set -o nounset
 set -o pipefail
 
 CLUSTER_SUFFIX=${CLUSTER_SUFFIX:-"cluster.local"}
-NODE_VERSION=${NODE_VERSION:-"v1.20.0"}
-NODE_SHA=${NODE_SHA:-"sha256:b40ecf8bcb188f6a0d0f5d406089c48588b75edc112c6f635d26be5de1c89040"}
+NODE_VERSION=${NODE_VERSION:-"v1.23.3"}
+NODE_SHA=${NODE_SHA:-"sha256:0df8215895129c0d3221cda19847d1296c4f29ec93487339149333bd9d899e5a"}
 
 cat <<EOF | kind create cluster --config=-
 apiVersion: kind.x-k8s.io/v1alpha4


### PR DESCRIPTION
Bump k8s versions to the latest 2 versions.

Drop verbose logging since doing through logs to 
find a failed test in GH actions is painful since 
there are all logs even of succeeded tests.

Fixes #1067