### PR TITLE
Use digest for data plane images

### DIFF
--- a/data-plane/config/broker/500-dispatcher.yaml
+++ b/data-plane/config/broker/500-dispatcher.yaml
@@ -17,50 +17,40 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kafka-sink-receiver
+  name: kafka-broker-dispatcher
   namespace: knative-eventing
   labels:
-    app: kafka-sink-receiver
+    app: kafka-broker-dispatcher
     kafka.eventing.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
-      app: kafka-sink-receiver
+      app: kafka-broker-dispatcher
   template:
     metadata:
-      name: kafka-sink-receiver
+      name: kafka-broker-dispatcher
       labels:
-        app: kafka-sink-receiver
+        app: kafka-broker-dispatcher
         kafka.eventing.knative.dev/release: devel
     spec:
-      serviceAccountName: knative-kafka-sink-data-plane
+      serviceAccountName: knative-kafka-broker-data-plane
       securityContext:
         runAsNonRoot: true
-      # To avoid node becoming SPOF, spread our replicas to different nodes.
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app: kafka-sink-receiver
-                topologyKey: kubernetes.io/hostname
-              weight: 100
       containers:
-        - name: kafka-sink-receiver
-          image: ${KNATIVE_KAFKA_SINK_RECEIVER_IMAGE}
+        - name: kafka-broker-dispatcher
+          image: ${KNATIVE_KAFKA_DISPATCHER_IMAGE}
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
-              name: config-kafka-sink-data-plane
+              name: config-kafka-broker-data-plane
               readOnly: true
-            - mountPath: /etc/sinks
-              name: kafka-sink-sinks
+            - mountPath: /etc/brokers-triggers
+              name: kafka-broker-brokers-triggers
               readOnly: true
             - mountPath: /tmp
               name: cache
             - mountPath: /etc/logging
-              name: kafka-sink-config-logging
+              name: kafka-broker-config-logging
               readOnly: true
             - mountPath: /etc/tracing
               name: config-tracing
@@ -69,28 +59,27 @@ spec:
             - containerPort: 9090
               name: http-metrics
               protocol: TCP
-            - containerPort: 8080
-              name: http
-              protocol: TCP
           env:
             - name: SERVICE_NAME
-              value: "kafka-sink-receiver"
+              value: "kafka-broker-dispatcher"
             - name: SERVICE_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: INGRESS_PORT
-              value: "8080"
             - name: PRODUCER_CONFIG_FILE_PATH
-              value: /etc/config/config-kafka-sink-producer.properties
-            - name: HTTPSERVER_CONFIG_FILE_PATH
-              value: /etc/config/config-kafka-sink-httpserver.properties
+              value: /etc/config/config-kafka-broker-producer.properties
+            - name: CONSUMER_CONFIG_FILE_PATH
+              value: /etc/config/config-kafka-broker-consumer.properties
+            - name: WEBCLIENT_CONFIG_FILE_PATH
+              value: /etc/config/config-kafka-broker-webclient.properties
             - name: DATA_PLANE_CONFIG_FILE_PATH
-              value: /etc/sinks/data
-            - name: LIVENESS_PROBE_PATH
-              value: /healthz
-            - name: READINESS_PROBE_PATH
-              value: /readyz
+              value: /etc/brokers-triggers/data
+            - name: EGRESSES_INITIAL_CAPACITY
+              value: "20"
+            - name: INSTANCE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: METRICS_PATH
               value: /metrics
             - name: METRICS_PORT
@@ -117,8 +106,8 @@ spec:
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              port: 8080
-              path: /healthz
+              port: 9090
+              path: /metrics
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
@@ -127,8 +116,8 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              port: 8080
-              path: /readyz
+              port: 9090
+              path: /metrics
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
@@ -141,41 +130,21 @@ spec:
             privileged: false
             readOnlyRootFilesystem: true
       volumes:
-        - name: kafka-sink-sinks
+        - name: config-kafka-broker-data-plane
           configMap:
-            name: kafka-sink-sinks
-        - name: config-kafka-sink-data-plane
+            name: config-kafka-broker-data-plane
+        - name: kafka-broker-brokers-triggers
           configMap:
-            name: config-kafka-sink-data-plane
+            name: kafka-broker-brokers-triggers
         - name: cache
           emptyDir: { }
