### PR TITLE
Verify post-install jobs succeess during post-upgrade tests

### DIFF
--- a/test/upgrade/postupgrade.go
+++ b/test/upgrade/postupgrade.go
@@ -17,6 +17,17 @@
 package upgrade
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/pkg/system"
 	pkgupgrade "knative.dev/pkg/test/upgrade"
 
 	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
@@ -26,13 +37,64 @@ import (
 // BrokerPostUpgradeTest tests channel operations after upgrade.
 func BrokerPostUpgradeTest() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("BrokerPostUpgradeTest", func(c pkgupgrade.Context) {
-		runBrokerSmokeTest(c.T)
+		c.T.Parallel()
+		c.T.Run("Verify post-install", func(t *testing.T) {
+			verifyPostInstall(t)
+		})
+		c.T.Run("tests", func(t *testing.T) {
+			runBrokerSmokeTest(t)
+		})
 	})
 }
 
 // SinkPostUpgradeTest tests sink basic operations post upgrade.
 func SinkPostUpgradeTest() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("SinkPostUpgradeTest", func(c pkgupgrade.Context) {
-		e2e.RunTestKafkaSink(c.T, eventing.ModeBinary, nil)
+		c.T.Parallel()
+		c.T.Run("Verify post-install", func(t *testing.T) {
+			verifyPostInstall(t)
+		})
+		c.T.Run("tests", func(t *testing.T) {
+			e2e.RunTestKafkaSink(t, eventing.ModeBinary, nil)
+		})
 	})
+}
+
+func verifyPostInstall(t *testing.T) {
+	t.Parallel()
+
+	const (
+		postInstallJob            = "kafka-controller-post-install"
+		storageVersionMigratorJob = "knative-kafka-storage-version-migrator"
+	)
+	for _, name := range []string{postInstallJob, storageVersionMigratorJob} {
+		t.Run(name, func(t *testing.T) {
+			client := testlib.Setup(t, true)
+			defer testlib.TearDown(client)
+
+			var lastJob *batchv1.Job
+			err := wait.Poll(5*time.Second, 10*time.Minute, func() (done bool, err error) {
+				lastJob, err = client.Kube.
+					BatchV1().
+					Jobs(system.Namespace()).
+					Get(context.Background(), name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+
+				if lastJob.Status.Failed == *lastJob.Spec.BackoffLimit {
+					return false, fmt.Errorf("job %s failed", name)
+				}
+
+				return lastJob.Status.Succeeded > 0, nil
+			})
+			if err != nil {
+				j := []byte("unknown")
+				if lastJob != nil {
+					j, _ = json.Marshal(lastJob)
+				}
+				t.Fatal(err, "\njob:\n", string(j))
+			}
+		})
+	}
 }


### PR DESCRIPTION
This helps catch bugs like https://github.com/knative-sandbox/eventing-kafka-broker/pull/1965.

- Verify `kafka-controller-post-install` job
- Verify `knative-kafka-storage-version-migrator` job

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>