### PR TITLE
Set FinishedSleep via env variable in upgrade tests 

### DIFF
--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -40,6 +40,7 @@ set -Eeuo pipefail
 TIMEOUT=${TIMEOUT:-60m}
 GO_TEST_VERBOSITY="${GO_TEST_VERBOSITY:-standard-verbose}"
 
+EVENTING_UPGRADE_TESTS_FINISHEDSLEEP="5m" \
 go_test_e2e -v \
   -tags=upgrade \
   -timeout="${TIMEOUT}" \

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -40,7 +40,7 @@ set -Eeuo pipefail
 TIMEOUT=${TIMEOUT:-60m}
 GO_TEST_VERBOSITY="${GO_TEST_VERBOSITY:-standard-verbose}"
 
-EVENTING_UPGRADE_TESTS_FINISHEDSLEEP="5m" \
+EVENTING_KAFKA_BROKER_UPGRADE_TESTS_FINISHEDSLEEP="5m" \
 go_test_e2e -v \
   -tags=upgrade \
   -timeout="${TIMEOUT}" \

--- a/test/upgrade/continual/verification.go
+++ b/test/upgrade/continual/verification.go
@@ -18,7 +18,6 @@ package continual
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	eventingkafkaupgrade "knative.dev/eventing-kafka/test/upgrade/continual"
@@ -78,7 +77,6 @@ func configurator(theSut sut.SystemUnderTest, configTemplate string) prober.Conf
 		// TODO: knative/eventing#5176 - this is cumbersome
 		config.ConfigTemplate = fmt.Sprintf("../../../../../../%s",
 			configTemplate)
-		config.FinishedSleep = 5 * time.Minute
 		// envconfig.Process invocation is repeated from within prober.NewConfig to
 		// make sure every knob is configurable, but using defaults from Eventing
 		// Kafka instead of Core. The prefix is also changed.


### PR DESCRIPTION
Fixes error such as:
Error: test/upgrade/continual/verification.go:81:9: config.FinishedSleep
undefined (type *prober.Config has no field or method FinishedSleep)

* The env variable can be removed once changes from
knative/eventing#6074 are propagated to this
repo.
