### PR TITLE
Bounded in-flight dispatch requests in unordered delivery for back-pressure

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
@@ -16,13 +16,31 @@
 package dev.knative.eventing.kafka.broker.dispatcher.impl.consumer;
 
 import dev.knative.eventing.kafka.broker.dispatcher.DeliveryOrder;
+import io.cloudevents.CloudEvent;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecords;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Set;
+
+import static dev.knative.eventing.kafka.broker.core.utils.Logging.keyValue;
 
 /**
  * This {@link io.vertx.core.Verticle} implements an unordered consumer logic, as described in {@link DeliveryOrder#UNORDERED}.
  */
 public final class UnorderedConsumerVerticle extends BaseConsumerVerticle {
+
+  private static final Logger logger = LoggerFactory.getLogger(UnorderedConsumerVerticle.class);
+
+  private static final long BACKOFF_DELAY_MS = 200;
+  // This shouldn't be more than 2000, which is the default max time allowed
+  // to block a verticle thread.
+  private static final Duration POLL_TIMEOUT = Duration.ofMillis(1000);
 
   public UnorderedConsumerVerticle(Initializer initializer,
                                    Set<String> topics) {
@@ -32,8 +50,42 @@ public final class UnorderedConsumerVerticle extends BaseConsumerVerticle {
   @Override
   void startConsumer(Promise<Void> startPromise) {
     this.consumer.exceptionHandler(this::exceptionHandler);
-    this.consumer.handler(record -> this.recordDispatcher.dispatch(record));
     this.consumer.subscribe(this.topics, startPromise);
+
+    startPromise.future()
+      .onSuccess(v -> poll());
   }
 
+  /**
+   * Vert.x auto-subscribe and handling of records might grow
+   * unbounded, and it is particularly evident when the consumer
+   * is slow to consume messages.
+   * <p>
+   * To apply backpressure, we need to bound the number of outbound
+   * in-flight requests, so we need to manually poll for new records
+   * as we dispatch them to the subscriber service.
+   * <p>
+   * The maximum number of outbound in-flight requests is already configurable
+   * with the consumer parameter `max.poll.records`, and it's critical to
+   * control the memory consumption of the dispatcher.
+   */
+  private void poll() {
+    this.consumer
+      .poll(POLL_TIMEOUT)
+      .onSuccess(this::handleRecords)
+      .onFailure(cause -> {
+        logger.error("Failed to poll messages {}", keyValue("topics", topics), cause);
+        // Wait before retrying.
+        vertx.setTimer(BACKOFF_DELAY_MS, t -> poll());
+      });
+  }
+
+  private void handleRecords(final KafkaConsumerRecords<Object, CloudEvent> records) {
+    final var futures = new ArrayList<Future>(records.size());
+    for (int i = 0; i < records.size(); i++) {
+      futures.add(this.recordDispatcher.dispatch(records.recordAt(i)));
+    }
+    CompositeFuture.join(futures)
+      .onComplete(v -> poll());
+  }
 }


### PR DESCRIPTION
Vert.x auto-subscribe and handling of records might grow
unbounded, and it is particularly evident when the consumer
is slow to consume messages.

To apply backpressure, we need to bound the number of outbound
in-flight requests, so we need to manually poll for new records
as we dispatch them to the subscriber service.

The maximum number of outbound in-flight requests is already configurable
with the consumer parameter `max.poll.records`, and it's critical to
control the memory consumption of the dispatcher.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Part of #1732 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Apply back-pressure by limiting the number of in-flight dispatch requests in the unordered event consumption 
```
