### PR TITLE
Increase E2E and rekt tests timeout

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -21,7 +21,7 @@ header "Running tests"
 
 export_logs_continuously
 
-go_test_e2e -timeout=30m ./test/e2e/... -channels=messaging.knative.dev/v1beta1:KafkaChannel || fail_test "E2E suite failed"
+go_test_e2e -timeout=1h ./test/e2e/... -channels=messaging.knative.dev/v1beta1:KafkaChannel || fail_test "E2E suite failed"
 
 go_test_e2e -tags=deletecm ./test/e2e/... -channels=messaging.knative.dev/v1beta1:KafkaChannel || fail_test "E2E (deletecm) suite failed"
 

--- a/test/reconciler-tests.sh
+++ b/test/reconciler-tests.sh
@@ -21,7 +21,7 @@ header "Running tests"
 
 export_logs_continuously
 
-go_test_e2e -timeout=30m ./test/e2e_new/... || fail_test "E2E (new) suite failed"
+go_test_e2e -timeout=1h ./test/e2e_new/... || fail_test "E2E (new) suite failed"
 
 go_test_e2e -tags=deletecm ./test/e2e_new/... || fail_test "E2E (new deletecm) suite failed"
 


### PR DESCRIPTION
This [test run](https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative-sandbox_eventing-kafka-broker/1728/pull-knative-sandbox-eventing-kafka-broker-integration-tests/1484140292578742272) failed with:

```
panic: test timed out after 30m0s
```
