### PR TITLE
Add component label to source dispatcher statefulset

### DIFF
--- a/data-plane/config/source/500-dispatcher.yaml
+++ b/data-plane/config/source/500-dispatcher.yaml
@@ -31,6 +31,7 @@ spec:
       name: kafka-source-dispatcher
       labels:
         app: kafka-source-dispatcher
+        app.kubernetes.io/component: kafka-dispatcher
         kafka.eventing.knative.dev/release: devel
     spec:
       serviceAccountName: knative-kafka-source-data-plane


### PR DESCRIPTION
This label is used by the pod webhook to select which
pods should be defaulted.

See https://github.com/knative-sandbox/eventing-kafka-broker/pull/1796

Part of #1537

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>