### PR TITLE
Add rate limiter to ordered consumer verticle 

### DIFF
--- a/data-plane/THIRD-PARTY.txt
+++ b/data-plane/THIRD-PARTY.txt
@@ -1,5 +1,5 @@
 
-Lists of 157 third-party dependencies.
+Lists of 158 third-party dependencies.
      (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Classic Module (ch.qos.logback:logback-classic:1.2.11 - http://logback.qos.ch/logback-classic)
      (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Core Module (ch.qos.logback:logback-core:1.2.11 - http://logback.qos.ch/logback-core)
      (The Apache Software License, Version 2.0) Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.13.2 - http://github.com/FasterXML/jackson)
@@ -12,6 +12,7 @@ Lists of 157 third-party dependencies.
      (The Apache Software License, Version 2.0) jackson-module-scala (com.fasterxml.jackson.module:jackson-module-scala_2.12:2.13.2 - http://wiki.fasterxml.com/JacksonModuleScala)
      (BSD 2-Clause License) zstd-jni (com.github.luben:zstd-jni:1.4.9-1 - https://github.com/luben/zstd-jni)
      (The Apache Software License, Version 2.0) Generex (com.github.mifmif:generex:1.0.2 - https://github.com/mifmif/Generex/tree/master)
+     (The Apache Software License, Version 2.0) bucket4j-core (com.github.vladimir-bukhtoyarov:bucket4j-core:7.4.0 - http://github.com/vladimir-bukhtoyarov/bucket4j/bucket4j-core)
      (The Apache Software License, Version 2.0) FindBugs-jsr305 (com.google.code.findbugs:jsr305:3.0.2 - http://findbugs.sourceforge.net/)
      (Apache-2.0) Gson (com.google.code.gson:gson:2.8.9 - https://github.com/google/gson/gson)
      (Apache 2.0) error-prone annotations (com.google.errorprone:error_prone_annotations:2.5.1 - http://nexus.sonatype.org/oss-repository-hosting.html/error_prone_parent/error_prone_annotations)

--- a/data-plane/dispatcher/pom.xml
+++ b/data-plane/dispatcher/pom.xml
@@ -82,6 +82,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.vladimir-bukhtoyarov</groupId>
+      <artifactId>bucket4j-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>dev.knative.eventing.kafka.broker</groupId>
       <artifactId>core</artifactId>
       <classifier>tests</classifier>

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
@@ -15,13 +15,20 @@
  */
 package dev.knative.eventing.kafka.broker.dispatcher.impl.consumer;
 
+import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import dev.knative.eventing.kafka.broker.core.OrderedAsyncExecutor;
 import io.cloudevents.CloudEvent;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import io.github.bucket4j.local.LocalBucketBuilder;
+import io.github.bucket4j.local.SynchronizationStrategy;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecords;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,13 +48,32 @@ public class OrderedConsumerVerticle extends BaseConsumerVerticle {
 
   private final Map<TopicPartition, OrderedAsyncExecutor> recordDispatcherExecutors;
   private final PartitionRevokedHandler partitionRevokedHandler;
+  private final DataPlaneContract.Egress egress;
+  private final Bucket bucket;
 
   private boolean closed;
   private long pollTimer;
   private boolean isPollInFlight;
 
-  public OrderedConsumerVerticle(Initializer initializer, Set<String> topics) {
+  public OrderedConsumerVerticle(final DataPlaneContract.Egress egress,
+                                 final Initializer initializer,
+                                 final Set<String> topics,
+                                 final int maxPollRecords) {
     super(initializer, topics);
+
+    final var vReplicas = Math.max(1, egress.getVReplicas());
+    final var tokens = maxPollRecords * vReplicas;
+    if (egress.getFeatureFlags().getEnableRateLimiter()) {
+      this.bucket = new LocalBucketBuilder()
+        .addLimit(Bandwidth.classic(tokens, Refill.greedy(tokens, Duration.ofSeconds(1))))
+        .withSynchronizationStrategy(SynchronizationStrategy.SYNCHRONIZED)
+        .withMillisecondPrecision()
+        .build();
+    } else {
+      this.bucket = null;
+    }
+
+    this.egress = egress;
     this.recordDispatcherExecutors = new HashMap<>();
     this.closed = false;
     this.isPollInFlight = false;
@@ -78,12 +104,35 @@ public class OrderedConsumerVerticle extends BaseConsumerVerticle {
   }
 
   private void poll() {
-    if (this.closed || this.isPollInFlight || !isWaitingForTasks()) {
+    if (this.closed || this.isPollInFlight) {
+      logger.debug("Consumer closed or poll is in-flight");
       return;
     }
+
+    // When we don't have tokens available, we just wait `POLLING_MS`
+    // before trying to poll again.
+    if (bucket != null && bucket.getAvailableTokens() <= 0) {
+      logger.info("Rate limiter, tokens unavailable {} {} {}",
+        keyValue("resource", egress.getReference()),
+        keyValue(ConsumerConfig.GROUP_ID_CONFIG, egress.getConsumerGroup()),
+        keyValue("wait.ms", POLLING_MS)
+      );
+      return;
+    }
+
+    // Only poll new records when at-least one internal per-partition queue
+    // needs more records.
+    if (areAllExecutorsBusy()) {
+      logger.debug("all executors are busy");
+      return;
+    }
+
     this.isPollInFlight = true;
 
-    logger.debug("Polling for records {}", keyValue("topics", topics));
+    logger.debug("Polling for records {} {}",
+      keyValue("topics", topics),
+      keyValue("resource", egress.getReference())
+    );
 
     this.consumer.poll(POLLING_TIMEOUT)
       .onSuccess(this::recordsHandler)
@@ -121,8 +170,13 @@ public class OrderedConsumerVerticle extends BaseConsumerVerticle {
     if (records == null || records.size() == 0) {
       return;
     }
-    // Put records in queues
-    // I assume the records are ordered per topic-partition
+
+    if (bucket != null) {
+      // Once we have new records, we force add them to internal per-partition queues.
+      bucket.forceAddTokens(records.size());
+    }
+
+    // Put records in internal per-partition queues.
     for (int i = 0; i < records.size(); i++) {
       final var record = records.recordAt(i);
       final var executor = executorFor(new TopicPartition(record.topic(), record.partition()));
@@ -132,7 +186,7 @@ public class OrderedConsumerVerticle extends BaseConsumerVerticle {
 
   private Future<Void> dispatch(final KafkaConsumerRecord<Object, CloudEvent> record) {
     if (this.closed) {
-      return Future.failedFuture("Consumer verticle closed topics=" + topics);
+      return Future.failedFuture("Consumer verticle closed topics=" + topics + " resource=" + egress.getReference());
     }
     return this.recordDispatcher.dispatch(record);
   }
@@ -147,12 +201,19 @@ public class OrderedConsumerVerticle extends BaseConsumerVerticle {
     return executor;
   }
 
-  private boolean isWaitingForTasks() {
-    for (OrderedAsyncExecutor value : this.recordDispatcherExecutors.values()) {
-      if (value.isWaitingForTasks()) {
-        return true;
+  private boolean areAllExecutorsBusy() {
+    if (recordDispatcherExecutors.isEmpty()) {
+      // No executors
+      return false;
+    }
+
+    for (OrderedAsyncExecutor executor: recordDispatcherExecutors.values()) {
+      if (executor.isWaitingForTasks()) {
+        return false;
       }
     }
-    return this.recordDispatcherExecutors.size() == 0;
+
+    // All executors are busy
+    return true;
   }
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
@@ -225,6 +225,7 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
        .mapEmpty();
 
     return getConsumerVerticle(
+      egress,
       deliveryOrder,
       initializer,
       new HashSet<>(resource.getTopicsList()),
@@ -400,15 +401,15 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
     return !(egressConfig == null || egressConfig.getDeadLetter().isEmpty());
   }
 
-  private static AbstractVerticle getConsumerVerticle(final DeliveryOrder type,
+  private static AbstractVerticle getConsumerVerticle(final DataPlaneContract.Egress egress,
+                                                      final DeliveryOrder type,
                                                       final BaseConsumerVerticle.Initializer initializer,
                                                       final Set<String> topics,
                                                       final Object maxPollRecords) {
+    final var maxRecords = maxPollRecords == null ? 0 : Integer.parseInt(maxPollRecords.toString());
     return switch (type) {
-      case ORDERED -> new OrderedConsumerVerticle(initializer, topics);
-      case UNORDERED -> new UnorderedConsumerVerticle(
-        initializer, topics, maxPollRecords == null ? 0 : Integer.parseInt(maxPollRecords.toString())
-      );
+      case ORDERED -> new OrderedConsumerVerticle(egress, initializer, topics, maxRecords);
+      case UNORDERED -> new UnorderedConsumerVerticle(initializer, topics, maxRecords);
     };
   }
 

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -47,6 +47,7 @@
     <opentelemetry.version>1.13.0</opentelemetry.version>
     <jackson.version>2.13.2.20220328</jackson.version>
     <protobuf.version>3.20.0</protobuf.version>
+    <bucket4j.version>7.4.0</bucket4j.version>
     <slf4j.version>1.7.36</slf4j.version>
     <ch.qos.logback.version>1.2.11</ch.qos.logback.version>
     <net.logstash.logback.encoder.version>7.1.1</net.logstash.logback.encoder.version>
@@ -291,6 +292,13 @@
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java-util</artifactId>
         <version>${protobuf.version}</version>
+      </dependency>
+
+      <!-- Rate Limiter -->
+      <dependency>
+        <groupId>com.github.vladimir-bukhtoyarov</groupId>
+        <artifactId>bucket4j-core</artifactId>
+        <version>${bucket4j.version}</version>
       </dependency>
 
       <!-- Testing -->


### PR DESCRIPTION
Build on top of https://github.com/knative-sandbox/eventing-kafka-broker/pull/1425

Part of #2125

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add rate limiter to ordered consumer verticle

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
