### PR TITLE
Set resource limit for Kafka data-plane

### DIFF
--- a/control-plane/pkg/reconciler/testing/objects_common.go
+++ b/control-plane/pkg/reconciler/testing/objects_common.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgotesting "k8s.io/client-go/testing"
@@ -337,6 +338,15 @@ func NewDispatcherPod(name string, options ...PodOption) *corev1.Pod {
 			UID:       DispatcherPodUUID,
 		},
 		Spec: corev1.PodSpec{
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("125m"),
+					corev1.ResourceMemory: resource.MustParse("128Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2200m"),
+					corev1.ResourceMemory: resource.MustParse("2048Mi"),
+				},
 			Volumes: []corev1.Volume{{
 				Name: kafkainternals.DispatcherVolumeName,
 				VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
Fixes #1942

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🧽 Add resource limits (CPU and memory) for Kafka dataplane

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