-        - name: kafka-sink-config-logging
+        - name: kafka-broker-config-logging
           configMap:
             name: kafka-config-logging
         - name: config-tracing
           configMap:
             name: config-tracing
       restartPolicy: Always
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: kafka-sink-ingress
-  namespace: knative-eventing
-  labels:
-    app: kafka-sink-receiver
-    kafka.eventing.knative.dev/release: devel
-spec:
-  selector:
-    app: kafka-sink-receiver
-  ports:
-    - name: http
-      port: 80
-      protocol: TCP
-      targetPort: 8080
-    - name: http-metrics
-      port: 9090
-      protocol: TCP
-      targetPort: 9090
----
+      dnsConfig:
+        options:
+          - name: single-request-reopen

--- a/data-plane/config/broker/500-receiver.yaml
+++ b/data-plane/config/broker/500-receiver.yaml
@@ -48,7 +48,7 @@ spec:
               weight: 100
       containers:
         - name: kafka-broker-receiver
-          image: ${KNATIVE_KAFKA_BROKER_RECEIVER_IMAGE}
+          image: ${KNATIVE_KAFKA_RECEIVER_IMAGE}
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config

--- a/data-plane/config/sink/500-receiver.yaml
+++ b/data-plane/config/sink/500-receiver.yaml
@@ -17,40 +17,50 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kafka-broker-dispatcher
+  name: kafka-sink-receiver
   namespace: knative-eventing
   labels:
-    app: kafka-broker-dispatcher
+    app: kafka-sink-receiver
     kafka.eventing.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
-      app: kafka-broker-dispatcher
+      app: kafka-sink-receiver
   template:
     metadata:
-      name: kafka-broker-dispatcher
+      name: kafka-sink-receiver
       labels:
-        app: kafka-broker-dispatcher
+        app: kafka-sink-receiver
         kafka.eventing.knative.dev/release: devel
     spec:
-      serviceAccountName: knative-kafka-broker-data-plane
+      serviceAccountName: knative-kafka-sink-data-plane
       securityContext:
         runAsNonRoot: true
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: kafka-sink-receiver
+                topologyKey: kubernetes.io/hostname
+              weight: 100
       containers:
-        - name: kafka-broker-dispatcher
-          image: ${KNATIVE_KAFKA_BROKER_DISPATCHER_IMAGE}
+        - name: kafka-sink-receiver
+          image: ${KNATIVE_KAFKA_RECEIVER_IMAGE}
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
-              name: config-kafka-broker-data-plane
+              name: config-kafka-sink-data-plane
               readOnly: true
-            - mountPath: /etc/brokers-triggers
-              name: kafka-broker-brokers-triggers
+            - mountPath: /etc/sinks
+              name: kafka-sink-sinks
               readOnly: true
             - mountPath: /tmp
               name: cache
             - mountPath: /etc/logging
-              name: kafka-broker-config-logging
+              name: kafka-sink-config-logging
               readOnly: true
             - mountPath: /etc/tracing
               name: config-tracing
@@ -59,27 +69,28 @@ spec:
             - containerPort: 9090
               name: http-metrics
               protocol: TCP
+            - containerPort: 8080
+              name: http
+              protocol: TCP
           env:
             - name: SERVICE_NAME
-              value: "kafka-broker-dispatcher"
+              value: "kafka-sink-receiver"
             - name: SERVICE_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: INGRESS_PORT
+              value: "8080"
             - name: PRODUCER_CONFIG_FILE_PATH
-              value: /etc/config/config-kafka-broker-producer.properties
-            - name: CONSUMER_CONFIG_FILE_PATH
-              value: /etc/config/config-kafka-broker-consumer.properties
-            - name: WEBCLIENT_CONFIG_FILE_PATH
-              value: /etc/config/config-kafka-broker-webclient.properties
+              value: /etc/config/config-kafka-sink-producer.properties
+            - name: HTTPSERVER_CONFIG_FILE_PATH
+              value: /etc/config/config-kafka-sink-httpserver.properties
             - name: DATA_PLANE_CONFIG_FILE_PATH
-              value: /etc/brokers-triggers/data
-            - name: EGRESSES_INITIAL_CAPACITY
-              value: "20"
-            - name: INSTANCE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.uid
+              value: /etc/sinks/data
+            - name: LIVENESS_PROBE_PATH
+              value: /healthz
+            - name: READINESS_PROBE_PATH
+              value: /readyz
             - name: METRICS_PATH
               value: /metrics
             - name: METRICS_PORT
