### PR TITLE
Make it possible to specify auth secret namespace in configmap

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -102,7 +102,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 
 	logger.Debug("config resolved", zap.Any("config", topicConfig))
 
-	secret, err := security.Secret(ctx, &security.MTConfigMapSecretLocator{ConfigMap: brokerConfig}, r.SecretProviderFunc())
+	secret, err := security.Secret(ctx, &security.MTConfigMapSecretLocator{ConfigMap: brokerConfig, UseNamespaceInConfigmap: false}, r.SecretProviderFunc())
 	if err != nil {
 		return fmt.Errorf("failed to get secret: %w", err)
 	}
@@ -323,7 +323,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 		return fmt.Errorf("failed to resolve broker config: %w", err)
 	}
 
-	secret, err := security.Secret(ctx, &security.MTConfigMapSecretLocator{ConfigMap: brokerConfig}, r.SecretProviderFunc())
+	secret, err := security.Secret(ctx, &security.MTConfigMapSecretLocator{ConfigMap: brokerConfig, UseNamespaceInConfigmap: false}, r.SecretProviderFunc())
 	if err != nil {
 		return fmt.Errorf("failed to get secret: %w", err)
 	}

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -275,7 +275,9 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 		},
 	}
 
+	logger.Debug("Going to probe address to check ingress readiness for the channel.", zap.Any("proberAddressable", proberAddressable))
 	if status := r.Prober.Probe(ctx, proberAddressable, prober.StatusReady); status != prober.StatusReady {
+		logger.Debug("Ingress is not ready for the channel. Going to requeue.", zap.Any("proberAddressable", proberAddressable))
 		statusConditionManager.ProbesStatusNotReady(status)
 		return nil // Object will get re-queued once probe status changes.
 	}

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -127,7 +127,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 	statusConditionManager.ConfigResolved()
 
 	// get the secret to access Kafka
-	secret, err := security.Secret(ctx, &security.MTConfigMapSecretLocator{ConfigMap: channelConfigMap}, r.SecretProviderFunc())
+	secret, err := security.Secret(ctx, &security.MTConfigMapSecretLocator{ConfigMap: channelConfigMap, UseNamespaceInConfigmap: true}, r.SecretProviderFunc())
 	if err != nil {
 		return fmt.Errorf("failed to get secret: %w", err)
 	}
@@ -374,7 +374,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 	logger.Debug("topic config resolved", zap.Any("config", topicConfig))
 
 	// get the secret to access Kafka
-	secret, err := security.Secret(ctx, &security.MTConfigMapSecretLocator{ConfigMap: channelConfigMap}, r.SecretProviderFunc())
+	secret, err := security.Secret(ctx, &security.MTConfigMapSecretLocator{ConfigMap: channelConfigMap, UseNamespaceInConfigmap: true}, r.SecretProviderFunc())
 	if err != nil {
 		return fmt.Errorf("failed to get secret: %w", err)
 	}

