### PR TITLE
KafkaChannel run e2e tests with auth - 2nd try

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -24,6 +24,9 @@ jobs:
         eventing-config:
           - "./third_party/eventing-latest/"
 
+        channel-auth-scenario:
+          - ""
+
         test-suite:
           - ./test/e2e
           - ./test/e2e_new
@@ -43,6 +46,20 @@ jobs:
           - test-suite: ./test/e2e_channel
             extra-test-flags: -channels=messaging.knative.dev/v1beta1:KafkaChannel
 
+          # additional tests for KafkaChannel auth scenarios
+          - test-suite: ./test/e2e_channel
+            extra-test-flags: -channels=messaging.knative.dev/v1beta1:KafkaChannel
+            channel-auth-scenario:
+              - "TLS"
+              - "SASL_SSL"
+              - "SASL_PLAIN"
+          # additional tests for KafkaChannel auth scenarios
+          - test-suite: ./test/e2e_new_channel
+            channel-auth-scenario:
+              - "TLS"
+              - "SASL_SSL"
+              - "SASL_PLAIN"
+
     env:
       GOPATH: ${{ github.workspace }}
       KO_DOCKER_REPO: kind.local
@@ -56,6 +73,8 @@ jobs:
       EVENTING_CONFIG: ${{ matrix.eventing-config }}
       NODE_VERSION: ${{ matrix.k8s-version }}
       NODE_SHA: ${{ matrix.kind-image-sha }}
+
+      CHANNEL_AUTH_SCENARIO: ${{ matrix.channel-auth-scenario }}
 
     steps:
       - name: Install Dependencies
@@ -123,6 +142,9 @@ jobs:
           export KO_FLAGS="--platform=linux/amd64"
           export SYSTEM_NAMESPACE=knative-eventing
           export CLUSTER_DOMAIN=${CLUSTER_SUFFIX}
+
+          # Setup auth config for KafkaChannel. Uses CHANNEL_AUTH_SCENARIO env var.
+          setup_kafka_channel_auth
 
           # Run the tests tagged as e2e on the KinD cluster.
           go test -race -count=1 -timeout=1h -v -short -tags=e2e,cloudevents \

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -143,6 +143,8 @@ jobs:
 
       - name: Run e2e Tests
         run: |
+          source test/e2e-common.sh
+
           export KO_FLAGS="--platform=linux/amd64"
           export SYSTEM_NAMESPACE=knative-eventing
           export CLUSTER_DOMAIN=${CLUSTER_SUFFIX}

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -24,9 +24,6 @@ jobs:
         eventing-config:
           - "./third_party/eventing-latest/"
 
-        channel-auth-scenario:
-          - ""
-
         test-suite:
           - ./test/e2e
           - ./test/e2e_new
@@ -49,16 +46,21 @@ jobs:
           # additional tests for KafkaChannel auth scenarios
           - test-suite: ./test/e2e_channel
             extra-test-flags: -channels=messaging.knative.dev/v1beta1:KafkaChannel
-            channel-auth-scenario:
-              - "TLS"
-              - "SASL_SSL"
-              - "SASL_PLAIN"
+            channel-auth-scenario: TLS
+          - test-suite: ./test/e2e_channel
+            extra-test-flags: -channels=messaging.knative.dev/v1beta1:KafkaChannel
+            channel-auth-scenario: SASL_SSL
+          - test-suite: ./test/e2e_channel
+            extra-test-flags: -channels=messaging.knative.dev/v1beta1:KafkaChannel
+            channel-auth-scenario: SASL_PLAIN
+
           # additional tests for KafkaChannel auth scenarios
           - test-suite: ./test/e2e_new_channel
-            channel-auth-scenario:
-              - "TLS"
-              - "SASL_SSL"
-              - "SASL_PLAIN"
+            channel-auth-scenario: TLS
+          - test-suite: ./test/e2e_new_channel
+            channel-auth-scenario: SASL_SSL
+          - test-suite: ./test/e2e_new_channel
+            channel-auth-scenario: SASL_PLAIN
 
     env:
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -24,6 +24,12 @@ jobs:
         eventing-config:
           - "./third_party/eventing-latest/"
 
