### PR TITLE
Fix class cast exception

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/ResponseFailureException.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/ResponseFailureException.java
@@ -15,7 +15,7 @@
  */
 package dev.knative.eventing.kafka.broker.dispatcher.impl;
 
-import java.net.http.HttpResponse;
+import io.vertx.ext.web.client.HttpResponse;
 
 public class ResponseFailureException extends RuntimeException {
 
@@ -23,12 +23,6 @@ public class ResponseFailureException extends RuntimeException {
 
   public ResponseFailureException(final HttpResponse response, final String msg) {
     super(msg);
-    this.response = response;
-  }
-
-  public ResponseFailureException(final HttpResponse<?> response,
-                                  final Throwable ex) {
-    super(ex);
     this.response = response;
   }
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
@@ -81,7 +81,6 @@ public final class WebClientCloudEventSender implements CloudEventSender {
     });
   }
 
-  @SuppressWarnings("rawtypes")
   private void send(final CloudEvent event, final Promise<HttpResponse<Buffer>> breaker) {
     VertxMessageFactory
       .createWriter(client.postAbs(target).putHeader("Prefer", "reply"))
@@ -95,7 +94,7 @@ public final class WebClientCloudEventSender implements CloudEventSender {
         if (isRetryableStatusCode(response.statusCode())) {
           logError(event, response);
           breaker.tryFail(new ResponseFailureException(
-            (java.net.http.HttpResponse) response,
+            response,
             "Received failure response, status code: " + response.statusCode())
           );
           return;


### PR DESCRIPTION
Wrong import for class `HttpResponse` leads to:

```
Feb 24, 2022 12:30:30 PM io.vertx.core.impl.ContextImpl
SEVERE: Unhandled exception
java.lang.ClassCastException: class io.vertx.ext.web.client.impl.HttpResponseImpl cannot be cast to class java.net.http.HttpResponse (io.vertx.ext.web.client.impl.HttpResponseImpl is in unnamed module of loader 'app'; java.net.http.HttpResponse is in module java.net.http of loader 'platform')
	at dev.knative.eventing.kafka.broker.dispatcher.impl.http.WebClientCloudEventSender.lambda$send$2(WebClientCloudEventSender.java:97)
	at io.vertx.core.impl.future.FutureImpl$1.onSuccess(FutureImpl.java:91)
	at io.vertx.core.impl.future.FutureImpl$ListenerArray.onSuccess(FutureImpl.java:262)
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60)
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211)
	at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23)
	at io.vertx.core.impl.future.PromiseImpl.onSuccess(PromiseImpl.java:49)
	at io.vertx.core.impl.future.PromiseImpl.handle(PromiseImpl.java:41)
	at io.vertx.core.impl.future.PromiseImpl.handle(PromiseImpl.java:23)
	at io.vertx.ext.web.client.impl.HttpContext.handleDispatchResponse(HttpContext.java:400)
	at io.vertx.ext.web.client.impl.HttpContext.execute(HttpContext.java:387)
	at io.vertx.ext.web.client.impl.HttpContext.next(HttpContext.java:365)
	at io.vertx.ext.web.client.impl.HttpContext.fire(HttpContext.java:332)
	at io.vertx.ext.web.client.impl.HttpContext.dispatchResponse(HttpContext.java:294)
	at io.vertx.ext.web.client.impl.HttpContext.lambda$null$8(HttpContext.java:549)
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:100)
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:63)
	at io.vertx.core.impl.EventLoopContext.lambda$runOnContext$0(EventLoopContext.java:38)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
```

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

/kind bug