### PR TITLE
Config retries for KafkaSource scheduler based

### DIFF
--- a/control-plane/pkg/reconciler/consumer/consumer.go
+++ b/control-plane/pkg/reconciler/consumer/consumer.go
@@ -57,11 +57,11 @@ type Reconciler struct {
 }
 
 var (
-	_ consumer.Interface = Reconciler{}
-	_ consumer.Finalizer = Reconciler{}
+	_ consumer.Interface = &Reconciler{}
+	_ consumer.Finalizer = &Reconciler{}
 )
 
-func (r Reconciler) ReconcileKind(ctx context.Context, c *kafkainternals.Consumer) reconciler.Event {
+func (r *Reconciler) ReconcileKind(ctx context.Context, c *kafkainternals.Consumer) reconciler.Event {
 	logger := logging.FromContext(ctx).Desugar()
 
 	resourceCt, err := r.reconcileContractResource(ctx, c)
@@ -88,7 +88,7 @@ func (r Reconciler) ReconcileKind(ctx context.Context, c *kafkainternals.Consume
 	return nil
 }
 
-func (r Reconciler) FinalizeKind(ctx context.Context, c *kafkainternals.Consumer) reconciler.Event {
+func (r *Reconciler) FinalizeKind(ctx context.Context, c *kafkainternals.Consumer) reconciler.Event {
 
 	logger := logging.FromContext(ctx).Desugar()
 

--- a/control-plane/pkg/reconciler/source/v2/sourcev2.go
+++ b/control-plane/pkg/reconciler/source/v2/sourcev2.go
@@ -126,8 +126,8 @@ func (r Reconciler) reconcileConsumerGroup(ctx context.Context, ks *sources.Kafk
 						DeliverySpec: &eventingduck.DeliverySpec{
 							Retry:         pointer.Int32(10),
 							BackoffPolicy: &backoffPolicy,
-							BackoffDelay:  pointer.String("PT10S"), // 10 seconds
-							Timeout:       pointer.String("PT500S"),
+							BackoffDelay:  pointer.String("PT10S"),
+							Timeout:       pointer.String("PT600S"),
 						},
 						Ordering: DefaultDeliveryOrder,
 					},

--- a/control-plane/pkg/reconciler/source/v2/sourcev2.go
+++ b/control-plane/pkg/reconciler/source/v2/sourcev2.go
@@ -24,7 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	sources "knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
@@ -91,6 +93,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *sources.KafkaSource)
 
 func (r Reconciler) reconcileConsumerGroup(ctx context.Context, ks *sources.KafkaSource) (*internalscg.ConsumerGroup, error) {
 
+	backoffPolicy := eventingduck.BackoffPolicyExponential
+
 	expectedCg := &internalscg.ConsumerGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      string(ks.UID),
@@ -119,6 +123,12 @@ func (r Reconciler) reconcileConsumerGroup(ctx context.Context, ks *sources.Kafk
 						NetSpec: &ks.Spec.KafkaAuthSpec.Net,
 					},
 					Delivery: &internalscg.DeliverySpec{
+						DeliverySpec: &eventingduck.DeliverySpec{
+							Retry:         pointer.Int32(10),
+							BackoffPolicy: &backoffPolicy,
+							BackoffDelay:  pointer.String("PT10S"), // 10 seconds
+							Timeout:       pointer.String("PT500S"),
+						},
 						Ordering: DefaultDeliveryOrder,
 					},
 					Subscriber: ks.Spec.Sink,

--- a/control-plane/pkg/reconciler/source/v2/sourcev2_test.go
+++ b/control-plane/pkg/reconciler/source/v2/sourcev2_test.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 
 	internals "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/internals/kafka/eventing"
@@ -69,7 +70,15 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerBootstrapServersConfig(SourceBootstrapServers),
 						),
 						ConsumerAuth(NewConsumerSpecAuth()),
-						ConsumerDelivery(NewConsumerSpecDelivery(internals.Ordered)),
+						ConsumerDelivery(
+							NewConsumerSpecDelivery(
+								internals.Ordered,
+								NewConsumerTimeout("PT500S"),
+								NewConsumerRetry(10),
+								NewConsumerBackoffDelay("PT10S"),
+								NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
+							),
+						),
 						ConsumerSubscriber(NewSourceSinkReference()),
 						ConsumerReply(ConsumerNoReply()),
 					)),
@@ -108,7 +117,15 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerBootstrapServersConfig(SourceBootstrapServers),
 						),
 						ConsumerAuth(NewConsumerSpecAuth()),
