### PR TITLE
Wait 10 mins before deleting the consolidated channel dataplane

### DIFF
--- a/control-plane/cmd/post-install/kafka_channel_post_migration_deleter.go
+++ b/control-plane/cmd/post-install/kafka_channel_post_migration_deleter.go
@@ -34,6 +34,8 @@ const (
 	ControlPlaneReadinessCheckInterval = 10 * time.Second
 	ControlPlaneReadinessCheckTimeout  = 10 * time.Minute
 
+	WaitDurationBeforePostMigration = 10 * time.Minute
+
 	NewControllerDeploymentName = "kafka-controller"
 )
 
@@ -57,7 +59,9 @@ func (d *kafkaChannelPostMigrationDeleter) Delete(ctx context.Context) error {
 		return fmt.Errorf("error while waiting the new control plane to become ready %w", err)
 	}
 
-	logger.Infof("New control plane is ready, progressing with the migration")
+	logger.Infof("New control plane is ready, waiting %s before deleting old data plane", WaitDurationBeforePostMigration)
+	time.Sleep(WaitDurationBeforePostMigration)
+	logger.Infof("Done waiting %s. Deleting old data plane...", WaitDurationBeforePostMigration)
 
 	///////////////////////////////////////////////////////////////////////////////
 	/////////// START DELETING DISPATCHER RESOURCES


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Wait 10 mins before deleting the consolidated channel dataplane
- To allow DNS resolution for the clients
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
