### PR TITLE
Add permission to set Pod finalizers for controller

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
@@ -43,7 +43,7 @@ rules:
   - apiGroups:
       - "*"
     resources:
-      - configmaps/finalizers
+      - pods/finalizers
     verbs:
       - update
   - apiGroups:


### PR DESCRIPTION
Error seen:
```
type: 'Warning' reason: 'InternalError' failed to bind resource to pod: failed to get or create data plane ConfigMap knative-eventing/kafka-source-dispatcher-2: configmaps \"kafka-source-dispatcher-2\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>","knative.dev/pod":"kafka-controller-bfcdc9d66-mfkrh"}
```

Signed-off-by: aavarghese <avarghese@us.ibm.com>

This is needed to set blockOwnerDeletion for Pod owner reference.

Part of #1537 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
