### PR TITLE
Adding non-empty ApiVersion and Kind values for CM ownerref (Consumer)

### DIFF
--- a/control-plane/pkg/reconciler/consumer/consumer.go
+++ b/control-plane/pkg/reconciler/consumer/consumer.go
@@ -393,8 +393,8 @@ func cmNameFromPod(p *corev1.Pod, c *kafkainternals.Consumer) (string, error) {
 func podOwnerReference(p *corev1.Pod) base.ConfigMapOption {
 	return func(cm *corev1.ConfigMap) {
 		cm.OwnerReferences = append(cm.OwnerReferences, metav1.OwnerReference{
-			APIVersion:         p.APIVersion,
-			Kind:               p.Kind,
+			APIVersion:         corev1.SchemeGroupVersion.String(),
+			Kind:               "Pod",
 			Name:               p.Name,
 			UID:                p.UID,
 			Controller:         pointer.Bool(true),


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

Part of #1537 

Error seen:
```
{"level":"error","ts":"2022-02-22T21:54:58.608Z","logger":"kafka-broker-controller","caller":"consumer/reconciler.go:302","msg":"Returned an error","knative.dev/pod":"kafka-controller-55f849c8bb-qsb7w","knative.dev/controller":"knative.dev.eventing-kafka-broker.control-plane.pkg.reconciler.consumer.Reconciler","knative.dev/kind":"internal.kafka.eventing.knative.dev.Consumer","knative.dev/traceid":"fe362d16-4641-4650-89c4-bd8c7f102ba9","knative.dev/key":"default/c3824c49-ebe9-4d22-bcb5-022fc74f3bc4-ldwnf","targetMethod":"ReconcileKind","error":"failed to bind resource to pod: failed to get or create data plane ConfigMap knative-eventing/kafka-source-dispatcher-1: ConfigMap \"kafka-source-dispatcher-1\" is invalid: [metadata.ownerReferences.apiVersion: Invalid value: \"\": version must not be empty, metadata.ownerReferences.kind: Invalid value: \"\": kind must not be empty]","stacktrace":"knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/injection/reconciler/eventing/v1alpha1/consumer.(*reconcilerImpl).Reconcile\n\tknative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/injection/reconciler/eventing/v1alpha1/consumer/reconciler.go:302\nknative.dev/pkg/controller.(*Impl).processNextWorkItem\n\tknative.dev/pkg@v0.0.0-20220201132031-8681fe2035b9/controller/controller.go:542\nknative.dev/pkg/controller.(*Impl).RunContext.func3\n\tknative.dev/pkg@v0.0.0-20220201132031-8681fe2035b9/controller/controller.go:478"}
{"level":"error","ts":"2022-02-22T21:54:58.608Z","logger":"kafka-broker-controller","caller":"controller/controller.go:566","msg":"Reconcile error","knative.dev/pod":"kafka-controller-55f849c8bb-qsb7w","knative.dev/controller":"knative.dev.eventing-kafka-broker.control-plane.pkg.reconciler.consumer.Reconciler","knative.dev/kind":"internal.kafka.eventing.knative.dev.Consumer","knative.dev/traceid":"fe362d16-4641-4650-89c4-bd8c7f102ba9","knative.dev/key":"default/c3824c49-ebe9-4d22-bcb5-022fc74f3bc4-ldwnf","duration":0.0056495,"error":"failed to bind resource to pod: failed to get or create data plane ConfigMap knative-eventing/kafka-source-dispatcher-1: ConfigMap \"kafka-source-dispatcher-1\" is invalid: [metadata.ownerReferences.apiVersion: Invalid value: \"\": version must not be empty, metadata.ownerReferences.kind: Invalid value: \"\": kind must not be empty]","stacktrace":"knative.dev/pkg/controller.(*Impl).handleErr\n\tknative.dev/pkg@v0.0.0-20220201132031-8681fe2035b9/controller/controller.go:566\nknative.dev/pkg/controller.(*Impl).processNextWorkItem\n\tknative.dev/pkg@v0.0.0-20220201132031-8681fe2035b9/controller/controller.go:543\nknative.dev/pkg/controller.(*Impl).RunContext.func3\n\tknative.dev/pkg@v0.0.0-20220201132031-8681fe2035b9/controller/controller.go:478"}
```

