### PR TITLE
Improve dispatcher components stop lifecycle

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
@@ -21,12 +21,13 @@ import io.vertx.core.Promise;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecords;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class OrderedConsumerVerticle extends BaseConsumerVerticle {
 
@@ -57,7 +58,6 @@ public class OrderedConsumerVerticle extends BaseConsumerVerticle {
 
   @Override
   void startConsumer(Promise<Void> startPromise) {
-    this.consumer.exceptionHandler(this::exceptionHandler);
     // We need to sub first, then we can start the polling loop
     this.consumer.subscribe(this.topics)
       .onFailure(startPromise::fail)

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
@@ -292,15 +292,16 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
     final String target,
     final EgressConfig egress) {
 
+    final var circuitBreakerOptions = createCircuitBreakerOptions(egress);
     final var circuitBreaker = CircuitBreaker
-      .create(target, vertx, createCircuitBreakerOptions(egress))
+      .create(target, vertx, circuitBreakerOptions)
       .retryPolicy(computeRetryPolicy(egress))
       .openHandler(r -> logger.info("Circuit breaker opened {}", keyValue("target", target)))
       .halfOpenHandler(r -> logger.info("Circuit breaker half-opened {}", keyValue("target", target)))
       .closeHandler(r -> logger.info("Circuit breaker closed {}", keyValue("target", target)));
 
     return new WebClientCloudEventSender(
-      WebClient.create(vertx, this.webClientOptions), circuitBreaker, target
+      WebClient.create(vertx, this.webClientOptions), circuitBreaker, circuitBreakerOptions, target
     );
   }
 

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherTest.java
@@ -307,7 +307,9 @@ public class RecordDispatcherTest {
   }
 
   public static RecordDispatcherListener offsetManagerMock() {
-    return mock(RecordDispatcherListener.class);
+    final var m = mock(RecordDispatcherListener.class);
+    when(m.close()).thenReturn(Future.succeededFuture());
+    return m;
   }
 
   private void assertNoEventCount() {

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSenderTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSenderTest.java
@@ -16,6 +16,7 @@
 package dev.knative.eventing.kafka.broker.dispatcher.impl.http;
 
 import io.vertx.circuitbreaker.CircuitBreaker;
+import io.vertx.circuitbreaker.CircuitBreakerOptions;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -48,7 +49,7 @@ public class WebClientCloudEventSenderTest {
     doNothing().when(webClient).close();
 
     final var consumerRecordSender = new WebClientCloudEventSender(
-      webClient, circuitBreaker, "http://localhost:12345"
+      webClient, circuitBreaker, new CircuitBreakerOptions(), "http://localhost:12345"
     );
 
     consumerRecordSender.close()


### PR DESCRIPTION
Sometimes when deleting resources, which end up stopping
associated data plane components the lifecycle might produce
errors (like commiting offsets after a consumer has been closed)

This PR rework the overall stop lifecycle of dispatcher
components.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Fixes https://github.com/knative-sandbox/eventing-kafka-broker/pull/2012#issuecomment-1075112440