-						ConsumerDelivery(NewConsumerSpecDelivery(internals.Ordered)),
+						ConsumerDelivery(
+							NewConsumerSpecDelivery(
+								internals.Ordered,
+								NewConsumerTimeout("PT500S"),
+								NewConsumerRetry(10),
+								NewConsumerBackoffDelay("PT10S"),
+								NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
+							),
+						),
 						ConsumerSubscriber(NewSourceSinkReference()),
 						ConsumerReply(ConsumerNoReply()),
 						ConsumerCloudEventOverrides(&duckv1.CloudEventOverrides{
@@ -147,7 +164,15 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerBootstrapServersConfig(SourceBootstrapServers),
 						),
 						ConsumerAuth(NewConsumerSpecAuth()),
-						ConsumerDelivery(NewConsumerSpecDelivery(internals.Ordered)),
+						ConsumerDelivery(
+							NewConsumerSpecDelivery(
+								internals.Ordered,
+								NewConsumerTimeout("PT500S"),
+								NewConsumerRetry(10),
+								NewConsumerBackoffDelay("PT10S"),
+								NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
+							),
+						),
 						ConsumerSubscriber(NewSourceSinkReference()),
 						ConsumerReply(ConsumerNoReply()),
 					)),
@@ -171,7 +196,15 @@ func TestReconcileKind(t *testing.T) {
 								ConsumerBootstrapServersConfig(SourceBootstrapServers),
 							),
 							ConsumerAuth(NewConsumerSpecAuth()),
-							ConsumerDelivery(NewConsumerSpecDelivery(internals.Ordered)),
+							ConsumerDelivery(
+								NewConsumerSpecDelivery(
+									internals.Ordered,
+									NewConsumerTimeout("PT500S"),
+									NewConsumerRetry(10),
+									NewConsumerBackoffDelay("PT10S"),
+									NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
+								),
+							),
 							ConsumerSubscriber(NewSourceSink2Reference()),
 							ConsumerReply(ConsumerNoReply()),
 						)),
@@ -220,7 +253,15 @@ func TestReconcileKind(t *testing.T) {
 								ConsumerBootstrapServersConfig(SourceBootstrapServers),
 							),
 							ConsumerAuth(NewConsumerSpecAuth()),
-							ConsumerDelivery(NewConsumerSpecDelivery(internals.Ordered)),
+							ConsumerDelivery(
+								NewConsumerSpecDelivery(
+									internals.Ordered,
+									NewConsumerTimeout("PT500S"),
+									NewConsumerRetry(10),
+									NewConsumerBackoffDelay("PT10S"),
+									NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
+								),
+							),
 							ConsumerSubscriber(NewSourceSinkReference()),
 							ConsumerReply(ConsumerNoReply()),
 						)),
@@ -268,7 +309,15 @@ func TestReconcileKind(t *testing.T) {
 								ConsumerBootstrapServersConfig(SourceBootstrapServers),
 							),
 							ConsumerAuth(NewConsumerSpecAuth()),
-							ConsumerDelivery(NewConsumerSpecDelivery(internals.Ordered)),
+							ConsumerDelivery(
+								NewConsumerSpecDelivery(
+									internals.Ordered,
+									NewConsumerTimeout("PT500S"),
+									NewConsumerRetry(10),
+									NewConsumerBackoffDelay("PT10S"),
+									NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
+								),
+							),
 							ConsumerSubscriber(NewSourceSinkReference()),
 							ConsumerReply(ConsumerNoReply()),
 						)),
@@ -302,7 +351,15 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerBootstrapServersConfig(SourceBootstrapServers),
 						),
 						ConsumerAuth(NewConsumerSpecAuth()),
-						ConsumerDelivery(NewConsumerSpecDelivery(internals.Ordered)),
+						ConsumerDelivery(
+							NewConsumerSpecDelivery(
+								internals.Ordered,
+								NewConsumerTimeout("PT500S"),
+								NewConsumerRetry(10),
+								NewConsumerBackoffDelay("PT10S"),
+								NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
+							),
+						),
 						ConsumerSubscriber(NewSourceSinkReference()),
 						ConsumerReply(ConsumerNoReply()),
 					)),
@@ -337,7 +394,15 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerBootstrapServersConfig(SourceBootstrapServers),
 						),
 						ConsumerAuth(NewConsumerSpecAuth()),
-						ConsumerDelivery(NewConsumerSpecDelivery(internals.Ordered)),
+						ConsumerDelivery(
+							NewConsumerSpecDelivery(
+								internals.Ordered,
+								NewConsumerTimeout("PT500S"),
+								NewConsumerRetry(10),
+								NewConsumerBackoffDelay("PT10S"),
+								NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
+							),
+						),
 						ConsumerSubscriber(NewSourceSinkReference()),
 						ConsumerReply(ConsumerNoReply()),
 					)),
@@ -372,7 +437,15 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerBootstrapServersConfig(SourceBootstrapServers),
 						),
 						ConsumerAuth(NewConsumerSpecAuth()),
