### PR TITLE
Clean up Zipkin tracing only once in upgrade tests

### DIFF
--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -20,12 +20,18 @@
 package upgrade
 
 import (
+	"log"
 	"testing"
 
 	pkgupgrade "knative.dev/pkg/test/upgrade"
+	"knative.dev/pkg/test/zipkin"
 )
 
 func TestUpgrades(t *testing.T) {
 	suite := Suite()
+	// Any tests may SetupZipkinTracing, it will only actually be done once. This should be the ONLY
+	// place that cleans it up. If an individual test calls this instead, then it will break other
+	// tests that need the tracing in place.
+	defer zipkin.CleanupZipkinTracingSetup(log.Printf)
 	suite.Execute(pkgupgrade.Configuration{T: t})
 }


### PR DESCRIPTION
This is similar to https://github.com/knative/eventing/pull/6331 . When the Eventing changes propagate to this repo we'll need to ensure cleanup of Zipkin port-forwarding. This PR fixes that.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Clean up Zipkin port-forwarding only, when the upgrade test suite ends

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
