### PR TITLE
Align dispatcher metrics to Eventing core filter metrics

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
@@ -74,11 +74,21 @@ public class Metrics {
 
   /**
    * @link https://knative.dev/docs/eventing/observability/metrics/eventing-metrics/
+   * @see Metrics#eventDispatchLatency(io.micrometer.core.instrument.Tags)
+   */
+  public static final String EVENT_PROCESSING_LATENCY = "event_processing_latencies";
+
+  /**
+   * @link https://knative.dev/docs/eventing/observability/metrics/eventing-metrics/
    */
   public static class Tags {
     public static final String RESPONSE_CODE = "response_code";
     public static final String RESPONSE_CODE_CLASS = "response_code_class";
     public static final String EVENT_TYPE = "event_type";
+
+    public static final String RESOURCE_NAME = "name";
+    public static final String RESOURCE_NAMESPACE = "namespace_name";
+    public static final String CONSUMER_NAME = "consumer_name";
   }
 
   /**
@@ -189,6 +199,15 @@ public class Metrics {
     return DistributionSummary
       .builder(EVENT_DISPATCH_LATENCY)
       .description("The time spent dispatching an event to Kafka")
+      .tags(tags)
+      .baseUnit(BaseUnits.MILLISECONDS)
+      .serviceLevelObjectives(1, 2, 5, 10, 20, 50, 100, 500, 1000, 5000, 10000);
+  }
+
+  public static DistributionSummary.Builder eventProcessingLatency(final io.micrometer.core.instrument.Tags tags) {
+    return DistributionSummary
+      .builder(EVENT_PROCESSING_LATENCY)
+      .description("The time spent processing an event")
       .tags(tags)
       .baseUnit(BaseUnits.MILLISECONDS)
       .serviceLevelObjectives(1, 2, 5, 10, 20, 50, 100, 500, 1000, 5000, 10000);

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
@@ -21,7 +21,6 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
-import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.vertx.core.http.HttpServerOptions;
@@ -98,6 +97,8 @@ public class Metrics {
     // Unified Code for Units of Measure: http://unitsofmeasure.org/ucum.html
     public static final String DIMENSIONLESS = "1";
   }
+
+  private static final double[] LATENCY_SLOs = new double[]{50, 100, 500, 1000, 5000, 10000};
 
   /**
    * Get metrics options from the given metrics configurations.
@@ -201,7 +202,7 @@ public class Metrics {
       .description("The time spent dispatching an event to Kafka")
       .tags(tags)
       .baseUnit(BaseUnits.MILLISECONDS)
-      .serviceLevelObjectives(1, 2, 5, 10, 20, 50, 100, 500, 1000, 5000, 10000);
+      .serviceLevelObjectives(LATENCY_SLOs);
   }
 
   public static DistributionSummary.Builder eventProcessingLatency(final io.micrometer.core.instrument.Tags tags) {
@@ -210,6 +211,6 @@ public class Metrics {
       .description("The time spent processing an event")
       .tags(tags)
       .baseUnit(BaseUnits.MILLISECONDS)
-      .serviceLevelObjectives(1, 2, 5, 10, 20, 50, 100, 500, 1000, 5000, 10000);
+      .serviceLevelObjectives(LATENCY_SLOs);
   }
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/ConsumerRecordContext.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/ConsumerRecordContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.dispatcher.impl;
 
 import io.cloudevents.CloudEvent;

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/ConsumerRecordContext.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/ConsumerRecordContext.java
@@ -1,0 +1,31 @@
+package dev.knative.eventing.kafka.broker.dispatcher.impl;
+
+import io.cloudevents.CloudEvent;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+
+class ConsumerRecordContext {
+
+  private KafkaConsumerRecord<Object, CloudEvent> record;
+  private long receivedAtMs;
+
+  ConsumerRecordContext(KafkaConsumerRecord<Object, CloudEvent> record) {
+    this.record = record;
+    this.resetTimer();
+  }
+
+  void resetTimer() {
+    this.receivedAtMs = System.currentTimeMillis();
+  }
+
+  long performLatency() {
+    return System.currentTimeMillis() - receivedAtMs;
+  }
+
+  KafkaConsumerRecord<Object, CloudEvent> getRecord() {
+    return record;
+  }
+
+  void setRecord(final KafkaConsumerRecord<Object, CloudEvent> record) {
+    this.record = record;
+  }
+}

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
@@ -200,7 +200,7 @@ public class RecordDispatcherImpl implements RecordDispatcher {
   }
 
   private void onFilterMatching(final ConsumerRecordContext recordContext, final Promise<Void> finalProm) {
-    logDebug("Record match filtering", recordContext.getRecord());
+    logDebug("Record matched filtering", recordContext.getRecord());
     subscriberSender.apply(recordContext.getRecord())
       .onSuccess(response -> onSubscriberSuccess(response, recordContext, finalProm))
       .onFailure(ex -> onSubscriberFailure(ex, recordContext, finalProm));

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
@@ -208,7 +208,7 @@ public class RecordDispatcherImpl implements RecordDispatcher {
 
   private void onFilterNotMatching(final ConsumerRecordContext recordContext,
                                    final Promise<Void> finalProm) {
-    logDebug("Record doesn't match filtering", recordContext.getRecord());
+    logDebug("Record did not match filtering", recordContext.getRecord());
     recordDispatcherListener.recordDiscarded(recordContext.getRecord());
     finalProm.complete();
   }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
@@ -291,10 +291,13 @@ public class RecordDispatcherImpl implements RecordDispatcher {
 
   private void recordDispatchLatency(final HttpResponse<?> response,
                                      final ConsumerRecordContext recordContext) {
+    final var latency = recordContext.performLatency();
+    logger.debug("Dispatch latency {}", keyValue("latency", latency));
+
     Metrics
       .eventDispatchLatency(getTags(response))
       .register(meterRegistry)
-      .record(recordContext.performLatency());
+      .record(latency);
   }
 
   private HttpResponse<?> getResponse(final Throwable throwable) {

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/ResourceContext.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/ResourceContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.dispatcher.impl;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/ResourceContext.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/ResourceContext.java
@@ -1,0 +1,38 @@
+package dev.knative.eventing.kafka.broker.dispatcher.impl;
+
+import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
+import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+
+public class ResourceContext {
+
+  private final DataPlaneContract.Resource resource;
+  private final DataPlaneContract.Egress egress;
+  private final Tags tags;
+
+  public ResourceContext(DataPlaneContract.Resource resource, DataPlaneContract.Egress egress) {
+    this.resource = resource;
+    this.egress = egress;
+
+    this.tags = Tags.of(
+      // Resource tags
+      Tag.of(Metrics.Tags.RESOURCE_NAME, resource.getReference().getName()),
+      Tag.of(Metrics.Tags.RESOURCE_NAMESPACE, resource.getReference().getNamespace()),
+      // Egress tags
+      Tag.of(Metrics.Tags.CONSUMER_NAME, egress.getReference().getName())
+    );
+  }
+
+  public DataPlaneContract.Resource getResource() {
+    return resource;
+  }
+
+  public DataPlaneContract.Egress getEgress() {
+    return egress;
+  }
+
+  public Tags getTags() {
+    return tags;
+  }
+}

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/ResponseFailureException.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/ResponseFailureException.java
@@ -1,0 +1,23 @@
+package dev.knative.eventing.kafka.broker.dispatcher.impl;
+
+import java.net.http.HttpResponse;
+
+public class ResponseFailureException extends RuntimeException {
+
+  private final HttpResponse<?> response;
+
+  public ResponseFailureException(final HttpResponse response, final String msg) {
+    super(msg);
+    this.response = response;
+  }
+
+  public ResponseFailureException(final HttpResponse<?> response,
+                                  final Throwable ex) {
+    super(ex);
+    this.response = response;
+  }
+
+  public HttpResponse<?> getResponse() {
+    return response;
+  }
+}

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/ResponseFailureException.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/ResponseFailureException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.dispatcher.impl;
 
 import java.net.http.HttpResponse;

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
@@ -17,6 +17,7 @@ package dev.knative.eventing.kafka.broker.dispatcher.impl.http;
 
 import dev.knative.eventing.kafka.broker.core.tracing.TracingSpan;
 import dev.knative.eventing.kafka.broker.dispatcher.CloudEventSender;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.ResponseFailureException;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.http.vertx.VertxMessageFactory;
 import io.cloudevents.rw.CloudEventRWException;
@@ -80,6 +81,7 @@ public final class WebClientCloudEventSender implements CloudEventSender {
     });
   }
 
+  @SuppressWarnings("rawtypes")
   private void send(final CloudEvent event, final Promise<HttpResponse<Buffer>> breaker) {
     VertxMessageFactory
       .createWriter(client.postAbs(target).putHeader("Prefer", "reply"))
@@ -92,7 +94,10 @@ public final class WebClientCloudEventSender implements CloudEventSender {
 
         if (isRetryableStatusCode(response.statusCode())) {
           logError(event, response);
-          breaker.tryFail("response status code is not 2xx - got: " + response.statusCode());
+          breaker.tryFail(new ResponseFailureException(
+            (java.net.http.HttpResponse) response,
+            "Received failure response, status code: " + response.statusCode())
+          );
           return;
         }
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
@@ -31,6 +31,7 @@ import dev.knative.eventing.kafka.broker.dispatcher.impl.RecordDispatcherImpl;
 import dev.knative.eventing.kafka.broker.dispatcher.impl.RecordDispatcherMutatorChain;
 import dev.knative.eventing.kafka.broker.dispatcher.impl.ResponseToHttpEndpointHandler;
 import dev.knative.eventing.kafka.broker.dispatcher.impl.ResponseToKafkaTopicHandler;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.ResourceContext;
 import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.BaseConsumerVerticle;
 import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.CloudEventOverridesMutator;
 import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.InvalidCloudEventInterceptor;
@@ -179,6 +180,7 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
 
         final var recordDispatcher = new RecordDispatcherMutatorChain(
           new RecordDispatcherImpl(
+            new ResourceContext(resource, egress),
             filter,
             egressSubscriberSender,
             egressDeadLetterSender,
@@ -190,7 +192,8 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
                 .setConfig(consumerConfigs)
                 // Make sure the policy is propagate for the manually instantiated consumer tracer
                 .setTracingPolicy(TracingPolicy.PROPAGATE)
-            )
+            ),
+            Metrics.getRegistry()
           ),
           new CloudEventOverridesMutator(resource.getCloudEventOverrides())
         );

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/IngressRequestHandlerImpl.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/IngressRequestHandlerImpl.java
@@ -82,8 +82,8 @@ public class IngressRequestHandlerImpl implements IngressRequestHandler {
   public void handle(final RequestContext requestContext, final IngressProducer producer) {
 
     final var resourceTags = Tags.of(
-      Tag.of("name", producer.getReference().getName()),
-      Tag.of("namespace_name", producer.getReference().getNamespace())
+      Tag.of(Metrics.Tags.RESOURCE_NAME, producer.getReference().getName()),
+      Tag.of(Metrics.Tags.RESOURCE_NAMESPACE, producer.getReference().getNamespace())
     );
 
     requestToRecordMapper


### PR DESCRIPTION
See https://knative.dev/docs/eventing/observability/metrics/eventing-metrics/#broker-filter

Eventing Core uses `broker_name` and `trigger_name` for the tag
but since we have Trigger/KafkaSource/Subscription, I'm using
`name` and `consumer_name` instead.

## Proposed Changes

- Align dispatcher metrics to Eventing core filter metrics

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
