### PR TITLE
Align Receiver metrics to Eventing core Ingress metrics

### DIFF
--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/IngressProducer.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/IngressProducer.java
@@ -15,6 +15,7 @@
  */
 package dev.knative.eventing.kafka.broker.receiver;
 
+import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import io.cloudevents.CloudEvent;
 import io.vertx.core.Future;
 import io.vertx.kafka.client.producer.KafkaProducer;
@@ -44,5 +45,10 @@ public interface IngressProducer {
    * @return the topic where the record should be sent to.
    */
   String getTopic();
+
+  /**
+   * @return the resource associated with this producer.
+   */
+  DataPlaneContract.Reference getReference();
 
 }

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/RequestContext.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/RequestContext.java
@@ -15,11 +15,23 @@
  */
 package dev.knative.eventing.kafka.broker.receiver;
 
-/**
- * This class handles incoming ingress requests.
- */
-public interface IngressRequestHandler {
+import io.vertx.core.http.HttpServerRequest;
 
-  void handle(RequestContext request, IngressProducer producer);
+public class RequestContext {
 
+  private final HttpServerRequest request;
+  private final long receivedAtMs;
+
+  public RequestContext(final HttpServerRequest request) {
+    this.request = request;
+    this.receivedAtMs = System.currentTimeMillis();
+  }
+
+  public long performLatency() {
+    return System.currentTimeMillis() - receivedAtMs;
+  }
+
+  public HttpServerRequest getRequest() {
+    return request;
+  }
 }

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/IngressProducerReconcilableStore.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/IngressProducerReconcilableStore.java
@@ -120,7 +120,7 @@ public class IngressProducerReconcilableStore implements IngressReconcilerListen
 
       final var ingressInfo = new IngressProducerImpl(
         rc.getValue().getProducer(),
-        resource.getTopics(0),
+        resource,
         ingress.getPath(),
         producerProps
       );
@@ -223,11 +223,15 @@ public class IngressProducerReconcilableStore implements IngressReconcilerListen
     private final String topic;
     private final String path;
     private final Properties producerProperties;
+    private final DataPlaneContract.Reference reference;
 
-    IngressProducerImpl(final KafkaProducer<String, CloudEvent> producer, final String topic, final String path,
+    IngressProducerImpl(final KafkaProducer<String, CloudEvent> producer,
+                        final DataPlaneContract.Resource resource,
+                        final String path,
                         final Properties producerProperties) {
       this.producer = producer;
-      this.topic = topic;
+      this.topic = resource.getTopics(0);
+      this.reference = resource.getReference();
       this.path = path;
       this.producerProperties = producerProperties;
     }
@@ -240,6 +244,11 @@ public class IngressProducerReconcilableStore implements IngressReconcilerListen
     @Override
     public String getTopic() {
       return topic;
+    }
+
+    @Override
+    public DataPlaneContract.Reference getReference() {
+      return reference;
     }
 
     String getPath() {

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticle.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticle.java
@@ -18,6 +18,7 @@ package dev.knative.eventing.kafka.broker.receiver.impl;
 import dev.knative.eventing.kafka.broker.core.reconciler.ResourcesReconciler;
 import dev.knative.eventing.kafka.broker.receiver.IngressProducer;
 import dev.knative.eventing.kafka.broker.receiver.IngressRequestHandler;
+import dev.knative.eventing.kafka.broker.receiver.RequestContext;
 import dev.knative.eventing.kafka.broker.receiver.impl.handler.MethodNotAllowedHandler;
 import dev.knative.eventing.kafka.broker.receiver.impl.handler.ProbeHandler;
 import dev.knative.eventing.kafka.broker.receiver.main.ReceiverEnv;
@@ -117,6 +118,8 @@ public class ReceiverVerticle extends AbstractVerticle implements Handler<HttpSe
   @Override
   public void handle(HttpServerRequest request) {
 
+    final var requestContext = new RequestContext(request);
+
     // Look up for the ingress producer
     IngressProducer producer = this.ingressProducerStore.resolve(request.path());
     if (producer == null) {
@@ -133,6 +136,6 @@ public class ReceiverVerticle extends AbstractVerticle implements Handler<HttpSe
     }
 
     // Invoke the ingress request handler
-    this.ingressRequestHandler.handle(request, producer);
+    this.ingressRequestHandler.handle(requestContext, producer);
   }
 }

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/IngressRequestHandlerImpl.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/IngressRequestHandlerImpl.java
@@ -15,17 +15,20 @@
  */
 package dev.knative.eventing.kafka.broker.receiver.impl.handler;
 
+import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
 import dev.knative.eventing.kafka.broker.core.tracing.TracingConfig;
 import dev.knative.eventing.kafka.broker.core.tracing.TracingSpan;
 import dev.knative.eventing.kafka.broker.receiver.IngressProducer;
 import dev.knative.eventing.kafka.broker.receiver.IngressRequestHandler;
+import dev.knative.eventing.kafka.broker.receiver.RequestContext;
 import dev.knative.eventing.kafka.broker.receiver.RequestToRecordMapper;
 import io.cloudevents.CloudEvent;
-import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.vertx.core.Future;
-import io.vertx.core.http.HttpServerRequest;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import io.vertx.kafka.client.producer.RecordMetadata;
 import org.slf4j.Logger;
@@ -43,36 +46,58 @@ import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE
  */
 public class IngressRequestHandlerImpl implements IngressRequestHandler {
 
+  static final Tag UNKNOWN_EVENT_TYPE_TAG = Tag.of(Metrics.Tags.EVENT_TYPE, "unknown");
+
   static final int MAPPER_FAILED = BAD_REQUEST.code();
+  static final Tags MAPPER_FAILED_COMMON_TAGS = Tags.of(
+    Tag.of(Metrics.Tags.RESPONSE_CODE_CLASS, "4xx"),
+    Tag.of(Metrics.Tags.RESPONSE_CODE, Integer.toString(MAPPER_FAILED)),
+    UNKNOWN_EVENT_TYPE_TAG
+  );
+
   static final int RECORD_PRODUCED = ACCEPTED.code();
+  static final Tags RECORD_PRODUCED_COMMON_TAGS = Tags.of(
+    Tag.of(Metrics.Tags.RESPONSE_CODE, Integer.toString(RECORD_PRODUCED)),
+    Tag.of(Metrics.Tags.RESPONSE_CODE_CLASS, "2xx")
+  );
+
   static final int FAILED_TO_PRODUCE = SERVICE_UNAVAILABLE.code();
+  static final Tags FAILED_TO_PRODUCE_COMMON_TAGS = Tags.of(
+    Tag.of(Metrics.Tags.RESPONSE_CODE, Integer.toString(FAILED_TO_PRODUCE)),
+    Tag.of(Metrics.Tags.RESPONSE_CODE_CLASS, "5xx")
+  );
 
   private static final Logger logger = LoggerFactory.getLogger(IngressRequestHandlerImpl.class);
 
   private final RequestToRecordMapper requestToRecordMapper;
-  private final Counter badRequestCounter;
-  private final Counter produceEventsCounter;
+  private final MeterRegistry meterRegistry;
 
-  public IngressRequestHandlerImpl(
-    RequestToRecordMapper requestToRecordMapper,
-    Counter badRequestCounter,
-    Counter produceEventsCounter) {
+  public IngressRequestHandlerImpl(final RequestToRecordMapper requestToRecordMapper,
+                                   final MeterRegistry meterRegistry) {
     this.requestToRecordMapper = requestToRecordMapper;
-    this.badRequestCounter = badRequestCounter;
-    this.produceEventsCounter = produceEventsCounter;
+    this.meterRegistry = meterRegistry;
   }
 
   @Override
-  public void handle(HttpServerRequest request, IngressProducer producer) {
+  public void handle(final RequestContext requestContext, final IngressProducer producer) {
+
+    final var resourceTags = Tags.of(
+      Tag.of("name", producer.getReference().getName()),
+      Tag.of("namespace_name", producer.getReference().getNamespace())
+    );
+
     requestToRecordMapper
-      .requestToRecord(request, producer.getTopic())
+      .requestToRecord(requestContext.getRequest(), producer.getTopic())
       .onFailure(cause -> {
         // Conversion to record failed
-        request.response().setStatusCode(MAPPER_FAILED).end();
-        badRequestCounter.increment();
+        requestContext.getRequest().response().setStatusCode(MAPPER_FAILED).end();
+
+        final var tags = MAPPER_FAILED_COMMON_TAGS.and(resourceTags);
+        Metrics.eventDispatchLatency(tags).register(meterRegistry).record(requestContext.performLatency());
+        Metrics.eventCount(tags).register(meterRegistry).increment();
 
         logger.warn("Failed to convert request to record {}",
-          keyValue("path", request.path()),
+          keyValue("path", requestContext.getRequest().path()),
           cause
         );
       })
@@ -93,28 +118,41 @@ public class IngressRequestHandlerImpl implements IngressRequestHandler {
         // Decorate the span with event specific attributed
         TracingSpan.decorateCurrentWithEvent(record.value());
 
-        // Publish the record
-        return publishRecord(producer, record).onComplete(ar -> {
-          // Write the response back
-          if (ar.succeeded()) {
-            request.response()
-              .setStatusCode(RECORD_PRODUCED)
-              .end();
-          } else {
-            request.response()
-              .setStatusCode(FAILED_TO_PRODUCE)
-              .end();
-          }
-        });
+        final var eventTypeTag = Tag.of(Metrics.Tags.EVENT_TYPE, record.value().getType());
+
+        return publishRecord(producer, record)
+          .onSuccess(m -> {
+            requestContext.getRequest().response().setStatusCode(RECORD_PRODUCED).end();
+
+            final var tags = RECORD_PRODUCED_COMMON_TAGS
+              .and(resourceTags)
+              .and(eventTypeTag);
+            Metrics.eventDispatchLatency(tags).register(meterRegistry).record(requestContext.performLatency());
+            Metrics.eventCount(tags).register(meterRegistry).increment();
+
+          })
+          .onFailure(cause -> {
+            requestContext.getRequest().response().setStatusCode(FAILED_TO_PRODUCE).end();
+
+            final var tags = FAILED_TO_PRODUCE_COMMON_TAGS
+              .and(resourceTags)
+              .and(eventTypeTag);
+            Metrics.eventDispatchLatency(tags).register(meterRegistry).record(requestContext.performLatency());
+            Metrics.eventCount(tags).register(meterRegistry).increment();
+
+            logger.warn("Failed to produce record {}",
+              keyValue("path", requestContext.getRequest().path()),
+              cause
+            );
+          });
       });
   }
 
-  private Future<RecordMetadata> publishRecord(IngressProducer ingress,
-                                               KafkaProducerRecord<String, CloudEvent> record) {
+  private static Future<RecordMetadata> publishRecord(final IngressProducer ingress,
+                                                      final KafkaProducerRecord<String, CloudEvent> record) {
     return ingress.send(record)
       .onComplete(ar -> {
         if (ar.succeeded()) {
-          produceEventsCounter.increment();
           if (logger.isDebugEnabled()) {
             logger.debug("Record produced {} {} {} {} {}",
               keyValue("topic", record.topic()),

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
@@ -36,7 +36,7 @@ import java.util.function.Supplier;
 
 class ReceiverVerticleFactory implements Supplier<Verticle> {
 
-  private ReceiverEnv env;
+  private final ReceiverEnv env;
   private final Properties producerConfigs;
   private final HttpServerOptions httpServerOptions;
 
@@ -51,8 +51,7 @@ class ReceiverVerticleFactory implements Supplier<Verticle> {
     this.httpServerOptions = httpServerOptions;
     this.ingressRequestHandler = new IngressRequestHandlerImpl(
       StrictRequestToRecordMapper.getInstance(),
-      metricsRegistry.counter(Metrics.HTTP_REQUESTS_MALFORMED_COUNT),
-      metricsRegistry.counter(Metrics.HTTP_REQUESTS_PRODUCE_COUNT)
+      metricsRegistry
     );
   }
 

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTracingTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTracingTest.java
@@ -124,8 +124,7 @@ public class ReceiverVerticleTracingTest {
       v -> store,
       new IngressRequestHandlerImpl(
         StrictRequestToRecordMapper.getInstance(),
-        new CumulativeCounter(mock(Id.class)),
-        new CumulativeCounter(mock(Id.class))
+        Metrics.getRegistry()
       )
     );
 

--- a/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/DataPlaneTest.java
+++ b/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/DataPlaneTest.java
@@ -36,7 +36,6 @@ import io.cloudevents.core.v1.CloudEventV1;
 import io.cloudevents.http.vertx.VertxMessageFactory;
 import io.cloudevents.kafka.CloudEventSerializer;
 import io.debezium.kafka.KafkaCluster;
-import io.micrometer.core.instrument.Counter;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.client.WebClient;
@@ -385,8 +384,7 @@ public class DataPlaneTest {
       ),
       new IngressRequestHandlerImpl(
         StrictRequestToRecordMapper.getInstance(),
-        mock(Counter.class),
-        mock(Counter.class)
+        Metrics.getRegistry()
       )
     );
 


### PR DESCRIPTION
See https://knative.dev/docs/eventing/observability/metrics/eventing-metrics/#broker-ingress

_Note: Eventing Core uses `broker_name` for the tag but since we have Broker/Channel/Sink, I'm using `name` instead._

Example metrics:
```
# HELP event_count_total Number of events received
# TYPE event_count_total counter
event_count_total{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",} 15915.0

# HELP event_dispatch_latencies_max The time spent dispatching an event to Kafka
# TYPE event_dispatch_latencies_max gauge
event_dispatch_latencies_max{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",} 99.0
# HELP event_dispatch_latencies The time spent dispatching an event to Kafka
# TYPE event_dispatch_latencies histogram
event_dispatch_latencies_bucket{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",le="1.0",} 7499.0
event_dispatch_latencies_bucket{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",le="2.0",} 14566.0
event_dispatch_latencies_bucket{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",le="5.0",} 15742.0
event_dispatch_latencies_bucket{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",le="10.0",} 15862.0
event_dispatch_latencies_bucket{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",le="20.0",} 15894.0
event_dispatch_latencies_bucket{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",le="50.0",} 15907.0
event_dispatch_latencies_bucket{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",le="100.0",} 15915.0
event_dispatch_latencies_bucket{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",le="500.0",} 15915.0
event_dispatch_latencies_bucket{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",le="1000.0",} 15915.0
event_dispatch_latencies_bucket{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",le="5000.0",} 15915.0
event_dispatch_latencies_bucket{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",le="10000.0",} 15915.0
event_dispatch_latencies_bucket{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",le="+Inf",} 15915.0
event_dispatch_latencies_count{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",} 15915.0
event_dispatch_latencies_sum{event_type="com.example.FullEvent",name="",namespace_name="",response_code="202",response_code_class="2xx",} 27753.0
```
_Note: `name="",namespace_name=""` tags require control plane changes that will be done in a follow up PR (edit: done https://github.com/knative-sandbox/eventing-kafka-broker/pull/1701)._

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

