### PR TITLE
Failed to build storage version migrator

### DIFF
--- a/hack/control-plane.sh
+++ b/hack/control-plane.sh
@@ -21,8 +21,6 @@ readonly CONTROL_PLANE_POST_INSTALL_CONFIG_DIR=control-plane/config/post-install
 
 # Note: do not change this function name, it's used during releases.
 function control_plane_setup() {
-  ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" &&
-    ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_POST_INSTALL_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}"
-
-  return $?
+  ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" || return $?
+  ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_POST_INSTALL_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" || return $?
 }

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -24,6 +24,9 @@ import (
 	_ "knative.dev/pkg/configmap/hash-gen"
 	_ "knative.dev/pkg/hack"
 
+	// Needed for the storage version migration.
+	_ "knative.dev/pkg/apiextensions/storageversion/cmd/migrate"
+
 	// Test images from eventing
 	_ "knative.dev/eventing/test/test_images/event-flaker"
 	_ "knative.dev/eventing/test/test_images/event-library"

--- a/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate/main.go
+++ b/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate/main.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"go.uber.org/zap"
+	apixclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"knative.dev/pkg/apiextensions/storageversion"
+	"knative.dev/pkg/environment"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/signals"
+)
+
+func main() {
+	logger := setupLogger()
+	defer logger.Sync()
+
+	env := environment.ClientConfig{}
+	env.InitFlags(flag.CommandLine)
+
+	flag.Parse()
+
+	config, err := env.GetRESTConfig()
+	if err != nil {
+		logger.Fatalf("failed to get kubeconfig %s", err)
+	}
+
+	grs, err := parseResources(flag.Args())
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	migrator := storageversion.NewMigrator(
+		dynamic.NewForConfigOrDie(config),
+		apixclient.NewForConfigOrDie(config),
+	)
+
+	ctx := signals.NewContext()
+
+	logger.Infof("Migrating %d group resources", len(grs))
+
+	for _, gr := range grs {
+		logger.Info("Migrating group resource ", gr)
+		if err := migrator.Migrate(ctx, gr); err != nil {
+			logger.Fatal("Failed to migrate: ", err)
+		}
+	}
+
+	logger.Info("Migration complete")
+}
+
+func parseResources(args []string) ([]schema.GroupResource, error) {
+	grs := make([]schema.GroupResource, 0, len(args))
+	for _, arg := range args {
+		gr := schema.ParseGroupResource(arg)
+		if gr.Empty() {
+			return nil, fmt.Errorf("unable to parse group version: %s", arg)
+		}
+		grs = append(grs, gr)
+	}
+	return grs, nil
+}
+
+func setupLogger() *zap.SugaredLogger {
+	const component = "storage-migrator"
+
+	config, err := logging.NewConfigFromMap(nil)
+	if err != nil {
+		log.Fatal("Failed to create logging config: ", err)
+	}
+
+	logger, _ := logging.NewLoggerFromConfig(config, component)
+	return logger
+}

--- a/vendor/knative.dev/pkg/apiextensions/storageversion/migrator.go
+++ b/vendor/knative.dev/pkg/apiextensions/storageversion/migrator.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageversion
+
+import (
+	"context"
+	"fmt"
+
+	apix "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apixclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/pager"
+)
+
+// Migrator will read custom resource definitions and upgrade
+// the associated resources to the latest storage version
+type Migrator struct {
+	dynamicClient dynamic.Interface
+	apixClient    apixclient.Interface
+}
+
+// NewMigrator will return a new Migrator
+func NewMigrator(d dynamic.Interface, a apixclient.Interface) *Migrator {
+	return &Migrator{
+		dynamicClient: d,
+		apixClient:    a,
+	}
+}
+
+// Migrate takes a group resource (ie. resource.some.group.dev) and
+// updates instances of the resource to the latest storage version
+//
+// This is done by listing all the resources and performing an empty patch
+// which triggers a migration on the K8s API server
+//
+// Finally the migrator will update the CRD's status and drop older storage
+// versions
+func (m *Migrator) Migrate(ctx context.Context, gr schema.GroupResource) error {
+	crdClient := m.apixClient.ApiextensionsV1().CustomResourceDefinitions()
+
+	crd, err := crdClient.Get(ctx, gr.String(), metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to fetch crd %s - %w", gr, err)
+	}
+
+	version := storageVersion(crd)
+
+	if version == "" {
+		return fmt.Errorf("unable to determine storage version for %s", gr)
+	}
+
+	if err := m.migrateResources(ctx, gr.WithVersion(version)); err != nil {
+		return err
+	}
+
+	patch := `{"status":{"storedVersions":["` + version + `"]}}`
+	_, err = crdClient.Patch(ctx, crd.Name, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "status")
+	if err != nil {
+		return fmt.Errorf("unable to drop storage version definition %s - %w", gr, err)
+	}
+
+	return nil
+}
+
+func (m *Migrator) migrateResources(ctx context.Context, gvr schema.GroupVersionResource) error {
+	client := m.dynamicClient.Resource(gvr)
+
+	listFunc := func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.Namespace(metav1.NamespaceAll).List(ctx, opts)
+	}
+
+	onEach := func(obj runtime.Object) error {
+		item := obj.(metav1.Object)
+
+		_, err := client.Namespace(item.GetNamespace()).
+			Patch(ctx, item.GetName(), types.MergePatchType, []byte("{}"), metav1.PatchOptions{})
+
+		if err != nil && !apierrs.IsNotFound(err) {
+			return fmt.Errorf("unable to patch resource %s/%s (gvr: %s) - %w",
+				item.GetNamespace(), item.GetName(),
+				gvr, err)
+		}
+
+		return nil
+	}
+
+	pager := pager.New(listFunc)
+	return pager.EachListItem(ctx, metav1.ListOptions{}, onEach)
+}
+
+func storageVersion(crd *apix.CustomResourceDefinition) string {
+	var version string
+
+	for _, v := range crd.Spec.Versions {
+		if v.Storage {
+			version = v.Name
+			break
+		}
+	}
+
+	return version
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1339,6 +1339,8 @@ knative.dev/hack
 knative.dev/hack/shell
 # knative.dev/pkg v0.0.0-20220301181942-2fdd5f232e77
 ## explicit
+knative.dev/pkg/apiextensions/storageversion
+knative.dev/pkg/apiextensions/storageversion/cmd/migrate
 knative.dev/pkg/apis
 knative.dev/pkg/apis/duck
 knative.dev/pkg/apis/duck/ducktypes


### PR DESCRIPTION
As per title.

storage version migrator wasn't included in the tools.go file:
```
_ "knative.dev/pkg/apiextensions/storageversion/cmd/migrate"
```

