### PR TITLE
Add Pod webhook to inject contract ConfigMap for scheduling

### DIFF
--- a/control-plane/cmd/webhook-kafka/main.go
+++ b/control-plane/cmd/webhook-kafka/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -33,9 +34,11 @@ import (
 	sourcesv1beta1 "knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
 	eventingcorev1beta1 "knative.dev/eventing/pkg/apis/eventing/v1"
 
+	messagingv1beta1 "knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/apis/core"
 	eventingv1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1"
 	eventingv1alpha1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
-	messagingv1beta1 "knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
 )
 
 const (
@@ -48,8 +51,12 @@ var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 	messagingv1beta1.SchemeGroupVersion.WithKind("KafkaChannel"): &messagingv1beta1.KafkaChannel{},
 }
 
-var callbacks = map[schema.GroupVersionKind]validation.Callback{
+var validationCallbacks = map[schema.GroupVersionKind]validation.Callback{
 	eventingcorev1beta1.SchemeGroupVersion.WithKind("Broker"): eventingv1.BrokerValidationCallback(),
+}
+
+var defaultingCallbacks = map[schema.GroupVersionKind]defaulting.Callback{
+	corev1.SchemeGroupVersion.WithKind("Pod"): core.DispatcherPodsDefaulting(),
 }
 
 func NewDefaultingAdmissionController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
@@ -77,6 +84,35 @@ func NewDefaultingAdmissionController(ctx context.Context, _ configmap.Watcher) 
 	)
 }
 
+func NewPodDefaultingAdmissionController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
+
+	// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
+	ctxFunc := func(ctx context.Context) context.Context {
+		return ctx
+	}
+
+	return defaulting.NewAdmissionController(ctx,
+		// Name of the resource webhook.
+		"pods.defaulting.webhook.kafka.eventing.knative.dev",
+
+		// The path on which to serve the webhook.
+		"/pods-defaulting",
+
+		// The resources to default.
+		// We use only defaulting callbacks for pods.
+		map[schema.GroupVersionKind]resourcesemantics.GenericCRD{},
+
+		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
+		ctxFunc,
+
+		// Whether to disallow unknown fields.
+		false,
+
+		// Extra defaulting callbacks to be applied to resources.
+		defaultingCallbacks,
+	)
+}
+
 func NewValidationAdmissionController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 	return validation.NewAdmissionController(ctx,
 		// Name of the resource webhook.
@@ -97,7 +133,7 @@ func NewValidationAdmissionController(ctx context.Context, _ configmap.Watcher) 
 		true,
 
 		// Extra validating callbacks to be applied to resources.
-		callbacks,
+		validationCallbacks,
 	)
 }
 
@@ -114,6 +150,7 @@ func main() {
 	sharedmain.MainWithContext(ctx, webhook.NameFromEnv(),
 		certificates.NewController,
 		NewDefaultingAdmissionController,
+		NewPodDefaultingAdmissionController,
 		NewValidationAdmissionController,
 	)
 }

--- a/control-plane/config/200-webhook/400-webhook-defaulting.yaml
+++ b/control-plane/config/200-webhook/400-webhook-defaulting.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     kafka.eventing.knative.dev/release: devel
 webhooks:
-  - admissionReviewVersions: ["v1", "v1beta1"]
+  - admissionReviewVersions: [ "v1", "v1beta1" ]
     clientConfig:
       service:
         name: kafka-webhook-eventing
@@ -28,3 +28,22 @@ webhooks:
     failurePolicy: Fail
     name: defaulting.webhook.kafka.eventing.knative.dev
     timeoutSeconds: 2
+
+  # Dispatcher pods webhook config.
+  - admissionReviewVersions: [ "v1", "v1beta1" ]
+    clientConfig:
+      service:
+        name: kafka-webhook-eventing
+        namespace: knative-eventing
+    sideEffects: None
+    failurePolicy: Fail
+    name: pods.defaulting.webhook.kafka.eventing.knative.dev
+    timeoutSeconds: 2
+    reinvocationPolicy: IfNeeded
+    matchPolicy: Equivalent
+    namespaceSelector:
+      matchLabels:
+        app.kubernetes.io/name: knative-eventing
+    objectSelector:
+      matchLabels:
+        app.kubernetes.io/component: kafka-dispatcher