--- a/control-plane/pkg/reconciler/channel/channel_test.go
+++ b/control-plane/pkg/reconciler/channel/channel_test.go
@@ -1005,9 +1005,10 @@ func TestReconcileKind(t *testing.T) {
 				NewConfigMapWithTextData(system.Namespace(), DefaultEnv.GeneralConfigMapName, map[string]string{
 					kafka.BootstrapServersConfigMapKey: ChannelBootstrapServers,
 					security.AuthSecretNameKey:         "secret-1",
+					security.AuthSecretNamespaceKey:    "ns-1",
 				}),
 				NewConfigMapWithBinaryData(&env, nil),
-				NewSSLSecret(system.Namespace(), "secret-1"),
+				NewSSLSecret("ns-1", "secret-1"),
 			},
 			Key: testKey,
 			WantUpdates: []clientgotesting.UpdateActionImpl{
@@ -1022,7 +1023,7 @@ func TestReconcileKind(t *testing.T) {
 							Auth: &contract.Resource_AuthSecret{
 								AuthSecret: &contract.Reference{
 									Uuid:      SecretUUID,
-									Namespace: system.Namespace(),
+									Namespace: "ns-1",
 									Name:      "secret-1",
 									Version:   SecretResourceVersion,
 								},

--- a/control-plane/pkg/reconciler/channel/v2/channelv2.go
+++ b/control-plane/pkg/reconciler/channel/v2/channelv2.go
@@ -132,7 +132,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, channel *messagingv1beta
 	statusConditionManager.ConfigResolved()
 
 	// get the secret to access Kafka
-	secret, err := security.Secret(ctx, &security.MTConfigMapSecretLocator{ConfigMap: channelConfigMap}, r.SecretProviderFunc())
+	secret, err := security.Secret(ctx, &security.MTConfigMapSecretLocator{ConfigMap: channelConfigMap, UseNamespaceInConfigmap: true}, r.SecretProviderFunc())
 	if err != nil {
 		return fmt.Errorf("failed to get secret: %w", err)
 	}
@@ -372,7 +372,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, channel *messagingv1beta1
 	logger.Debug("topic config resolved", zap.Any("config", topicConfig))
 
 	// get the secret to access Kafka
-	secret, err := security.Secret(ctx, &security.MTConfigMapSecretLocator{ConfigMap: channelConfigMap}, r.SecretProviderFunc())
+	secret, err := security.Secret(ctx, &security.MTConfigMapSecretLocator{ConfigMap: channelConfigMap, UseNamespaceInConfigmap: true}, r.SecretProviderFunc())
 	if err != nil {
 		return fmt.Errorf("failed to get secret: %w", err)
 	}

--- a/control-plane/pkg/reconciler/channel/v2/channelv2_test.go
+++ b/control-plane/pkg/reconciler/channel/v2/channelv2_test.go
@@ -1008,9 +1008,10 @@ func TestReconcileKind(t *testing.T) {
 				NewConfigMapWithTextData(system.Namespace(), DefaultEnv.GeneralConfigMapName, map[string]string{
 					kafka.BootstrapServersConfigMapKey: ChannelBootstrapServers,
 					security.AuthSecretNameKey:         "secret-1",
+					security.AuthSecretNamespaceKey:    "ns-1",
 				}),
 				NewConfigMapWithBinaryData(&env, nil),
-				NewSSLSecret(system.Namespace(), "secret-1"),
+				NewSSLSecret("ns-1", "secret-1"),
 				NewConsumerGroup(
 					WithConsumerGroupName(Subscription1UUID),
 					WithConsumerGroupNamespace(ChannelNamespace),
@@ -1042,7 +1043,7 @@ func TestReconcileKind(t *testing.T) {
 							Auth: &contract.Resource_AuthSecret{
 								AuthSecret: &contract.Reference{
 									Uuid:      SecretUUID,
-									Namespace: system.Namespace(),
+									Namespace: "ns-1",
 									Name:      "secret-1",
 									Version:   SecretResourceVersion,
 								},

--- a/control-plane/pkg/security/config.go
+++ b/control-plane/pkg/security/config.go
@@ -99,10 +99,12 @@ func DefaultSecretProviderFunc(lister corelisters.SecretLister, kc kubernetes.In
 // MTConfigMapSecretLocator is a SecretLocator that locates a secret using a reference in a ConfigMap.
 //
 // The name is taken from the data field using the key: AuthSecretNameKey.
-// The namespace is taken from the data field using the key: AuthSecretNamespaceKey but if it is not defined,
-// namespace of the ConfigMap is returned.
+// When UseNamespaceInConfigmap=true, the namespace is taken from the data field using the
+// key: AuthSecretNamespaceKey. When false, namespace of the ConfigMap is returned.
 type MTConfigMapSecretLocator struct {
 	*corev1.ConfigMap
+	// if false, secret namespace is NOT read from the configmap
+	UseNamespaceInConfigmap bool
 }
 
 func (cmp *MTConfigMapSecretLocator) SecretName() (string, bool) {
@@ -114,12 +116,9 @@ func (cmp *MTConfigMapSecretLocator) SecretName() (string, bool) {
 }
 
 func (cmp *MTConfigMapSecretLocator) SecretNamespace() (string, bool) {
-	if cmp.ConfigMap == nil {
-		return cmp.Namespace, true
-	}
-
-	if v, ok := cmp.Data[AuthSecretNamespaceKey]; ok {
-		return v, true
+	if cmp.UseNamespaceInConfigmap {
+		v, ok := cmp.Data[AuthSecretNamespaceKey]
+		return v, ok
 	}
 
 	return cmp.Namespace, true

--- a/control-plane/pkg/security/config.go
+++ b/control-plane/pkg/security/config.go
@@ -117,8 +117,9 @@ func (cmp *MTConfigMapSecretLocator) SecretName() (string, bool) {
 
 func (cmp *MTConfigMapSecretLocator) SecretNamespace() (string, bool) {
 	if cmp.UseNamespaceInConfigmap {
-		v, ok := cmp.Data[AuthSecretNamespaceKey]
-		return v, ok
+		if v, ok := cmp.Data[AuthSecretNamespaceKey]; ok && len(v) > 0 {
+			return v, ok
+		}
 	}
 
 	return cmp.Namespace, true

--- a/control-plane/pkg/security/config.go
+++ b/control-plane/pkg/security/config.go
@@ -30,7 +30,8 @@ import (
 )
 
 const (
-	AuthSecretNameKey = "auth.secret.ref.name" /* #nosec G101 */ /* Potential hardcoded credentials (gosec) */
+	AuthSecretNameKey      = "auth.secret.ref.name"      /* #nosec G101 */ /* Potential hardcoded credentials (gosec) */
+	AuthSecretNamespaceKey = "auth.secret.ref.namespace" /* #nosec G101 */ /* Potential hardcoded credentials (gosec) */
 )
 
 // SecretLocator locates a secret in a cluster.
@@ -97,8 +98,9 @@ func DefaultSecretProviderFunc(lister corelisters.SecretLister, kc kubernetes.In
 
 // MTConfigMapSecretLocator is a SecretLocator that locates a secret using a reference in a ConfigMap.
 //
-// The name is take from the data field using the key: AuthSecretNameKey.
-// The namespace is the same namespace of the ConfigMap.
+// The name is taken from the data field using the key: AuthSecretNameKey.
+// The namespace is taken from the data field using the key: AuthSecretNamespaceKey but if it is not defined,
+// namespace of the ConfigMap is returned.
 type MTConfigMapSecretLocator struct {
 	*corev1.ConfigMap
 }
@@ -112,5 +114,13 @@ func (cmp *MTConfigMapSecretLocator) SecretName() (string, bool) {
 }
 
 func (cmp *MTConfigMapSecretLocator) SecretNamespace() (string, bool) {
+	if cmp.ConfigMap == nil {
+		return cmp.Namespace, true
+	}
+
+	if v, ok := cmp.Data[AuthSecretNamespaceKey]; ok {
+		return v, true
+	}
+
 	return cmp.Namespace, true
 }

--- a/control-plane/pkg/security/config_test.go
+++ b/control-plane/pkg/security/config_test.go
@@ -70,6 +70,39 @@ func TestSecret(t *testing.T) {
 						Name:      "my-name",
 					},
 					Data: map[string]string{
+						AuthSecretNameKey:      "my-name",
+						AuthSecretNamespaceKey: "my-ns",
+					},
+				},
+			},
+			secretProviderFunc: (&SecretProviderFuncMock{
+				secret: &corev1.Secret{
+					Data: map[string][]byte{
+						ProtocolKey: []byte(ProtocolPlaintext),
+					},
+				},
+				err:           nil,
+				wantName:      "my-name",
+				wantNamespace: "my-ns",
+				t:             t,
+			}).F,
+			wantSecret: &corev1.Secret{
+				Data: map[string][]byte{
+					ProtocolKey: []byte(ProtocolPlaintext),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "happy case with fallback to configmap namespace",
+			ctx:  context.Background(),
+			config: &MTConfigMapSecretLocator{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "my-name",
+					},
+					Data: map[string]string{
 						AuthSecretNameKey: "my-name",
 					},
 				},
@@ -123,7 +156,8 @@ func TestSecret(t *testing.T) {
 						Name:      "my-name",
 					},
 					Data: map[string]string{
-						AuthSecretNameKey: "my-name",
+						AuthSecretNameKey:      "my-name",
+						AuthSecretNamespaceKey: "my-ns",
 					},
 				},
 			},

--- a/control-plane/pkg/security/config_test.go
+++ b/control-plane/pkg/security/config_test.go
@@ -105,7 +105,8 @@ func TestSecret(t *testing.T) {
 						Name:      "my-name",
 					},
 					Data: map[string]string{
-						AuthSecretNameKey: "my-name",
+						AuthSecretNamespaceKey: "my-ns",
+						AuthSecretNameKey:      "my-name",
 					},
 				},
 			},

--- a/control-plane/pkg/security/config_test.go
+++ b/control-plane/pkg/security/config_test.go
@@ -61,17 +61,18 @@ func TestSecret(t *testing.T) {
 		wantErr            bool
 	}{
 		{
-			name: "happy case",
+			name: "happy case - use configmap namespace",
 			ctx:  context.Background(),
 			config: &MTConfigMapSecretLocator{
-				&corev1.ConfigMap{
+				UseNamespaceInConfigmap: false,
+				ConfigMap: &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "my-ns",
 						Name:      "my-name",
 					},
 					Data: map[string]string{
 						AuthSecretNameKey:      "my-name",
-						AuthSecretNamespaceKey: "my-ns",
+						AuthSecretNamespaceKey: "NOT_USED",
 					},
 				},
 			},
@@ -94,10 +95,11 @@ func TestSecret(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "happy case with fallback to configmap namespace",
+			name: "happy case - use namespace in configmap",
 			ctx:  context.Background(),
 			config: &MTConfigMapSecretLocator{
-				&corev1.ConfigMap{
+				UseNamespaceInConfigmap: true,
+				ConfigMap: &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "my-ns",
 						Name:      "my-name",
@@ -128,14 +130,15 @@ func TestSecret(t *testing.T) {
 		{
 			name:       "no secret in MTConfigMapSecretLocator config",
 			ctx:        context.Background(),
-			config:     &MTConfigMapSecretLocator{nil},
+			config:     &MTConfigMapSecretLocator{ConfigMap: nil},
 			wantSecret: nil,
 		},
 		{
 			name: "no secret in MTConfigMapSecretLocator",
 			ctx:  context.Background(),
 			config: &MTConfigMapSecretLocator{
-				&corev1.ConfigMap{
+				UseNamespaceInConfigmap: false,
+				ConfigMap: &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "my-ns",
 						Name:      "my-name",
@@ -150,7 +153,8 @@ func TestSecret(t *testing.T) {
 			name: "secret provider error",
 			ctx:  context.Background(),
 			config: &MTConfigMapSecretLocator{
-				&corev1.ConfigMap{
+				UseNamespaceInConfigmap: false,
+				ConfigMap: &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "my-ns",
 						Name:      "my-name",

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -271,19 +271,19 @@ function setup_kafka_channel_auth() {
     kubectl patch configmap/kafka-channel-config \
       -n knative-eventing \
       --type merge \
-      -p '{"data":{"bootstrap.servers":"my-cluster-kafka-bootstrap.kafka:9093", "auth.secret.ref.name": "strimzi-tls-secret"}}'
+      -p '{"data":{"bootstrap.servers":"my-cluster-kafka-bootstrap.kafka:9093", "auth.secret.ref.name": "strimzi-tls-secret", "auth.secret.ref.name": "knative-eventing"}}'
   elif [ "$EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO" == "SASL_SSL" ]; then
     echo "Setting up SASL_SSL configuration for KafkaChannel"
     kubectl patch configmap/kafka-channel-config \
       -n knative-eventing \
       --type merge \
-      -p '{"data":{"bootstrap.servers":"my-cluster-kafka-bootstrap.kafka:9094", "auth.secret.ref.name": "strimzi-sasl-secret"}}'
+      -p '{"data":{"bootstrap.servers":"my-cluster-kafka-bootstrap.kafka:9094", "auth.secret.ref.name": "strimzi-sasl-secret", "auth.secret.ref.name": "knative-eventing"}}'
   elif [ "$EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO" == "SASL_PLAIN" ]; then
     echo "Setting up SASL_PLAIN configuration for KafkaChannel"
     kubectl patch configmap/kafka-channel-config \
       -n knative-eventing \
       --type merge \
-      -p '{"data":{"bootstrap.servers":"my-cluster-kafka-bootstrap.kafka:9095", "auth.secret.ref.name": "strimzi-sasl-plain-secret"}}'
+      -p '{"data":{"bootstrap.servers":"my-cluster-kafka-bootstrap.kafka:9095", "auth.secret.ref.name": "strimzi-sasl-plain-secret", "auth.secret.ref.name": "knative-eventing"}}'
   else
     echo "Setting up no auth configuration for KafkaChannel"
     kubectl patch configmap/kafka-channel-config \
@@ -293,6 +293,6 @@ function setup_kafka_channel_auth() {
     kubectl patch configmap/kafka-channel-config \
       -n knative-eventing \
       --type=json \
-      -p='[{"op": "remove", "path": "/data/auth.secret.ref.name"}]' || true
+      -p='[{"op": "remove", "path": "/data/auth.secret.ref.name"}, {"op": "remove", "path": "/data/auth.secret.ref.namespace"}]' || true
   fi
 }

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -271,19 +271,19 @@ function setup_kafka_channel_auth() {
     kubectl patch configmap/kafka-channel-config \
       -n knative-eventing \
       --type merge \
-      -p '{"data":{"bootstrap.servers":"my-cluster-kafka-bootstrap.kafka:9093", "auth.secret.ref.name": "strimzi-tls-secret", "auth.secret.ref.name": "knative-eventing"}}'
+      -p '{"data":{"bootstrap.servers":"my-cluster-kafka-bootstrap.kafka:9093", "auth.secret.ref.name": "strimzi-tls-secret", "auth.secret.ref.namespace": "knative-eventing"}}'
   elif [ "$EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO" == "SASL_SSL" ]; then
     echo "Setting up SASL_SSL configuration for KafkaChannel"
     kubectl patch configmap/kafka-channel-config \
       -n knative-eventing \
       --type merge \
-      -p '{"data":{"bootstrap.servers":"my-cluster-kafka-bootstrap.kafka:9094", "auth.secret.ref.name": "strimzi-sasl-secret", "auth.secret.ref.name": "knative-eventing"}}'
+      -p '{"data":{"bootstrap.servers":"my-cluster-kafka-bootstrap.kafka:9094", "auth.secret.ref.name": "strimzi-sasl-secret", "auth.secret.ref.namespace": "knative-eventing"}}'
   elif [ "$EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO" == "SASL_PLAIN" ]; then
     echo "Setting up SASL_PLAIN configuration for KafkaChannel"
     kubectl patch configmap/kafka-channel-config \
       -n knative-eventing \
       --type merge \
-      -p '{"data":{"bootstrap.servers":"my-cluster-kafka-bootstrap.kafka:9095", "auth.secret.ref.name": "strimzi-sasl-plain-secret", "auth.secret.ref.name": "knative-eventing"}}'
+      -p '{"data":{"bootstrap.servers":"my-cluster-kafka-bootstrap.kafka:9095", "auth.secret.ref.name": "strimzi-sasl-plain-secret", "auth.secret.ref.namespace": "knative-eventing"}}'
   else
     echo "Setting up no auth configuration for KafkaChannel"
     kubectl patch configmap/kafka-channel-config \


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Make it possible to specify auth secret namespace in configmap
- This is needed for KafkaChannel migration because:
  - It is possible to specify the auth secret namespace in the consolidated
  - We will read the namespace in the migration process and just set it on the new configmap
- Default behaviour is as before: secret namespace is the configmap's namespace

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
