### PR TITLE
Consumer reconciler sets ConfigMap owner reference to dispatcher pod

### DIFF
--- a/control-plane/pkg/reconciler/base/reconciler.go
+++ b/control-plane/pkg/reconciler/base/reconciler.go
@@ -106,20 +106,22 @@ func isAtLeastOneRunning(pods []*corev1.Pod) bool {
 	return false
 }
 
-func (r *Reconciler) GetOrCreateDataPlaneConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
+type ConfigMapOption func(cm *corev1.ConfigMap)
+
+func (r *Reconciler) GetOrCreateDataPlaneConfigMap(ctx context.Context, options ...ConfigMapOption) (*corev1.ConfigMap, error) {
 
 	cm, err := r.KubeClient.CoreV1().
 		ConfigMaps(r.DataPlaneConfigMapNamespace).
 		Get(ctx, r.DataPlaneConfigMapName, metav1.GetOptions{})
 
 	if apierrors.IsNotFound(err) {
-		cm, err = r.createDataPlaneConfigMap(ctx)
+		cm, err = r.createDataPlaneConfigMap(ctx, options)
 	}
 
 	return cm, err
 }
 
-func (r *Reconciler) createDataPlaneConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
+func (r *Reconciler) createDataPlaneConfigMap(ctx context.Context, options []ConfigMapOption) (*corev1.ConfigMap, error) {
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
@@ -130,6 +132,11 @@ func (r *Reconciler) createDataPlaneConfigMap(ctx context.Context) (*corev1.Conf
 			ConfigMapDataKey: []byte(""),
 		},
 	}
+
+	for _, opt := range options {
+		opt(cm)
+	}
+
 	return r.KubeClient.CoreV1().ConfigMaps(r.DataPlaneConfigMapNamespace).Create(ctx, cm, metav1.CreateOptions{})
 }
 

--- a/control-plane/pkg/reconciler/consumer/consumer_test.go
+++ b/control-plane/pkg/reconciler/consumer/consumer_test.go
@@ -91,7 +91,9 @@ func TestReconcileKind(t *testing.T) {
 					DataPlaneConfigFormat:       base.Json,
 					DataPlaneConfigMapNamespace: SystemNamespace,
 					DataPlaneConfigMapName:      "p1",
-				}, []byte("")),
+				}, []byte(""),
+					DispatcherPodAsOwnerReference("p1"),
+				),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
 				ConfigMapUpdate(&config.Env{
@@ -129,7 +131,9 @@ func TestReconcileKind(t *testing.T) {
 							},
 						},
 					},
-				}),
+				},
+					DispatcherPodAsOwnerReference("p1"),
+				),
 				{Object: NewDispatcherPod("p1",
 					PodRunning(),
 					PodAnnotations(map[string]string{
@@ -204,7 +208,10 @@ func TestReconcileKind(t *testing.T) {
 					DataPlaneConfigFormat:       base.Json,
 					DataPlaneConfigMapNamespace: SystemNamespace,
 					DataPlaneConfigMapName:      "p1",
-				}, []byte("")),
+				},
+					[]byte(""),
+					DispatcherPodAsOwnerReference("p1"),
+				),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
 				ConfigMapUpdate(&config.Env{
@@ -248,7 +255,9 @@ func TestReconcileKind(t *testing.T) {
 							},
 						},
 					},
-				}),
+				},
+					DispatcherPodAsOwnerReference("p1"),
+				),
 				{Object: NewDispatcherPod("p1",
 					PodRunning(),
 					PodAnnotations(map[string]string{


### PR DESCRIPTION
When a consumer is removed and its binding dispatcher pod also
gone (autoscaled down), the config map is cleaned up.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Part of #1537 