@@ -106,8 +117,8 @@ spec:
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              port: 9090
-              path: /metrics
+              port: 8080
+              path: /healthz
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
@@ -116,8 +127,8 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              port: 9090
-              path: /metrics
+              port: 8080
+              path: /readyz
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
@@ -130,21 +141,41 @@ spec:
             privileged: false
             readOnlyRootFilesystem: true
       volumes:
-        - name: config-kafka-broker-data-plane
+        - name: kafka-sink-sinks
           configMap:
-            name: config-kafka-broker-data-plane
-        - name: kafka-broker-brokers-triggers
+            name: kafka-sink-sinks
+        - name: config-kafka-sink-data-plane
           configMap:
-            name: kafka-broker-brokers-triggers
+            name: config-kafka-sink-data-plane
         - name: cache
           emptyDir: { }
-        - name: kafka-broker-config-logging
+        - name: kafka-sink-config-logging
           configMap:
             name: kafka-config-logging
         - name: config-tracing
           configMap:
             name: config-tracing
       restartPolicy: Always
-      dnsConfig:
-        options:
-          - name: single-request-reopen
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-sink-ingress
+  namespace: knative-eventing
+  labels:
+    app: kafka-sink-receiver
+    kafka.eventing.knative.dev/release: devel
+spec:
+  selector:
+    app: kafka-sink-receiver
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: http-metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+---

--- a/data-plane/config/source/500-dispatcher.yaml
+++ b/data-plane/config/source/500-dispatcher.yaml
@@ -38,7 +38,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kafka-source-dispatcher
-          image: ${KNATIVE_KAFKA_SOURCE_DISPATCHER_IMAGE}
+          image: ${KNATIVE_KAFKA_DISPATCHER_IMAGE}
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config

--- a/hack/data-plane.sh
+++ b/hack/data-plane.sh
@@ -19,37 +19,27 @@
 # - UUID (default: latest)
 # - SKIP_PUSH (default: false) --> images will not be pushed to remote registry, nor to kind local registry
 
-source $(pwd)/hack/label.sh
+source "$(pwd)"/hack/label.sh
 
 readonly SKIP_PUSH=${SKIP_PUSH:-false}
-readonly UUID=${UUID:-${TAG:-latest}}
 
 readonly DATA_PLANE_DIR=data-plane
 readonly DATA_PLANE_CONFIG_DIR=${DATA_PLANE_DIR}/config
 
 # Source config
 readonly SOURCE_DATA_PLANE_CONFIG_DIR=${DATA_PLANE_CONFIG_DIR}/source
-readonly KAFKA_SOURCE_DATA_PLANE_CONFIG_TEMPLATE_DIR=${SOURCE_DATA_PLANE_CONFIG_DIR}/template # no trailing slash
-readonly KAFKA_SOURCE_DISPATCHER_TEMPLATE_FILE=${KAFKA_SOURCE_DATA_PLANE_CONFIG_TEMPLATE_DIR}/500-dispatcher.yaml
-
 # Broker config
 readonly BROKER_DATA_PLANE_CONFIG_DIR=${DATA_PLANE_CONFIG_DIR}/broker
-readonly KAFKA_BROKER_DATA_PLANE_CONFIG_TEMPLATE_DIR=${BROKER_DATA_PLANE_CONFIG_DIR}/template # no trailing slash
-readonly KAFKA_BROKER_DISPATCHER_TEMPLATE_FILE=${KAFKA_BROKER_DATA_PLANE_CONFIG_TEMPLATE_DIR}/500-dispatcher.yaml
-readonly KAFKA_BROKER_RECEIVER_TEMPLATE_FILE=${KAFKA_BROKER_DATA_PLANE_CONFIG_TEMPLATE_DIR}/500-receiver.yaml
-
 # Sink config
 readonly SINK_DATA_PLANE_CONFIG_DIR=${DATA_PLANE_CONFIG_DIR}/sink
-readonly KAFKA_SINK_DATA_PLANE_CONFIG_TEMPLATE_DIR=${SINK_DATA_PLANE_CONFIG_DIR}/template
-readonly KAFKA_SINK_RECEIVER_TEMPLATE_FILE=${KAFKA_SINK_DATA_PLANE_CONFIG_TEMPLATE_DIR}/500-receiver.yaml
 
