### PR TITLE
Simulate dispatch latency during unit tests

### DIFF
--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherTest.java
@@ -118,6 +118,7 @@ public class RecordDispatcherTest {
       new CloudEventSenderMock(
         record -> {
           sendCalled.set(true);
+          simulateLatency(); // Simulate dispatch latency
           return Future.succeededFuture();
         }
       ),
@@ -160,6 +161,7 @@ public class RecordDispatcherTest {
       new CloudEventSenderMock(
         record -> {
           subscriberSenderSendCalled.set(true);
+          simulateLatency(); // Simulate dispatch latency
           return Future.failedFuture("");
         }
       ),
@@ -201,6 +203,7 @@ public class RecordDispatcherTest {
       value -> true, new CloudEventSenderMock(
       record -> {
         subscriberSenderSendCalled.set(true);
+        simulateLatency(); // Simulate dispatch latency
         return Future.failedFuture("");
       }
     ),
@@ -242,6 +245,7 @@ public class RecordDispatcherTest {
       new CloudEventSenderMock(
         record -> {
           subscriberSenderSendCalled.set(true);
+          simulateLatency(); // Simulate dispatch latency
           return Future.failedFuture("");
         }
       ),
@@ -379,6 +383,13 @@ public class RecordDispatcherTest {
           .max()
       ).isGreaterThan(0)
     );
+  }
+
+  private void simulateLatency() {
+    try {
+      Thread.sleep(100);
+    } catch (InterruptedException ignored) {
+    }
   }
 
 }


### PR DESCRIPTION
The assertion for dispatch latency metrics is flaky since the
sender is a mock that doesn't do anything.
This ends up producing a dispatch latency of 0.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Simulate dispatch latency during unit tests

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->
