### PR TITLE
Use Git patches for pkg issue and E2E tests failures

### DIFF
--- a/hack/patches/defaulting-webhook-queue-name.patch
+++ b/hack/patches/defaulting-webhook-queue-name.patch
@@ -1,0 +1,15 @@
+diff --git a/vendor/knative.dev/pkg/webhook/resourcesemantics/defaulting/controller.go b/vendor/knative.dev/pkg/webhook/resourcesemantics/defaulting/controller.go
+index b50fcf8f..b18fe8fa 100644
+--- a/vendor/knative.dev/pkg/webhook/resourcesemantics/defaulting/controller.go
++++ b/vendor/knative.dev/pkg/webhook/resourcesemantics/defaulting/controller.go
+@@ -90,8 +90,8 @@ func NewAdmissionController(
+ 	}
+
+ 	logger := logging.FromContext(ctx)
+-	const queueName = "DefaultingWebhook"
+-	c := controller.NewContext(ctx, wh, controller.ControllerOptions{WorkQueueName: queueName, Logger: logger.Named(queueName)})
++	// TODO: https://github.com/knative/pkg/issues/2418
++	c := controller.NewContext(ctx, wh, controller.ControllerOptions{WorkQueueName: name, Logger: logger.Named(name)})
+
+ 	// Reconcile when the named MutatingWebhookConfiguration changes.
+ 	mwhInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -22,3 +22,5 @@ source $(dirname "$0")/../vendor/knative.dev/hack/library.sh
 
 go_update_deps "$@"
 
+# Apply Git patches
+git apply $(dirname "$0")/patches/*

--- a/vendor/knative.dev/pkg/webhook/resourcesemantics/defaulting/controller.go
+++ b/vendor/knative.dev/pkg/webhook/resourcesemantics/defaulting/controller.go
@@ -90,8 +90,8 @@ func NewAdmissionController(
 	}
 
 	logger := logging.FromContext(ctx)
-	const queueName = "DefaultingWebhook"
-	c := controller.NewContext(ctx, wh, controller.ControllerOptions{WorkQueueName: queueName, Logger: logger.Named(queueName)})
+	// TODO: https://github.com/knative/pkg/issues/2418
+	c := controller.NewContext(ctx, wh, controller.ControllerOptions{WorkQueueName: name, Logger: logger.Named(name)})
 
 	// Reconcile when the named MutatingWebhookConfiguration changes.
 	mwhInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{


### PR DESCRIPTION
See the linked issue in `TODO: ...`

this is causing errors like:
```
channel_impl.go:76: admission webhook "validation.webhook.kafka.eventing.knative.dev" denied the request: validation failed: invalid value: : spec.retentionDuration
```
In this case, the pod webhook is the leader over the resource webhook.