+        channel-auth-scenario:
+          - ""
+          - "TLS"
+          - "SASL_SSL"
+          - "SASL_PLAIN"
+
         test-suite:
           - ./test/e2e
           - ./test/e2e_new
@@ -43,24 +49,20 @@ jobs:
           - test-suite: ./test/e2e_channel
             extra-test-flags: -channels=messaging.knative.dev/v1beta1:KafkaChannel
 
-          # additional tests for KafkaChannel auth scenarios
-          - test-suite: ./test/e2e_channel
-            extra-test-flags: -channels=messaging.knative.dev/v1beta1:KafkaChannel
-            channel-auth-scenario: TLS
-          - test-suite: ./test/e2e_channel
-            extra-test-flags: -channels=messaging.knative.dev/v1beta1:KafkaChannel
-            channel-auth-scenario: SASL_SSL
-          - test-suite: ./test/e2e_channel
-            extra-test-flags: -channels=messaging.knative.dev/v1beta1:KafkaChannel
-            channel-auth-scenario: SASL_PLAIN
-
-          # additional tests for KafkaChannel auth scenarios
-          - test-suite: ./test/e2e_new_channel
-            channel-auth-scenario: TLS
-          - test-suite: ./test/e2e_new_channel
-            channel-auth-scenario: SASL_SSL
-          - test-suite: ./test/e2e_new_channel
-            channel-auth-scenario: SASL_PLAIN
+        # don't run e2e for tests other than KafkaChannel when channel-auth-scenario is set
+        exclude:
+          - test-suite: ./test/e2e
+            channel-auth-scenario: "TLS"
+          - test-suite: ./test/e2e
+            channel-auth-scenario: "SASL_SSL"
+          - test-suite: ./test/e2e
+            channel-auth-scenario: "SASL_PLAIN"
+          - test-suite: ./test/e2e_new
+            channel-auth-scenario: "TLS"
+          - test-suite: ./test/e2e_new
+            channel-auth-scenario: "SASL_SSL"
+          - test-suite: ./test/e2e_new
+            channel-auth-scenario: "SASL_PLAIN"
 
     env:
       GOPATH: ${{ github.workspace }}

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -286,6 +286,6 @@ function setup_kafka_channel_auth() {
     kubectl patch configmap/kafka-channel-config \
       -n knative-eventing \
       --type=json \
-      -p='[{"op": "remove", "path": "/data/auth.secret.ref.name"}]'
+      -p='[{"op": "remove", "path": "/data/auth.secret.ref.name"}]' || true
   fi
 }

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -289,3 +289,26 @@ function setup_kafka_channel_auth() {
       -p='[{"op": "remove", "path": "/data/auth.secret.ref.name"}]' || true
   fi
 }
+
+function parse_flags() {
+  # This function will be called repeatedly by initialize() with one fewer
+  # argument each time and expects a return value of "the number of arguments to skip"
+  # so we can just check the first argument and return 1 (to have it redirected to the
+  # test container) or 0 (to have initialize() parse it normally).
+  case $1 in
+    --channel-tls)
+      CHANNEL_AUTH_SCENARIO="TLS"
+      return 1
+      ;;
+    --channel-sasl-ssl)
+      CHANNEL_AUTH_SCENARIO="SASL_SSL"
+      return 1
+      ;;
+    --channel-sasl-plain)
+      CHANNEL_AUTH_SCENARIO="SASL_PLAIN"
+      return 1
+      ;;
+  esac
+  return 0
+}
+

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -40,6 +40,8 @@ export_logs_continuously
 
 go_test_e2e -timeout=1h ./test/e2e/... || fail_test "E2E suite failed"
 
