### PR TITLE
Enqueue trigger when ConsumerGroups change

### DIFF
--- a/control-plane/pkg/reconciler/trigger/v2/controllerv2.go
+++ b/control-plane/pkg/reconciler/trigger/v2/controllerv2.go
@@ -88,7 +88,7 @@ func NewControllerV2(ctx context.Context, configs *config.Env) *controller.Impl 
 	// ConsumerGroup changes and enqueue associated Trigger
 	consumerGroupInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: consumergroup.Filter("trigger"),
-		Handler:    controller.HandleAll(impl.Enqueue),
+		Handler:    controller.HandleAll(consumergroup.Enqueue("trigger", impl.EnqueueKey)),
 	})
 
 	return impl


### PR DESCRIPTION
We need to enqueue the Trigger key associated with the 
ConsumerGroup and not the ConsumerGroup resource.

Related https://github.com/knative-sandbox/eventing-kafka-broker/pull/1611#discussion_r780340587

## Proposed Changes

- Enqueue trigger when ConsumerGroups change

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->