-						ConsumerDelivery(NewConsumerSpecDelivery(internals.Ordered)),
+						ConsumerDelivery(
+							NewConsumerSpecDelivery(
+								internals.Ordered,
+								NewConsumerTimeout("PT500S"),
+								NewConsumerRetry(10),
+								NewConsumerBackoffDelay("PT10S"),
+								NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
+							),
+						),
 						ConsumerSubscriber(NewSourceSinkReference()),
 						ConsumerReply(ConsumerNoReply()),
 					)),
@@ -408,7 +481,15 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerBootstrapServersConfig(SourceBootstrapServers),
 						),
 						ConsumerAuth(NewConsumerSpecAuth()),
-						ConsumerDelivery(NewConsumerSpecDelivery(internals.Ordered)),
+						ConsumerDelivery(
+							NewConsumerSpecDelivery(
+								internals.Ordered,
+								NewConsumerTimeout("PT500S"),
+								NewConsumerRetry(10),
+								NewConsumerBackoffDelay("PT10S"),
+								NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
+							),
+						),
 						ConsumerSubscriber(NewSourceSinkReference()),
 						ConsumerReply(ConsumerNoReply()),
 					)),

--- a/control-plane/pkg/reconciler/source/v2/sourcev2_test.go
+++ b/control-plane/pkg/reconciler/source/v2/sourcev2_test.go
@@ -73,7 +73,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerDelivery(
 							NewConsumerSpecDelivery(
 								internals.Ordered,
-								NewConsumerTimeout("PT500S"),
+								NewConsumerTimeout("PT600S"),
 								NewConsumerRetry(10),
 								NewConsumerBackoffDelay("PT10S"),
 								NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
@@ -120,7 +120,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerDelivery(
 							NewConsumerSpecDelivery(
 								internals.Ordered,
-								NewConsumerTimeout("PT500S"),
+								NewConsumerTimeout("PT600S"),
 								NewConsumerRetry(10),
 								NewConsumerBackoffDelay("PT10S"),
 								NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
@@ -167,7 +167,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerDelivery(
 							NewConsumerSpecDelivery(
 								internals.Ordered,
-								NewConsumerTimeout("PT500S"),
+								NewConsumerTimeout("PT600S"),
 								NewConsumerRetry(10),
 								NewConsumerBackoffDelay("PT10S"),
 								NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
@@ -199,7 +199,7 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerDelivery(
 								NewConsumerSpecDelivery(
 									internals.Ordered,
-									NewConsumerTimeout("PT500S"),
+									NewConsumerTimeout("PT600S"),
 									NewConsumerRetry(10),
 									NewConsumerBackoffDelay("PT10S"),
 									NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
@@ -256,7 +256,7 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerDelivery(
 								NewConsumerSpecDelivery(
 									internals.Ordered,
-									NewConsumerTimeout("PT500S"),
+									NewConsumerTimeout("PT600S"),
 									NewConsumerRetry(10),
 									NewConsumerBackoffDelay("PT10S"),
 									NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
@@ -312,7 +312,7 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerDelivery(
 								NewConsumerSpecDelivery(
 									internals.Ordered,
-									NewConsumerTimeout("PT500S"),
+									NewConsumerTimeout("PT600S"),
 									NewConsumerRetry(10),
 									NewConsumerBackoffDelay("PT10S"),
 									NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
@@ -354,7 +354,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerDelivery(
 							NewConsumerSpecDelivery(
 								internals.Ordered,
-								NewConsumerTimeout("PT500S"),
+								NewConsumerTimeout("PT600S"),
 								NewConsumerRetry(10),
 								NewConsumerBackoffDelay("PT10S"),
 								NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
@@ -397,7 +397,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerDelivery(
 							NewConsumerSpecDelivery(
 								internals.Ordered,
-								NewConsumerTimeout("PT500S"),
+								NewConsumerTimeout("PT600S"),
 								NewConsumerRetry(10),
 								NewConsumerBackoffDelay("PT10S"),
 								NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
@@ -440,7 +440,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerDelivery(
 							NewConsumerSpecDelivery(
 								internals.Ordered,
-								NewConsumerTimeout("PT500S"),
+								NewConsumerTimeout("PT600S"),
 								NewConsumerRetry(10),
 								NewConsumerBackoffDelay("PT10S"),
 								NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
@@ -484,7 +484,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerDelivery(
 							NewConsumerSpecDelivery(
 								internals.Ordered,
-								NewConsumerTimeout("PT500S"),
+								NewConsumerTimeout("PT600S"),
 								NewConsumerRetry(10),
 								NewConsumerBackoffDelay("PT10S"),
 								NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),


### PR DESCRIPTION
As per title.

These values are the same we use in the existing
KafkaSource in this repository