### PR TITLE
Add consumer group to logging output

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
@@ -225,7 +225,7 @@ public class RecordDispatcherImpl implements RecordDispatcher {
   }
 
   private void onFilterMatching(final ConsumerRecordContext recordContext, final Promise<Void> finalProm) {
-    logDebug("Record matched filtering", recordContext.getRecord());
+    logTrace("Record matched filtering", recordContext.getRecord());
     subscriberSender.apply(recordContext.getRecord())
       .onSuccess(response -> onSubscriberSuccess(response, recordContext, finalProm))
       .onFailure(ex -> onSubscriberFailure(ex, recordContext, finalProm));
@@ -233,7 +233,7 @@ public class RecordDispatcherImpl implements RecordDispatcher {
 
   private void onFilterNotMatching(final ConsumerRecordContext recordContext,
                                    final Promise<Void> finalProm) {
-    logDebug("Record did not match filtering", recordContext.getRecord());
+    logTrace("Record did not match filtering", recordContext.getRecord());
     recordDispatcherListener.recordDiscarded(recordContext.getRecord());
     finalProm.complete();
   }
@@ -241,7 +241,7 @@ public class RecordDispatcherImpl implements RecordDispatcher {
   private void onSubscriberSuccess(final HttpResponse<?> response,
                                    final ConsumerRecordContext recordContext,
                                    final Promise<Void> finalProm) {
-    logDebug("Successfully sent event to subscriber", recordContext.getRecord());
+    logTrace("Successfully sent event to subscriber", recordContext.getRecord());
 
     incrementEventCount(response, recordContext);
     recordDispatchLatency(response, recordContext);
@@ -265,7 +265,7 @@ public class RecordDispatcherImpl implements RecordDispatcher {
 
   private void onDeadLetterSinkSuccess(final ConsumerRecordContext recordContext,
                                        final Promise<Void> finalProm) {
-    logDebug("Successfully sent event to the dead letter sink", recordContext.getRecord());
+    logTrace("Successfully sent event to the dead letter sink", recordContext.getRecord());
     recordDispatcherListener.successfullySentToDeadLetterSink(recordContext.getRecord());
     finalProm.complete();
   }
@@ -290,7 +290,7 @@ public class RecordDispatcherImpl implements RecordDispatcher {
     //
     // That means that we get a record with a null value and some CE
     // headers even though the record is a valid CloudEvent.
-    logDebug("Value is null", recordContext.getRecord());
+    logTrace("Value is null", recordContext.getRecord());
     final var value = cloudEventDeserializer.deserialize(recordContext.getRecord().record().topic(), recordContext.getRecord().record().headers(), null);
     recordContext.setRecord(new KafkaConsumerRecordImpl<>(KafkaConsumerRecordUtils.copyRecordAssigningValue(recordContext.getRecord().record(), value)));
     return recordContext;
@@ -378,7 +378,7 @@ public class RecordDispatcherImpl implements RecordDispatcher {
     final KafkaConsumerRecord<Object, CloudEvent> record,
     final Throwable cause) {
 
-    if (logger.isDebugEnabled()) {
+    if (logger.isTraceEnabled()) {
       logger.error(msg + " {} {} {} {} {} {}",
         keyValue("topic", record.topic()),
         keyValue("partition", record.partition()),
@@ -399,11 +399,11 @@ public class RecordDispatcherImpl implements RecordDispatcher {
     }
   }
 
-  private void logDebug(
+  private void logTrace(
     final String msg,
     final KafkaConsumerRecord<Object, CloudEvent> record) {
 
-    logger.debug(msg + " {} {} {} {} {} {} {}",
+    logger.trace(msg + " {} {} {} {} {} {} {}",
       keyValue("topic", record.topic()),
       keyValue("partition", record.partition()),
       keyValue("headers", record.headers()),

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
@@ -373,41 +373,44 @@ public class RecordDispatcherImpl implements RecordDispatcher {
     );
   }
 
-  private static void logError(
+  private void logError(
     final String msg,
     final KafkaConsumerRecord<Object, CloudEvent> record,
     final Throwable cause) {
 
     if (logger.isDebugEnabled()) {
-      logger.error(msg + " {} {} {} {} {}",
+      logger.error(msg + " {} {} {} {} {} {}",
         keyValue("topic", record.topic()),
         keyValue("partition", record.partition()),
         keyValue("headers", record.headers()),
         keyValue("offset", record.offset()),
         keyValue("event", record.value()),
+        keyValue("group", resourceContext.getEgress().getConsumerGroup()),
         cause
       );
     } else {
-      logger.error(msg + " {} {} {}",
+      logger.error(msg + " {} {} {} {}",
         keyValue("topic", record.topic()),
         keyValue("partition", record.partition()),
         keyValue("offset", record.offset()),
+        keyValue("group", resourceContext.getEgress().getConsumerGroup()),
         cause
       );
     }
   }
 
-  private static void logDebug(
+  private void logDebug(
     final String msg,
     final KafkaConsumerRecord<Object, CloudEvent> record) {
 
-    logger.debug(msg + " {} {} {} {} {} {}",
+    logger.debug(msg + " {} {} {} {} {} {} {}",
       keyValue("topic", record.topic()),
       keyValue("partition", record.partition()),
       keyValue("headers", record.headers()),
       keyValue("offset", record.offset()),
       keyValue("key", record.key()),
-      keyValue("event", record.value())
+      keyValue("event", record.value()),
+      keyValue("group", resourceContext.getEgress().getConsumerGroup())
     );
   }
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
@@ -422,7 +422,7 @@ public class RecordDispatcherImpl implements RecordDispatcher {
   }
 
   private void recordHandlingCompleted(final ConsumerRecordContext recordContext) {
-    logDebug("Record handling completed", recordContext.getRecord());
+    logTrace("Record handling completed", recordContext.getRecord());
     inFlightEvents.decrementAndGet();
     if (closed.get() && inFlightEvents.get() == 0) {
       closePromise.tryComplete();
@@ -430,7 +430,7 @@ public class RecordDispatcherImpl implements RecordDispatcher {
   }
 
   private void recordReceived(final ConsumerRecordContext recordContext) {
-    logDebug("Handling record", recordContext.getRecord());
+    logTrace("Handling record", recordContext.getRecord());
     inFlightEvents.incrementAndGet();
   }
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
@@ -278,7 +278,7 @@ public class RecordDispatcherImpl implements RecordDispatcher {
     finalProm.complete();
   }
 
-  private static ConsumerRecordContext maybeDeserializeValueFromHeaders(ConsumerRecordContext recordContext) {
+  private ConsumerRecordContext maybeDeserializeValueFromHeaders(ConsumerRecordContext recordContext) {
     if (recordContext.getRecord().value() != null) {
       return recordContext;
     }
@@ -296,7 +296,7 @@ public class RecordDispatcherImpl implements RecordDispatcher {
     return recordContext;
   }
 
-  private static Function<KafkaConsumerRecord<Object, CloudEvent>, Future<HttpResponse<?>>> composeSenderAndSinkHandler(
+  private Function<KafkaConsumerRecord<Object, CloudEvent>, Future<HttpResponse<?>>> composeSenderAndSinkHandler(
     CloudEventSender sender, ResponseHandler sinkHandler, String senderType) {
     return rec -> sender.send(rec.value())
       .onFailure(ex -> logError("Failed to send event to " + senderType, rec, ex))


### PR DESCRIPTION
While troubleshooting problematic consumers (for example, that return malformed event data or are lagging behind), it would be helpful to know which particular consumer a record fails on. With the current log structure, we only receive the partition/offset of a record, but the same record can be dispatched to many different consumers.

## Proposed Changes

- :broom: Add consumer group as a key to logs in the RecordDispatcher

**Release Note**

```release-note
Log output from the record dispatcher now contains the consumer group as a key for better tracing of a record.
```
