### PR TITLE
Propagate ConsumerGroup status to KafkaSource

### DIFF
--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_types.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_types.go
@@ -162,3 +162,8 @@ func (cg *ConsumerGroup) ConsumerFromTemplate(options ...ConsumerOption) *Consum
 	}
 	return c
 }
+
+func (cg *ConsumerGroup) IsReady() bool {
+	return cg.Generation == cg.Status.ObservedGeneration &&
+		cg.GetConditionSet().Manage(cg.GetStatus()).IsHappy()
+}


### PR DESCRIPTION
We cannot mark the `KafkaConditionConsumerGroup` as ready until
the underlying ConsumerGroup is ready.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

/assign @aavarghese 