--- a/control-plane/pkg/apis/core/pod_defaulting.go
+++ b/control-plane/pkg/apis/core/pod_defaulting.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
+	"knative.dev/pkg/webhook/resourcesemantics/defaulting"
+
+	kafkainternals "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1"
+)
+
+// DispatcherPodsDefaulting returns the defaulting Callback for dispatcher pods
+func DispatcherPodsDefaulting() defaulting.Callback {
+	return defaulting.NewCallback(
+		podDefaultingCallback(func(u *unstructured.Unstructured) uuid.UUID { return uuid.New() }),
+		webhook.Create,
+	)
+}
+
+// generatorFunc generates uuid to set as ConfigMap names.
+type generatorFunc func(*unstructured.Unstructured) uuid.UUID
+
+func podDefaultingCallback(generator generatorFunc) defaulting.CallbackFunc {
+	namespace := system.Namespace()
+	return func(ctx context.Context, unstructured *unstructured.Unstructured) error {
+		if unstructured.GetNamespace() != namespace {
+			return nil
+		}
+
+		var cmName string
+		if unstructured.GetName() == "" {
+			cmName = generator(unstructured).String()
+		} else {
+			cmName = unstructured.GetName()
+		}
+
+		volume := &corev1.Volume{
+			Name: kafkainternals.DispatcherVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
+				},
+			},
+		}
+
+		unstrVolume, err := runtime.DefaultUnstructuredConverter.ToUnstructured(volume)
+		if err != nil {
+			return fmt.Errorf("failed to convert volume struct to unstructured object: %w", err)
+		}
+
+		pod := unstructured.Object
+		spec := pod["spec"].(map[string]interface{})
+
+		volumes, ok := spec["volumes"].([]interface{})
+		if !ok {
+			volumes = []interface{}{}
+			spec["volumes"] = volumes
+		}
+
+		found := false
+		for k, v := range volumes {
+			vt := v.(map[string]interface{})
+			if vt["name"].(string) == "contract-resources" {
+				found = true
+				volumes[k] = unstrVolume
+			}
+		}
+
+		if !found {
+			spec["volumes"] = append(volumes, unstrVolume)
+		}
+
+		unstructured.Object = pod
+
+		return nil
+	}
+}

