### PR TITLE
Move pod mutating webhook configuration to its own manifest

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-pod-defaulting.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-pod-defaulting.yaml
@@ -15,10 +15,11 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: defaulting.webhook.kafka.eventing.knative.dev
+  name: pods.defaulting.webhook.kafka.eventing.knative.dev
   labels:
     kafka.eventing.knative.dev/release: devel
 webhooks:
+  # Dispatcher pods webhook config.
   - admissionReviewVersions: [ "v1", "v1beta1" ]
     clientConfig:
       service:
@@ -26,5 +27,14 @@ webhooks:
         namespace: knative-eventing
     sideEffects: None
     failurePolicy: Fail
-    name: defaulting.webhook.kafka.eventing.knative.dev
+    name: pods.defaulting.webhook.kafka.eventing.knative.dev
     timeoutSeconds: 2
+    reinvocationPolicy: IfNeeded
+    matchPolicy: Equivalent
+    namespaceSelector:
+      matchExpressions: [ ]
+      matchLabels:
+        app.kubernetes.io/name: knative-eventing
+    objectSelector:
+      matchLabels:
+        app.kubernetes.io/component: kafka-dispatcher


### PR DESCRIPTION
`knative/pkg` webhook infra doesn't work with multiple webhooks
in the same mutating webhook configuration, so this patch move
the pod webhook configuration into its own separate manifest.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Part of #1537

## Proposed Changes

- Move pod mutating webhook configuration to its own manifest

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->
