### PR TITLE
Fix metrics naming for Kafka clients

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
@@ -97,8 +97,6 @@ public class Metrics {
    */
   public static MetricsOptions getOptions(final BaseEnv metricsConfigs) {
     final var registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-    registry.config().namingConvention(NamingConvention.identity);
-
     return new MicrometerMetricsOptions()
       .setEnabled(true)
       .addDisabledMetricsCategory(MetricsDomain.EVENT_BUS)


### PR DESCRIPTION
Kafka Consumer and Producer metrics can't be scraped if we use
the prometheus naming convention since internally the micrometer
libary uses micromether specific logic to convert Kafka clients
metric names to micrometer metric names.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>