### PR TITLE
TestBrokerDeletedRecreated deletes the broker only

### DIFF
--- a/test/e2e_new/features/broker_deleted_recreated.go
+++ b/test/e2e_new/features/broker_deleted_recreated.go
@@ -36,7 +36,7 @@ func BrokerDeletedRecreated() *feature.Feature {
 	triggerName := feature.MakeRandomK8sName("trigger")
 
 	f.Setup("test broker", featuressteps.BrokerSmokeTest(brokerName, triggerName))
-	f.Requirement("delete resources", featuressteps.DeleteResources(f))
+	f.Requirement("delete broker", featuressteps.DeleteBroker(brokerName))
 	f.Assert("test broker after deletion", featuressteps.BrokerSmokeTest(brokerName, triggerName))
 
 	return f


### PR DESCRIPTION
Using `DeleteResources` isn't a good idea since that function deletes
some internal resources like RBAC (for eventshub), etc

Fixes #1510