### PR TITLE
Probe ingress resources on finalize

### DIFF
--- a/control-plane/pkg/receiver/address_test.go
+++ b/control-plane/pkg/receiver/address_test.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package receiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
+)
+
+func TestAddress(t *testing.T) {
+	host := "example.com"
+	ks := &eventing.KafkaSink{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "ks",
+		},
+	}
+	url := Address(host, ks)
+
+	require.Equal(t, host, url.Host)
+	require.Equal(t, "http", url.Scheme)
+	require.Contains(t, url.Path, ks.GetNamespace())
+	require.Contains(t, url.Path, ks.GetName())
+}

--- a/control-plane/pkg/reconciler/broker/broker_test.go
+++ b/control-plane/pkg/reconciler/broker/broker_test.go
@@ -1856,6 +1856,9 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 				}),
 				ConfigMapFinalizerUpdateRemove(ConfigMapFinalizerName),
 			},
+			OtherTestData: map[string]interface{}{
+				testProber: probertesting.MockProber(prober.StatusNotReady),
+			},
 		},
 		{
 			Name: "Reconciled normal - with DLS",
@@ -1884,6 +1887,9 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 					Generation: 2,
 				}),
 				ConfigMapFinalizerUpdateRemove(ConfigMapFinalizerName),
+			},
+			OtherTestData: map[string]interface{}{
+				testProber: probertesting.MockProber(prober.StatusNotReady),
 			},
 		},
 		{
@@ -1921,6 +1927,7 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 			},
 			OtherTestData: map[string]interface{}{
 				wantErrorOnDeleteTopic: deleteTopicError,
+				testProber:             probertesting.MockProber(prober.StatusNotReady),
 			},
 		},
 		{
@@ -1942,6 +1949,9 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 				NewConfigMapWithBinaryData(&env, nil),
 			},
 			SkipNamespaceValidation: true, // WantCreates compare the broker namespace with configmap namespace, so skip it
+			OtherTestData: map[string]interface{}{
+				testProber: probertesting.MockProber(prober.StatusNotReady),
+			},
 		},
 		{
 			Name: "Reconciled normal - preserve config map previous state",
@@ -1979,6 +1989,9 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 					Generation: 6,
 				}),
 				ConfigMapFinalizerUpdateRemove(ConfigMapFinalizerName),
+			},
+			OtherTestData: map[string]interface{}{
+				testProber: probertesting.MockProber(prober.StatusNotReady),
 			},
 		},
 		{
@@ -2020,6 +2033,7 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 			},
 			OtherTestData: map[string]interface{}{
 				wantErrorOnDeleteTopic: sarama.ErrUnknownTopicOrPartition,
+				testProber:             probertesting.MockProber(prober.StatusNotReady),
 			},
 		},
 		{
@@ -2043,6 +2057,9 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 			Key: testKey,
 			WantUpdates: []clientgotesting.UpdateActionImpl{
 				ConfigMapFinalizerUpdateRemove(ConfigMapFinalizerName),
+			},
+			OtherTestData: map[string]interface{}{
+				testProber: probertesting.MockProber(prober.StatusNotReady),
 			},
 		},
 	}

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -322,6 +322,8 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 		logger.Debug("Contract config map updated")
 	}
 
+	channel.Status.Address = nil
+
 	// We update receiver and dispatcher pods annotation regardless of our contract changed or not due to the fact
 	// that in a previous reconciliation we might have failed to update one of our data plane pod annotation, so we want
 	// to update anyway remaining annotations with the contract generation that was saved in the CM.
@@ -336,12 +338,22 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 		return err
 	}
 
-	// TODO probe (as in #974) and check if status code is 404 otherwise requeue and return.
 	//  Rationale: after deleting a topic closing a producer ends up blocking and requesting metadata for max.block.ms
 	//  because topic metadata aren't available anymore.
 	// 	See (under discussions KIPs, unlikely to be accepted as they are):
 	// 	- https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181306446
 	// 	- https://cwiki.apache.org/confluence/display/KAFKA/KIP-286%3A+producer.send%28%29+should+not+block+on+metadata+update
+	address := receiver.Address(r.IngressHost, channel)
+	proberAddressable := prober.Addressable{
+		Address: address,
+		ResourceKey: types.NamespacedName{
+			Namespace: channel.GetNamespace(),
+			Name:      channel.GetName(),
+		},
+	}
+	if status := r.Prober.Probe(ctx, proberAddressable); status != prober.StatusNotReady {
+		return nil // Object will get re-queued once probe status changes.
+	}
 
 	// get the channel configmap
 	channelConfigMap, err := r.channelConfigMap()

--- a/control-plane/pkg/reconciler/sink/kafka_sink_test.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink_test.go
@@ -1158,6 +1158,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 			OtherTestData: map[string]interface{}{
 				wantErrorOnDeleteTopic: deleteTopicError,
 				wantTopicName:          "topic-2",
+				testProber:             probertesting.MockProber(prober.StatusNotReady),
 			},
 		},
 	}

--- a/test/upgrade/continual/verification.go
+++ b/test/upgrade/continual/verification.go
@@ -18,6 +18,7 @@ package continual
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	eventingkafkaupgrade "knative.dev/eventing-kafka/test/upgrade/continual"
@@ -77,6 +78,7 @@ func configurator(theSut sut.SystemUnderTest, configTemplate string) prober.Conf
 		// TODO: knative/eventing#5176 - this is cumbersome
 		config.ConfigTemplate = fmt.Sprintf("../../../../../../%s",
 			configTemplate)
+		config.FinishedSleep = 5 * time.Minute
 		// envconfig.Process invocation is repeated from within prober.NewConfig to
 		// make sure every knob is configurable, but using defaults from Eventing
 		// Kafka instead of Core. The prefix is also changed.


### PR DESCRIPTION
After deleting a topic if a producer wasn't closed yet,
closing a producer ends up blocking and requesting metadata
for `max.block.ms`.

See (under discussions KIPs, unlikely to be accepted as they are):
- https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181306446
- https://cwiki.apache.org/confluence/display/KAFKA/KIP-286%3A+producer.send%28%29+should+not+block+on+metadata+update

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>