### PR TITLE
Clean up ordered delivery verticle

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/OrderedAsyncExecutor.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/OrderedAsyncExecutor.java
@@ -46,6 +46,7 @@ public class OrderedAsyncExecutor {
    */
   public void offer(Supplier<Future<?>> task) {
     if (this.isStopped) {
+      // Executor is stopped, return without adding the task to the queue.
       return;
     }
     boolean wasEmpty = this.queue.isEmpty();

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
@@ -161,9 +161,13 @@ public class Metrics {
    * @return A meter binder to close once the consumer is closed.
    */
   public static <K, V> AutoCloseable register(final Consumer<K, V> consumer) {
-    final var clientMetrics = new KafkaClientMetrics(consumer);
-    clientMetrics.bindTo(getRegistry());
-    return clientMetrics;
+    final var registry = getRegistry();
+    if (registry != null) {
+      final var clientMetrics = new KafkaClientMetrics(consumer);
+      clientMetrics.bindTo(registry);
+      return clientMetrics;
+    }
+    return () -> {};
   }
 
   /**
@@ -175,9 +179,13 @@ public class Metrics {
    * @return A meter binder to close once the producer is closed.
    */
   public static <K, V> AutoCloseable register(final Producer<K, V> producer) {
-    final var clientMetrics = new KafkaClientMetrics(producer);
-    clientMetrics.bindTo(getRegistry());
-    return clientMetrics;
+    final var registry = getRegistry();
+    if (registry != null) {
+      final var clientMetrics = new KafkaClientMetrics(producer);
+      clientMetrics.bindTo(registry);
+      return clientMetrics;
+    }
+    return () -> {};
   }
 
   public static PemKeyCertOptions permKeyCertOptions() {

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerMessageHandler.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerMessageHandler.java
@@ -21,8 +21,10 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageConsumer;
+
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,17 +69,19 @@ public class ResourcesReconcilerMessageHandler implements Handler<Message<Object
       logger.info("Reconciling contract {}", keyValue("contractGeneration", contract.getGeneration()));
 
       resourcesReconciler.reconcile(contract.getResourcesList())
-        .onSuccess(v -> logger.info(
-          "Reconciled contract generation {}",
-          keyValue("contractGeneration", contract.getGeneration()))
-        )
-        .onFailure(cause -> logger.error(
-          "Failed to reconcile contract generation {}",
-          keyValue("contractGeneration", contract.getGeneration()),
-          cause
-          )
-        )
         .onComplete(r -> {
+          if (r.succeeded()) {
+            logger.info(
+              "Reconciled contract generation {}",
+              keyValue("contractGeneration", contract.getGeneration())
+            );
+          } else {
+            logger.error(
+              "Failed to reconcile contract generation {}",
+              keyValue("contractGeneration", contract.getGeneration()),
+              r.cause()
+            );
+          }
 
           // We have reconciled the last known contract.
           reconciling.set(false);

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
@@ -95,7 +95,6 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
   private final WebClientOptions webClientOptions;
   private final Map<String, Object> producerConfigs;
   private final AuthProvider authProvider;
-  private final Counter eventsSentCounter;
 
   /**
    * All args constructor.
@@ -116,7 +115,6 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
     Objects.requireNonNull(consumerConfigs, "provide consumerConfigs");
     Objects.requireNonNull(webClientOptions, "provide webClientOptions");
     Objects.requireNonNull(producerConfigs, "provide producerConfigs");
-    Objects.requireNonNull(metricsRegistry, "provide metricsRegistry");
 
     this.consumerConfigs = consumerConfigs.entrySet()
       .stream()
@@ -128,7 +126,6 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
       .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     this.webClientOptions = webClientOptions;
     this.authProvider = authProvider;
-    this.eventsSentCounter = metricsRegistry.counter(Metrics.HTTP_EVENTS_SENT_COUNT);
   }
 
   /**
@@ -195,7 +192,7 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
            egressSubscriberSender,
            egressDeadLetterSender,
            responseHandler,
-           new OffsetManager(vertx, consumer, eventsSentCounter::increment, commitIntervalMs),
+           new OffsetManager(vertx, consumer, (v) -> {}, commitIntervalMs),
            ConsumerTracer.create(
              ((VertxInternal) vertx).tracer(),
              new KafkaClientOptions()

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverEnvTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverEnvTest.java
@@ -42,9 +42,9 @@ class ReceiverEnvTest {
         case ReceiverEnv.HTTPSERVER_CONFIG_FILE_PATH -> HTTPSERVER_CONFIG_FILE_PATH;
         case BaseEnv.PRODUCER_CONFIG_FILE_PATH -> PRODUCER_CONFIG_PATH;
         case BaseEnv.DATA_PLANE_CONFIG_FILE_PATH -> DATA_PLANE_CONFIG_FILE_PATH;
+        case BaseEnv.METRICS_PUBLISH_QUANTILES -> "TRUE";
         case BaseEnv.METRICS_PORT -> "9092";
         case BaseEnv.METRICS_PATH -> "/path";
-        case BaseEnv.METRICS_PUBLISH_QUANTILES -> "TRUE";
         case BaseEnv.CONFIG_TRACING_PATH -> TRACING_CONFIG_PATH;
         case BaseEnv.METRICS_JVM_ENABLED -> METRICS_JVM_ENABLED;
         case BaseEnv.WAIT_STARTUP_SECONDS -> Integer.valueOf(WAIT_STARTUP_SECONDS).toString();


### PR DESCRIPTION
The ordered delivery verticle had a complicated logic
to perform the next poll.

Now, it's more "Vert.x idiomatic".

Tested with some perf test runs at ~1.5k events/s and latency is <1s.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Part of https://github.com/knative-sandbox/eventing-kafka-broker/issues/2125

## Proposed Changes

- Cleanup ordered delivery verticle