### PR TITLE
Use main as branch in codecov config

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,3 +1,6 @@
+codecov:
+  branch: main
+
 ignore:
   - "**/zz_generated*.go" # Ignore generated files.
   - "pkg/client"


### PR DESCRIPTION
It uses master by default, so it can't show coverage data:
https://app.codecov.io/gh/knative-sandbox/eventing-kafka-broker/blob/master/control-plane/pkg/kafka/consumer_group_lag.go

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Part of #1682 #1683 