--- a/control-plane/pkg/apis/core/pod_defaulting_test.go
+++ b/control-plane/pkg/apis/core/pod_defaulting_test.go
@@ -1,0 +1,501 @@
+/*
+ * Copyright 2022 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/system"
+)
+
+func TestPodDefaulting(t *testing.T) {
+	t.Setenv("SYSTEM_NAMESPACE", "knative-eventing")
+
+	id := uuid.New()
+
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		given   corev1.Pod
+		want    corev1.Pod
+		wantErr bool
+	}{
+		{
+			name: "add volume source",
+			ctx:  context.Background(),
+			given: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka-source-dispatcher",
+					Namespace: system.Namespace(),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "dispatcher",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "contract-resources",
+									ReadOnly:  false,
+									MountPath: "/etc/contract/contract-resources",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka-source-dispatcher",
+					Namespace: system.Namespace(),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "dispatcher",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "contract-resources",
+									ReadOnly:  false,
+									MountPath: "/etc/contract/contract-resources",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "contract-resources",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "add volume source, preserving another volume",
+			ctx:  context.Background(),
+			given: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka-source-dispatcher",
+					Namespace: system.Namespace(),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "dispatcher",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "contract-resources",
+									ReadOnly:  false,
+									MountPath: "/etc/contract/contract-resources",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "contract-resources-2",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher-2"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka-source-dispatcher",
+					Namespace: system.Namespace(),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "dispatcher",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "contract-resources",
+									ReadOnly:  false,
+									MountPath: "/etc/contract/contract-resources",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "contract-resources-2",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher-2"},
+								},
+							},
+						},
+						{
+							Name: "contract-resources",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "replace volume source, preserving another volume",
+			ctx:  context.Background(),
+			given: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka-source-dispatcher",
+					Namespace: system.Namespace(),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "dispatcher",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "contract-resources",
+									ReadOnly:  false,
+									MountPath: "/etc/contract/contract-resources",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "contract-resources-2",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher-2"},
+								},
+							},
+						},
+						{
+							Name: "contract-resources",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: id.String() + "-aaa"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka-source-dispatcher",
+					Namespace: system.Namespace(),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "dispatcher",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "contract-resources",
+									ReadOnly:  false,
+									MountPath: "/etc/contract/contract-resources",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "contract-resources-2",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher-2"},
+								},
+							},
+						},
+						{
+							Name: "contract-resources",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "no changes to volume source, preserving another volume",
+			ctx:  context.Background(),
+			given: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka-source-dispatcher",
+					Namespace: system.Namespace(),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "dispatcher",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "contract-resources",
+									ReadOnly:  false,
+									MountPath: "/etc/contract/contract-resources",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "contract-resources-2",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher-2"},
+								},
+							},
+						},
+						{
+							Name: "contract-resources",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka-source-dispatcher",
+					Namespace: system.Namespace(),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "dispatcher",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "contract-resources",
+									ReadOnly:  false,
+									MountPath: "/etc/contract/contract-resources",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "contract-resources-2",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher-2"},
+								},
+							},
+						},
+						{
+							Name: "contract-resources",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "no namespace, no changes",
+			ctx:  context.Background(),
+			given: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "kafka-source-dispatcher"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "dispatcher",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "contract-resources",
+									ReadOnly:  false,
+									MountPath: "/etc/contract/contract-resources",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "contract-resources-2",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher-2"},
+								},
+							},
+						},
+						{
+							Name: "contract-resources",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "kafka-source-dispatcher"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "dispatcher",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "contract-resources",
+									ReadOnly:  false,
+									MountPath: "/etc/contract/contract-resources",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "contract-resources-2",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher-2"},
+								},
+							},
+						},
+						{
+							Name: "contract-resources",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "No name, use generator",
+			ctx:  context.Background(),
+			given: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: system.Namespace()},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "dispatcher",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "contract-resources",
+									ReadOnly:  false,
+									MountPath: "/etc/contract/contract-resources",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "contract-resources-2",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher-2"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: system.Namespace()},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "dispatcher",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "contract-resources",
+									ReadOnly:  false,
+									MountPath: "/etc/contract/contract-resources",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "contract-resources-2",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "kafka-source-dispatcher-2"},
+								},
+							},
+						},
+						{
+							Name: "contract-resources",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: id.String()},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	var generator generatorFunc = func(*unstructured.Unstructured) uuid.UUID { return id }
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			given, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tt.given)
+			require.Nil(t, err)
+
+			unstr := &unstructured.Unstructured{Object: given}
+			if err := podDefaultingCallback(generator)(tt.ctx, unstr); (err != nil) != tt.wantErr {
+				t.Errorf("podDefaultingCallback() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			got := corev1.Pod{}
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstr.UnstructuredContent(), &got)
+			require.Nil(t, err)
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Error("(-want,+got)", diff)
+			}
+		})
+	}
+}

--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_types.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_types.go
@@ -28,6 +28,10 @@ import (
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/apis/internals/kafka/eventing"
 )
 
+const (
+	DispatcherVolumeName = "contract-resources"
+)
+
 // +genclient
 // +genreconciler
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
To be able to mount a `ConfigMap` per dispatcher pod, we need
to use a webhook that reacts when a _dispatcher_ `Pod` is created.

Dispatcher pods are selected based on this label:
```
app.kubernetes.io/component: kafka-dispatcher
```
(so the StatefulSets kafka-source-dispatcher,
kafka-broker-dispatcher, etc must have these labels).
and only when they are in a namespace labeled with:
```
app.kubernetes.io/name: knative-eventing
```
which is the label used for the `knative-eventing` namespace.

To every dispatcher pod, we inject a volume in `spec.volumes`
`contract-resources` which then reference a ConfigMap which
has the same name as the `Pod`.

The volume can be (statically) referenced by the `VolumeMount`
section of the (to be added) StatefulSets.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>