### PR TITLE
Global resync consumers and consumergroups on statefulset changes

### DIFF
--- a/control-plane/pkg/reconciler/consumergroup/controller.go
+++ b/control-plane/pkg/reconciler/consumergroup/controller.go
@@ -102,9 +102,9 @@ func NewController(ctx context.Context) *controller.Impl {
 	impl := cgreconciler.NewImpl(ctx, r)
 	consumerInformer := consumer.Get(ctx)
 
-	consumerGroupInformer := consumer.Get(ctx)
+	consumerGroupInformer := consumergroup.Get(ctx)
 
-	consumergroup.Get(ctx).Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	consumerGroupInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 	consumerInformer.Informer().AddEventHandler(controller.HandleAll(enqueueConsumerGroupFromConsumer(impl.EnqueueKey)))
 
 	globalResync := func(interface{}) {


### PR DESCRIPTION
To keep resource statuses in sync with the actual current state, we
need to global resync consumer groups when the statefulsets changes.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Part of #1537