### PR TITLE
Add HTTP Header 'Prefer: reply' in accordance with KNative specs

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
@@ -79,7 +79,7 @@ public final class WebClientCloudEventSender implements CloudEventSender {
 
   private void send(final CloudEvent event, final Promise<HttpResponse<Buffer>> breaker) {
     VertxMessageFactory
-      .createWriter(client.postAbs(target))
+      .createWriter(client.postAbs(target).putHeader("Prefer", "reply"))
       .writeBinary(event)
       .onFailure(ex -> {
         logError(event, ex);


### PR DESCRIPTION
Fixes #

[<!-- Please include the 'why' behind your changes if no issue exists -->](https://github.com/knative-sandbox/eventing-kafka-broker/issues/1770)

## Proposed Changes

- Add HTTP Header `Prefer: reply` according to [Knative specs](https://github.com/knative/specs/blob/main/specs/eventing/data-plane.md#derived-reply-events)
- :bug: Fix bug https://github.com/knative-sandbox/eventing-kafka-broker/issues/1770

**Release Note**

```release-note
An HTTP header will be supplied to your event consumers when the broker it is communicating with supports reply events. This will always be sent while using this Kafka broker since it supports handling reply events.
```

**Docs**

