### PR TITLE
Add more permissions to set Pod finalizers for controller 

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
@@ -45,7 +45,11 @@ rules:
     resources:
       - pods/finalizers
     verbs:
+      - get
+      - list
+      - create
       - update
+      - delete
   - apiGroups:
       - "*"
     resources:


### PR DESCRIPTION
Error previously seen:
```
type: 'Warning' reason: 'InternalError' failed to bind resource to pod: failed to get or create data plane ConfigMap knative-eventing/kafka-source-dispatcher-2: configmaps \"kafka-source-dispatcher-2\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>","knative.dev/pod":"kafka-controller-bfcdc9d66-mfkrh"}
```

Previous changes in https://github.com/knative-sandbox/eventing-kafka-broker/pull/2024 weren't sufficient for the pods to fully come up.

Signed-off-by: aavarghese <avarghese@us.ibm.com>

Part of #1537 