### PR TITLE
Increase default timeout to 10 minutes

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
@@ -85,6 +85,8 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
 
   private static final Logger logger = LoggerFactory.getLogger(ConsumerVerticleFactoryImpl.class);
 
+  private static final long DEFAULT_TIMEOUT_MS = 600_000L;
+
   private final static CloudEventSender NO_DEAD_LETTER_SINK_SENDER = CloudEventSender.noop("No dead letter sink set");
 
   private final Map<String, Object> consumerConfigs;
@@ -316,7 +318,7 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
       options.setTimeout(
         egressConfig.getTimeout() > 0 ?
           egressConfig.getTimeout() :
-          CircuitBreakerOptions.DEFAULT_TIMEOUT
+          DEFAULT_TIMEOUT_MS
       );
 
       // Retry options


### PR DESCRIPTION
As discussed previously, the default timeout of 10 seconds isn't
sometimes enough to even start a Knative Service.

Using 10 minutes will avoid overriding the timeout with
`spec.delivery.timeout` in most of the use cases.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Increase default timeout to 10 minutes

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
The default request timeout is 10 minutes now, it was previously set to 10 seconds.
It can be overridden using `spec.delivery.timeout` on `Broker`, `Trigger`, `KafkaChannel` and `Subscription`.
```
