### PR TITLE
Enable Zipkin tracing for upgrade tests

### DIFF
--- a/test/config/monitoring.yaml
+++ b/test/config/monitoring.yaml
@@ -53,9 +53,13 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: JAVA_OPTS
+          value: '-Xms128m -Xmx5G -XX:+ExitOnOutOfMemoryError'
+        - name: MEM_MAX_SPANS
+          value: '10000000'
         resources:
           limits:
-            memory: 1000Mi
+            memory: 6Gi
           requests:
             memory: 256Mi
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -136,6 +136,8 @@ function install_latest_release() {
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_CHANNEL_ARTIFACT}" || return $?
 
   oc get cm config-tracing -n knative-eventing -oyaml
+  kubectl replace -f ./test/config/config-tracing.yaml
+  oc get cm config-tracing -n knative-eventing -oyaml
 }
 
 function install_head() {
@@ -148,6 +150,8 @@ function install_head() {
   kubectl apply -f "${EVENTING_KAFKA_CHANNEL_ARTIFACT}" || return $?
   kubectl apply -f "${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" || return $?
 
+  oc get cm config-tracing -n knative-eventing -oyaml
+  kubectl replace -f ./test/config/config-tracing.yaml
   oc get cm config-tracing -n knative-eventing -oyaml
 }
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -127,17 +127,14 @@ function install_latest_release() {
 
   ko apply -f ./test/config/ || fail_test "Failed to apply test configurations"
 
-  kubectl get cm config-tracing -n knative-eventing -oyaml
-
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" || return $?
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_BROKER_ARTIFACT}" || return $?
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_SINK_ARTIFACT}" || return $?
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_SOURCE_ARTIFACT}" || return $?
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_CHANNEL_ARTIFACT}" || return $?
 
-  kubectl get cm config-tracing -n knative-eventing -oyaml
-  kubectl replace -f ./test/config/config-tracing.yaml
-  kubectl get cm config-tracing -n knative-eventing -oyaml
+  # Restore test config-tracing.
+  kubectl replace -f ./test/config/100-config-tracing.yaml
 }
 
 function install_head() {
@@ -150,9 +147,8 @@ function install_head() {
   kubectl apply -f "${EVENTING_KAFKA_CHANNEL_ARTIFACT}" || return $?
   kubectl apply -f "${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" || return $?
 
-  kubectl get cm config-tracing -n knative-eventing -oyaml
-  kubectl replace -f ./test/config/config-tracing.yaml
-  kubectl get cm config-tracing -n knative-eventing -oyaml
+  # Restore test config-tracing.
+  kubectl replace -f ./test/config/100-config-tracing.yaml
 }
 
 function test_setup() {

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -127,7 +127,7 @@ function install_latest_release() {
 
   ko apply -f ./test/config/ || fail_test "Failed to apply test configurations"
 
-  oc get cm config-tracing -n knative-eventing -oyaml
+  kubectl get cm config-tracing -n knative-eventing -oyaml
 
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" || return $?
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_BROKER_ARTIFACT}" || return $?
@@ -135,9 +135,9 @@ function install_latest_release() {
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_SOURCE_ARTIFACT}" || return $?
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_CHANNEL_ARTIFACT}" || return $?
 
-  oc get cm config-tracing -n knative-eventing -oyaml
+  kubectl get cm config-tracing -n knative-eventing -oyaml
   kubectl replace -f ./test/config/config-tracing.yaml
-  oc get cm config-tracing -n knative-eventing -oyaml
+  kubectl get cm config-tracing -n knative-eventing -oyaml
 }
 
 function install_head() {
@@ -150,9 +150,9 @@ function install_head() {
   kubectl apply -f "${EVENTING_KAFKA_CHANNEL_ARTIFACT}" || return $?
   kubectl apply -f "${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" || return $?
 
-  oc get cm config-tracing -n knative-eventing -oyaml
+  kubectl get cm config-tracing -n knative-eventing -oyaml
   kubectl replace -f ./test/config/config-tracing.yaml
-  oc get cm config-tracing -n knative-eventing -oyaml
+  kubectl get cm config-tracing -n knative-eventing -oyaml
 }
 
 function test_setup() {

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -127,11 +127,15 @@ function install_latest_release() {
 
   ko apply -f ./test/config/ || fail_test "Failed to apply test configurations"
 
+  oc get cm config-tracing -n knative-eventing -oyaml
+
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" || return $?
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_BROKER_ARTIFACT}" || return $?
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_SINK_ARTIFACT}" || return $?
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_SOURCE_ARTIFACT}" || return $?
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_CHANNEL_ARTIFACT}" || return $?
+
+  oc get cm config-tracing -n knative-eventing -oyaml
 }
 
 function install_head() {
@@ -143,6 +147,8 @@ function install_head() {
   kubectl apply -f "${EVENTING_KAFKA_SINK_ARTIFACT}" || return $?
   kubectl apply -f "${EVENTING_KAFKA_CHANNEL_ARTIFACT}" || return $?
   kubectl apply -f "${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" || return $?
+
+  oc get cm config-tracing -n knative-eventing -oyaml
 }
 
 function test_setup() {


### PR DESCRIPTION
Fixes issues like this one: https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative-sandbox_eventing-kafka-broker/2038/upgrade-tests_eventing-kafka-broker_main/1511168436032507904

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Actually use test config-tracing
- Increase Zipkin resources to handle the increased load in upgrade tests

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
