### PR TITLE
Cluster role in controller for consumer deletion update

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
@@ -105,6 +105,7 @@ rules:
       - watch
       - patch
       - update
+      - delete
   - apiGroups:
       - "internal.kafka.eventing.knative.dev"
     resources:
@@ -112,7 +113,7 @@ rules:
       - "consumergroups/finalizers"
     verbs:
       - update
-
+      - delete
   # Eventing resources and statuses we care about
   - apiGroups:
       - "eventing.knative.dev"


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

Part of #1537 

Error seen:
```
{"level":"error","ts":"2022-02-17T21:13:18.048Z","logger":"kafka-broker-controller","caller":"controller/controller.go:566","msg":"Reconcile error","knative.dev/pod":"kafka-controller-7b48c89984-br9pr","knative.dev/controller":"knative.dev.eventing-kafka-broker.control-plane.pkg.reconciler.consumergroup.Reconciler","knative.dev/kind":"internal.kafka.eventing.knative.dev.ConsumerGroup","knative.dev/traceid":"5f8774e4-c895-4358-9c94-070851bd4b77","knative.dev/key":"default/331aa464-5ec1-4b0d-8a3c-1d591d64ea90","duration":0.0528905,"error":"failed to reconcile consumers: failed to remove consumer default/331aa464-5ec1-4b0d-8a3c-1d591d64ea90-gn2n2: consumers.internal.kafka.eventing.knative.dev \"331aa464-5ec1-4b0d-8a3c-1d591d64ea90-gn2n2\" is forbidden: User \"system:serviceaccount:knative-eventing:kafka-controller\" cannot delete resource \"consumers\" in API group \"internal.kafka.eventing.knative.dev\" in the namespace \"default\"","stacktrace":"knative.dev/pkg/controller.(*Impl).handleErr\n\tknative.dev/pkg@v0.0.0-20220201132031-8681fe2035b9/controller/controller.go:566\nknative.dev/pkg/controller.(*Impl).processNextWorkItem\n\tknative.dev/pkg@v0.0.0-20220201132031-8681fe2035b9/controller/controller.go:543\nknative.dev/pkg/controller.(*Impl).RunContext.func3\n\tknative.dev/pkg@v0.0.0-20220201132031-8681fe2035b9/controller/controller.go:478"}
```

- Adding `delete` verb 