-readonly receiver="${KNATIVE_KAFKA_BROKER_RECEIVER:-knative-kafka-broker-receiver}"
-readonly dispatcher="${KNATIVE_KAFKA_BROKER_DISPATCHER:-knative-kafka-broker-dispatcher}"
+readonly receiver="${KNATIVE_KAFKA_BROKER_RECEIVER:-${KO_DOCKER_REPO}/knative-kafka-broker-receiver}"
+readonly dispatcher="${KNATIVE_KAFKA_BROKER_DISPATCHER:-${KO_DOCKER_REPO}/knative-kafka-broker-dispatcher}"
 
 # The BASE_IMAGE must have system libraries (libc, zlib, etc) compatible with the JAVA_IMAGE because
 # Jlink generates a jdk linked to the same system libraries available on the base images.
-readonly BASE_IMAGE=gcr.io/distroless/java-debian11:base-nonroot  # Based on debian:buster
-readonly JAVA_IMAGE=docker.io/eclipse-temurin:17-jdk-centos7      # Based on centos7
+readonly BASE_IMAGE=${BASE_IMAGE:-"gcr.io/distroless/java-debian11:base-nonroot"} # Based on debian:buster
+readonly JAVA_IMAGE=${JAVA_IMAGE:-"docker.io/eclipse-temurin:17-jdk-centos7"}     # Based on centos7
 
 readonly RECEIVER_JAR="receiver-1.0-SNAPSHOT.jar"
 readonly RECEIVER_DIRECTORY=receiver
