### PR TITLE
HA Scheduler config map update

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-scheduler.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-scheduler.yaml
@@ -24,9 +24,7 @@ data:
                   [
                     {"Name": "PodFitsResources"},
                     {"Name": "NoMaxResourceCount",
-                    "Args": "{\"NumPartitions\": 100}"},
-                    {"Name": "EvenPodSpread",
-                    "Args": "{\"MaxSkew\": 2}"}
+                    "Args": "{\"NumPartitions\": 100}"}
                   ]
     priorities: |+
                   [
@@ -34,5 +32,8 @@ data:
                     "Weight": 10,
                     "Args":  "{\"MaxSkew\": 2}"},
                     {"Name": "LowestOrdinalPriority",
-                    "Weight": 2}
+                    "Weight": 2},
+                    {"Name": "EvenPodSpread",
+                    "Weight": 2,
+                    "Args": "{\"MaxSkew\": 2}"}
                   ]


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

`EvenPodSpread` is specified to schedule vreplicas evenly across dispatcher pods which is very important for an equal event consumption from Kafka topic. 

`EvenPodSpread` can both be specified as a filter (predicate) OR as a scorer (priority). When specified as a predicate, the scheduler is highly constrained by the skew factor and requires a large number of pods (in some scenarios) which is not very friendly for small clusters (pods that have low capacity are filtered out and not used). Instead, we can use this plugin to score pods and schedule onto higher score pods. 

Changed `EvenPodSpread` to a priority instead of a predicate for the default config scheduler in this repo. 
Either can work depending on the cluster and the requirements.

Part of #1537 

/cc @pierDipi 