### PR TITLE
Remove teardown phase in GH actions since it takes a lot of time

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -128,9 +128,6 @@ jobs:
           go test -race -count=1 -timeout=1h -v -short -tags=e2e \
              ${{ matrix.test-suite }} ${{ matrix.extra-test-flags }}
 
-      - name: Teardown Eventing Kafka Broker
-        run: ./hack/run.sh teardown
-
       - name: Collect system diagnostics
         if: ${{ failure() }}
         run: |


### PR DESCRIPTION
As per title.

It just consumes GH action time for no reason. 