+go_test_e2e -timeout=1h ./test/e2e_channel/... -channels=messaging.knative.dev/v1beta1:KafkaChannel || fail_test "E2E suite (KafkaChannel) failed"
+
 go_test_e2e -tags=deletecm ./test/e2e/... || fail_test "E2E (deletecm) suite failed"
 
 if ! ${LOCAL_DEVELOPMENT}; then

--- a/test/kafka/kafka_setup.sh
+++ b/test/kafka/kafka_setup.sh
@@ -103,6 +103,7 @@ function create_sasl_secrets() {
     --from-literal=user="my-sasl-user" \
     --from-literal=protocol="SASL_SSL" \
     --from-literal=sasl.mechanism="SCRAM-SHA-512" \
+    --from-literal=saslType="SCRAM-SHA-512" \
     --dry-run=client -o yaml | kubectl apply -n "${SYSTEM_NAMESPACE}" -f -
 
   kubectl create secret --namespace "${SYSTEM_NAMESPACE}" generic strimzi-sasl-plain-secret \
@@ -110,6 +111,7 @@ function create_sasl_secrets() {
     --from-literal=user="my-sasl-user" \
     --from-literal=protocol="SASL_PLAINTEXT" \
     --from-literal=sasl.mechanism="SCRAM-SHA-512" \
+    --from-literal=saslType="SCRAM-SHA-512" \
     --dry-run=client -o yaml | kubectl apply -n "${SYSTEM_NAMESPACE}" -f -
 }
 

--- a/test/reconciler-tests.sh
+++ b/test/reconciler-tests.sh
@@ -17,13 +17,28 @@ header "Waiting Knative eventing to come up"
 
 wait_until_pods_running knative-eventing || fail_test "Pods in knative-eventing didn't come up"
 
+if [ ! -z "${CHANNEL_AUTH_SCENARIO}" ]; then
+  # if this flag exists, only test Kafka channel scenarios with auth
+
+  # Setup auth config for KafkaChannel. Uses CHANNEL_AUTH_SCENARIO env var.
+  header "Setting up auth config for KafkaChannel"
+  setup_kafka_channel_auth
+
+  header "Running KafkaChannel tests"
+
+  export_logs_continuously
+
+  go_test_e2e -tags=e2e,cloudevents -timeout=1h ./test/e2e_new_channel/... || fail_test "E2E (new - KafkaChannel) suite failed"
+
+  # this exits the script
+  success
+fi
+
 header "Running tests"
 
 export_logs_continuously
 
 go_test_e2e -timeout=1h ./test/e2e_new/... || fail_test "E2E (new) suite failed"
-
-go_test_e2e -tags=e2e,cloudevents -timeout=1h ./test/e2e_new_channel/... || fail_test "E2E (new - KafkaChannel) suite failed"
 
 go_test_e2e -tags=deletecm ./test/e2e_new/... || fail_test "E2E (new deletecm) suite failed"
 

--- a/test/reconciler-tests.sh
+++ b/test/reconciler-tests.sh
@@ -40,6 +40,8 @@ export_logs_continuously
 
 go_test_e2e -timeout=1h ./test/e2e_new/... || fail_test "E2E (new) suite failed"
 
+go_test_e2e -tags=e2e,cloudevents -timeout=1h ./test/e2e_new_channel/... || fail_test "E2E (new - KafkaChannel) suite failed"
+
 go_test_e2e -tags=deletecm ./test/e2e_new/... || fail_test "E2E (new deletecm) suite failed"
 
 if ! ${LOCAL_DEVELOPMENT}; then


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

Motivation is being able to run channel e2e and Rekt tests independently with auth.

- Tooling to only run KafkaChannel tests when requested.
- When `CHANNEL_AUTH_SCENARIO` env var is set, e2e and reconciler test scripts will only run KafkaChannel tests and with the given auth scenario.
- 3 new prow jobs are to be added for each of the auth options that run the e2e and Rekt tests for the Channel here: https://github.com/knative/test-infra/pull/3062


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:gift: KafkaChannel is now conformant to Knative Eventing spec also while supporting auth.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
