### PR TITLE
Remove ConfigMap finalizer during reconcile

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -222,6 +222,11 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 	}
 	statusConditionManager.Addressable(address)
 
+	// TODO(pierDipi) remove after some releases (released in 1.4)
+	if err := r.removeFinalizerCM(ctx, finalizerCM(broker), brokerConfig); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
We removed the "add finalizer to the ConfigMap logic" in
https://github.com/knative-sandbox/eventing-kafka-broker/pull/1971
and we kept the "remove the ConfigMap finalizer" in `FinalizeKind`.

However, in order to remove the ConfigMap finalizer from every
existing Broker that won't be deleted in the time span going from
1.3 to whatever release we remove the logic to remove the finalizer,
we should remove the finalizer in `ReconcileKind` too.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>