### PR TITLE
kafka-source-dispatcher fails with LZ4 compression #2106

### DIFF
--- a/data-plane/dispatcher/pom.xml
+++ b/data-plane/dispatcher/pom.xml
@@ -127,9 +127,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>${maven.shade.plugin.version}</version>
-        <configuration>
-          <minimizeJar>true</minimizeJar>
-        </configuration>
         <executions>
           <execution>
             <phase>package</phase>
@@ -137,6 +134,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <minimizeJar>true</minimizeJar>
               <transformers>
                 <!-- This merges all the META-INF/services -->
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
@@ -158,6 +156,13 @@
                 </filter>
                 <filter>
                   <artifact>org.apache.kafka:kafka-clients</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <!-- Some LZ4 classes are loaded via reflection. Required explicit inclusion due to minimizeJar=true -->
+                  <artifact>org.lz4:lz4-java</artifact>
                   <includes>
                     <include>**</include>
                   </includes>

--- a/data-plane/receiver/pom.xml
+++ b/data-plane/receiver/pom.xml
@@ -119,9 +119,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>${maven.shade.plugin.version}</version>
-        <configuration>
-          <minimizeJar>true</minimizeJar>
-        </configuration>
         <executions>
           <execution>
             <phase>package</phase>
@@ -129,6 +126,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <minimizeJar>true</minimizeJar>
               <transformers>
                 <!-- This merges all the META-INF/services -->
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
@@ -150,6 +148,13 @@
                 </filter>
                 <filter>
                   <artifact>org.apache.kafka:kafka-clients</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <!-- Some LZ4 classes are loaded via reflection. Required explicit inclusion due to minimizeJar=true -->
+                  <artifact>org.lz4:lz4-java</artifact>
                   <includes>
                     <include>**</include>
                   </includes>


### PR DESCRIPTION
Explicit inclusion of org.lz4:lz4-java classes in maven-shade-plugin.

Fixes #2106 

Some LZ4 classes are loaded via reflection. maven-shade-plugin.configure.minimizeJar=true Removes from final jar all classes not directly loaded in code.
This lead to a ClassNotFound error on runtime when dispatcher handle a LZ4 encoded message.

## Proposed Changes

- Explicit inclusion of org.lz4:lz4-java classes in maven-shade-plugin. 
