### PR TITLE
Add test for PartitionLag.String() method

### DIFF
--- a/control-plane/pkg/kafka/consumer_group_lag_test.go
+++ b/control-plane/pkg/kafka/consumer_group_lag_test.go
@@ -512,3 +512,8 @@ func fakeKafkaBrokerListener(t *testing.T, addr string) (*sarama.Broker, func())
 		_ = listener.Close()
 	}
 }
+
+func TestPartitionLagString(t *testing.T) {
+	pl := PartitionLag{}
+	require.NotEmpty(t, pl.String())
+}


### PR DESCRIPTION
As per title, to increase code coverage.

Part of #1682 