@@ -73,7 +63,7 @@ function image_push() {
     return
   fi
   if [ "$KO_DOCKER_REPO" = "kind.local" ]; then
-   kind load docker-image "$1"
+    kind load docker-image "$1"
   else
     docker push "$1"
   fi
@@ -82,14 +72,35 @@ function image_push() {
 function receiver_build_push() {
   header "Building receiver ..."
 
-  docker build \
+  local digest
+  digest=$(docker build \
+    -q \
     -f ${DATA_PLANE_DIR}/docker/Dockerfile \
-    --build-arg JAVA_IMAGE=${JAVA_IMAGE} \
-    --build-arg BASE_IMAGE=${BASE_IMAGE} \
+    --build-arg JAVA_IMAGE="${JAVA_IMAGE}" \
+    --build-arg BASE_IMAGE="${BASE_IMAGE}" \
     --build-arg APP_JAR=${RECEIVER_JAR} \
     --build-arg APP_DIR=${RECEIVER_DIRECTORY} \
-    -t "${KNATIVE_KAFKA_BROKER_RECEIVER_IMAGE}" ${DATA_PLANE_DIR} &&
-    image_push "${KNATIVE_KAFKA_BROKER_RECEIVER_IMAGE}"
+    -t "${receiver}:latest" ${DATA_PLANE_DIR})
+
+  header "Pushing receiver image, digest: $digest"
+
+  # Remove sha256 prefix from digest "sha256:..." since that's not legal
+  # for pushing the image.
+  local tag=${digest/sha256/""}
+
+  # Export variable that identifies the image.
+  #
+  # We cannot reference the image by digest since re-tagging
+  # the image with docker or podman will produce a different
+  # digest.
+  export KNATIVE_KAFKA_RECEIVER_IMAGE="$receiver$tag"
+
+  # Tag the built image with the latest tag with the tag based on the digest.
+  docker tag "${receiver}:latest" "${KNATIVE_KAFKA_RECEIVER_IMAGE}" &&
+    image_push "${KNATIVE_KAFKA_RECEIVER_IMAGE}" &&
+    # Remove the tagged image after pushing it to avoid having
+    # many images during local development.
+    docker image rm "${KNATIVE_KAFKA_RECEIVER_IMAGE}"
 
   return $?
 }
@@ -97,63 +108,67 @@ function receiver_build_push() {
 function dispatcher_build_push() {
   header "Building dispatcher ..."
 
-  docker build \
+  local digest
+  digest=$(docker build \
+    -q \
     -f ${DATA_PLANE_DIR}/docker/Dockerfile \
     --build-arg JAVA_IMAGE=${JAVA_IMAGE} \
     --build-arg BASE_IMAGE=${BASE_IMAGE} \
     --build-arg APP_JAR=${DISPATCHER_JAR} \
     --build-arg APP_DIR=${DISPATCHER_DIRECTORY} \
-    -t "${KNATIVE_KAFKA_BROKER_DISPATCHER_IMAGE}" ${DATA_PLANE_DIR} &&
-    image_push "${KNATIVE_KAFKA_BROKER_DISPATCHER_IMAGE}"
+    -t "${dispatcher}:latest" ${DATA_PLANE_DIR})
+
+  header "Pushing dispatcher image digest: $digest"
+
+  # Remove sha256 prefix from digest "sha256:..." since that's not legal
+  # for pushing the image.
+  local tag=${digest/sha256/""}
+
+  # Export variable that identifies the image.
+  #
+  # We cannot reference the image by digest since re-tagging
+  # the image with docker or podman will produce a different
+  # digest.
+  export KNATIVE_KAFKA_DISPATCHER_IMAGE="$dispatcher$tag"
+
+  # Tag the built image with the latest tag with the tag based on the digest.
+  docker tag "${dispatcher}:latest" "${KNATIVE_KAFKA_DISPATCHER_IMAGE}" &&
+    image_push "${KNATIVE_KAFKA_DISPATCHER_IMAGE}" &&
+    # Remove the tagged image after pushing it to avoid having
+    # many images during local development.
+    docker image rm "${KNATIVE_KAFKA_DISPATCHER_IMAGE}"
 
   return $?
 }
 
 function data_plane_build_push() {
-
-  local uuid=${UUID}
-  if [ "${uuid}" = "latest" ]; then
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      # MacOS
-      uuid="$(uuidgen)"
-    else
-      uuid="$(uuidgen --time)"
-    fi
-  fi
-
-  export KNATIVE_KAFKA_SOURCE_DISPATCHER_IMAGE="${KO_DOCKER_REPO}"/"${dispatcher}":"${uuid}"
-
-  export KNATIVE_KAFKA_BROKER_RECEIVER_IMAGE="${KO_DOCKER_REPO}"/"${receiver}":"${uuid}"
-
-  export KNATIVE_KAFKA_BROKER_DISPATCHER_IMAGE="${KO_DOCKER_REPO}"/"${dispatcher}":"${uuid}"
-
-  export KNATIVE_KAFKA_SINK_RECEIVER_IMAGE="${KO_DOCKER_REPO}"/"${receiver}":"${uuid}"
-
   receiver_build_push || receiver_build_push || fail_test "failed to build receiver"
   dispatcher_build_push || dispatcher_build_push || fail_test "failed to build dispatcher"
 }
 
+function replace_images() {
+  local file=$1
+
+  sed -i "s|\${KNATIVE_KAFKA_DISPATCHER_IMAGE}|${KNATIVE_KAFKA_DISPATCHER_IMAGE}|g" "${file}" &&
+    sed -i "s|\${KNATIVE_KAFKA_RECEIVER_IMAGE}|${KNATIVE_KAFKA_RECEIVER_IMAGE}|g" "${file}"
+
+  return $?
+}
+
 function k8s() {
-  echo "source dispatcher image ---> ${KNATIVE_KAFKA_SOURCE_DISPATCHER_IMAGE}"
-  echo "broker dispatcher image ---> ${KNATIVE_KAFKA_BROKER_DISPATCHER_IMAGE}"
-  echo "broker receiver image   ---> ${KNATIVE_KAFKA_BROKER_RECEIVER_IMAGE}"
-  echo "sink receiver image   ---> ${KNATIVE_KAFKA_SINK_RECEIVER_IMAGE}"
+  header "Creating artifacts"
 
-  ko resolve ${KO_FLAGS} -f ${SOURCE_DATA_PLANE_CONFIG_DIR} | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_SOURCE_ARTIFACT}"
-  ko resolve ${KO_FLAGS} -f ${BROKER_DATA_PLANE_CONFIG_DIR} | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_BROKER_ARTIFACT}"
-  ko resolve ${KO_FLAGS} -f ${SINK_DATA_PLANE_CONFIG_DIR} | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_SINK_ARTIFACT}"
+  echo "Dispatcher image ---> ${KNATIVE_KAFKA_DISPATCHER_IMAGE}"
+  echo "Receiver image   ---> ${KNATIVE_KAFKA_RECEIVER_IMAGE}"
 
-  sed "s|\${KNATIVE_KAFKA_SOURCE_DISPATCHER_IMAGE}|${KNATIVE_KAFKA_SOURCE_DISPATCHER_IMAGE}|g" ${KAFKA_SOURCE_DISPATCHER_TEMPLATE_FILE} |
-    "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_SOURCE_ARTIFACT}" || fail_test "Failed to append ${KAFKA_SOURCE_DISPATCHER_TEMPLATE_FILE}"
+  ko resolve ${KO_FLAGS} -Rf ${SOURCE_DATA_PLANE_CONFIG_DIR} | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_SOURCE_ARTIFACT}"
+  ko resolve ${KO_FLAGS} -Rf ${BROKER_DATA_PLANE_CONFIG_DIR} | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_BROKER_ARTIFACT}"
+  ko resolve ${KO_FLAGS} -Rf ${SINK_DATA_PLANE_CONFIG_DIR} | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_SINK_ARTIFACT}"
 
