### PR TITLE
Increase timeout for data plane test

### DIFF
--- a/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/DataPlaneTest.java
+++ b/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/DataPlaneTest.java
@@ -147,7 +147,7 @@ public class DataPlaneTest {
 
    */
   @Test
-  @Timeout(timeUnit = TimeUnit.MINUTES, value = 1)
+  @Timeout(timeUnit = TimeUnit.MINUTES, value = 5)
   public void execute(final Vertx vertx, final VertxTestContext context) throws InterruptedException {
 
     final var checkpoints = context.checkpoint(4);


### PR DESCRIPTION
As per title. This test is flaky probably because slow fsyncs