### PR TITLE
Disable unnecessary metrics

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
@@ -116,6 +116,11 @@ public class Metrics {
     final var registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
     return new MicrometerMetricsOptions()
       .setEnabled(true)
+      .addDisabledMetricsCategory(MetricsDomain.HTTP_CLIENT)
+      .addDisabledMetricsCategory(MetricsDomain.HTTP_SERVER)
+      .addDisabledMetricsCategory(MetricsDomain.VERTICLES)
+      .addDisabledMetricsCategory(MetricsDomain.NET_CLIENT)
+      .addDisabledMetricsCategory(MetricsDomain.NET_SERVER)
       .addDisabledMetricsCategory(MetricsDomain.EVENT_BUS)
       .addDisabledMetricsCategory(MetricsDomain.DATAGRAM_SOCKET)
       // NAMED_POOL allocates a lot, so disable it.


### PR DESCRIPTION
Vert.x's client, server and verticles metrics adds a lot of
allocations and their metrics exposed add little value in a
kubernetes environment or in our case.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Disable unnecessary metrics

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
`vertx_*` metrics have been removed since they were causing unnecessary allocations.
```
