### PR TITLE
Add permission to set ConfigMap owner references to controller

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
@@ -43,6 +43,12 @@ rules:
   - apiGroups:
       - "*"
     resources:
+      - configmaps/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - "*"
+    resources:
       - events
     verbs:
       - patch


### PR DESCRIPTION
This is needed to be able to set the owner reference of the
ConfigMaps to their associated pods.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>