-  sed "s|\${KNATIVE_KAFKA_BROKER_DISPATCHER_IMAGE}|${KNATIVE_KAFKA_BROKER_DISPATCHER_IMAGE}|g" ${KAFKA_BROKER_DISPATCHER_TEMPLATE_FILE} |
-    "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_BROKER_ARTIFACT}" || fail_test "Failed to append ${KAFKA_BROKER_DISPATCHER_TEMPLATE_FILE}"
-
-  sed "s|\${KNATIVE_KAFKA_BROKER_RECEIVER_IMAGE}|${KNATIVE_KAFKA_BROKER_RECEIVER_IMAGE}|g" ${KAFKA_BROKER_RECEIVER_TEMPLATE_FILE} |
-    "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_BROKER_ARTIFACT}" || fail_test "Failed to append ${KAFKA_BROKER_RECEIVER_TEMPLATE_FILE}"
-
-  sed "s|\${KNATIVE_KAFKA_SINK_RECEIVER_IMAGE}|${KNATIVE_KAFKA_SINK_RECEIVER_IMAGE}|g" ${KAFKA_SINK_RECEIVER_TEMPLATE_FILE} |
-    "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_SINK_ARTIFACT}" || fail_test "Failed to append ${KAFKA_SINK_RECEIVER_TEMPLATE_FILE}"
+  replace_images "${EVENTING_KAFKA_SOURCE_ARTIFACT}" &&
+    replace_images "${EVENTING_KAFKA_BROKER_ARTIFACT}" &&
+    replace_images "${EVENTING_KAFKA_SINK_ARTIFACT}" &&
+    return $?
 }
 
 function data_plane_unit_tests() {
@@ -164,8 +179,8 @@ function data_plane_unit_tests() {
   echo "Copy test reports in ${ARTIFACTS}"
   find . -type f -regextype posix-extended -regex ".*/TEST-.*.xml$" | xargs -I '{}' cp {} ${ARTIFACTS}/
   pushd ${ARTIFACTS} || fail_test
-  for f in * ; do
-    mv -- "$f" "junit_$f" ;
+  for f in *; do
+    mv -- "$f" "junit_$f"
   done
   popd || fail_test
   popd || fail_test

--- a/hack/data-plane.sh
+++ b/hack/data-plane.sh
@@ -33,9 +33,6 @@ readonly BROKER_DATA_PLANE_CONFIG_DIR=${DATA_PLANE_CONFIG_DIR}/broker
 # Sink config
 readonly SINK_DATA_PLANE_CONFIG_DIR=${DATA_PLANE_CONFIG_DIR}/sink
 
-readonly receiver="${KNATIVE_KAFKA_BROKER_RECEIVER:-${KO_DOCKER_REPO}/knative-kafka-broker-receiver}"
-readonly dispatcher="${KNATIVE_KAFKA_BROKER_DISPATCHER:-${KO_DOCKER_REPO}/knative-kafka-broker-dispatcher}"
-
 # The BASE_IMAGE must have system libraries (libc, zlib, etc) compatible with the JAVA_IMAGE because
 # Jlink generates a jdk linked to the same system libraries available on the base images.
 readonly BASE_IMAGE=${BASE_IMAGE:-"gcr.io/distroless/java-debian11:base-nonroot"} # Based on debian:buster
@@ -72,6 +69,8 @@ function image_push() {
 function receiver_build_push() {
   header "Building receiver ..."
 
+  readonly receiver="${KNATIVE_KAFKA_BROKER_RECEIVER:-${KO_DOCKER_REPO}/knative-kafka-broker-receiver}"
+
   local digest
   digest=$(docker build \
     -q \
@@ -107,6 +106,8 @@ function receiver_build_push() {
 
 function dispatcher_build_push() {
   header "Building dispatcher ..."
+
+  readonly dispatcher="${KNATIVE_KAFKA_BROKER_DISPATCHER:-${KO_DOCKER_REPO}/knative-kafka-broker-dispatcher}"
 
   local digest
   digest=$(docker build \


### PR DESCRIPTION
The use of `TAG` for referencing images isn't reliable.

During the v1.1, release artifacts reference a `devel` image
which isn't correct.

In this patch, we start using a new tag which is based on the
image digest.

This fixes recent failures of the upgrade test.

Fixes #1667

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>