### PR TITLE
Run channel Rekt tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -123,7 +123,7 @@ jobs:
           export CLUSTER_DOMAIN=${CLUSTER_SUFFIX}
 
           # Run the tests tagged as e2e on the KinD cluster.
-          go test -race -count=1 -timeout=1h -v -short -tags=e2e \
+          go test -race -count=1 -timeout=1h -v -short -tags=e2e,cloudevents \
              ${{ matrix.test-suite }} ${{ matrix.extra-test-flags }}
 
       - name: Collect system diagnostics

--- a/test/reconciler-tests.sh
+++ b/test/reconciler-tests.sh
@@ -21,7 +21,7 @@ header "Running tests"
 
 export_logs_continuously
 
-go_test_e2e -timeout=1h ./test/e2e_new/... || fail_test "E2E (new) suite failed"
+go_test_e2e -tags=e2e,cloudevents -timeout=1h ./test/e2e_new/... || fail_test "E2E (new) suite failed"
 
 go_test_e2e -tags=deletecm ./test/e2e_new/... || fail_test "E2E (new deletecm) suite failed"
 


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Run channel Rekt tests
- `cloudevents` tag was required to run Rekt tests for KafkaChannel but was forgotten
- Depends on https://github.com/knative-sandbox/eventing-kafka-broker/pull/1824. It is to revert the breakage merged unnoticed because of the conformance tests not running.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:gift: KafkaChannel becomes conformant with spec. Conformance tests are now run with every code change.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
