### PR TITLE
Fix release: artifact to publish type

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -67,6 +67,11 @@ function build_release() {
     "${EVENTING_KAFKA_CHANNEL_ARTIFACT}"
     "${EVENTING_KAFKA_CHANNEL_PROMETHEUS_OPERATOR_ARTIFACT}"
   )
+
+  # ARTIFACTS_TO_PUBLISH has to be a string, not an array.
+  # shellcheck disable=SC2178
+  # shellcheck disable=SC2124
+  export ARTIFACTS_TO_PUBLISH="${ARTIFACTS_TO_PUBLISH[@]}"
 }
 
 main $@


### PR DESCRIPTION
Release 1.2.0 went wrong since the `ARTIFACT_TO_PUBLISH`
variable has to be a string, but it was an array.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>
