### PR TITLE
Expensive metrics endpoint for dispatcher liveness and readiness probe

### DIFF
--- a/data-plane/config/broker/500-dispatcher.yaml
+++ b/data-plane/config/broker/500-dispatcher.yaml
@@ -105,10 +105,8 @@ spec:
           # TODO set resources (limits and requests)
           livenessProbe:
             failureThreshold: 3
-            httpGet:
+            tcpSocket:
               port: 9090
-              path: /metrics
-              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1

--- a/data-plane/config/brokerv2/500-dispatcher.yaml
+++ b/data-plane/config/brokerv2/500-dispatcher.yaml
@@ -117,20 +117,16 @@ spec:
 
           livenessProbe:
             failureThreshold: 3
-            httpGet:
+            tcpSocket:
               port: 9090
-              path: /metrics
-              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 1
           readinessProbe:
             failureThreshold: 3
-            httpGet:
+            tcpSocket:
               port: 9090
-              path: /metrics
-              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1

--- a/data-plane/config/channel/500-dispatcher.yaml
+++ b/data-plane/config/channel/500-dispatcher.yaml
@@ -105,10 +105,8 @@ spec:
           # TODO set resources (limits and requests)
           livenessProbe:
             failureThreshold: 3
-            httpGet:
+            tcpSocket:
               port: 9090
-              path: /metrics
-              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1

--- a/data-plane/config/channelv2/500-dispatcher.yaml
+++ b/data-plane/config/channelv2/500-dispatcher.yaml
@@ -117,20 +117,16 @@ spec:
 
           livenessProbe:
             failureThreshold: 3
-            httpGet:
+            tcpSocket:
               port: 9090
-              path: /metrics
-              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 1
           readinessProbe:
             failureThreshold: 3
-            httpGet:
+            tcpSocket:
               port: 9090
-              path: /metrics
-              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1

--- a/data-plane/config/source/500-dispatcher.yaml
+++ b/data-plane/config/source/500-dispatcher.yaml
@@ -105,20 +105,16 @@ spec:
           # TODO set resources (limits and requests)
           livenessProbe:
             failureThreshold: 3
-            httpGet:
+            tcpSocket:
               port: 9090
-              path: /metrics
-              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 1
           readinessProbe:
             failureThreshold: 3
-            httpGet:
+            tcpSocket:
               port: 9090
-              path: /metrics
-              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1

--- a/data-plane/config/sourcev2/500-dispatcher.yaml
+++ b/data-plane/config/sourcev2/500-dispatcher.yaml
@@ -117,20 +117,16 @@ spec:
 
           livenessProbe:
             failureThreshold: 3
-            httpGet:
+            tcpSocket:
               port: 9090
-              path: /metrics
-              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 1
           readinessProbe:
             failureThreshold: 3
-            httpGet:
+            tcpSocket:
               port: 9090
-              path: /metrics
-              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1


### PR DESCRIPTION
The dispatcher is using the `/metrics` endpoint to signal liveness
and readiness, however, responding with metrics involves expensive
operations [1] [2] (allocations and CPU).

In this patch, I'm migrating readiness and liveness probes
to use a `TCP` probe against the same metrics server but
avoiding the above-mentioned expensive operations.

[1] https://github.com/micrometer-metrics/micrometer/blob/30c8a1bf1b0bf867232630b0dcd2b272975b68a2/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java#L101-L154
[2] https://github.com/prometheus/client_java/blob/master/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>