### PR TITLE
Fix for teardown eventing

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -64,7 +64,6 @@ function knative_teardown() {
   if ! is_release_branch; then
     echo ">> Delete Knative Eventing from HEAD"
     pushd .
-    cd eventing || fail_test "Failed to set up Eventing"
     kubectl delete --ignore-not-found -f "${EVENTING_CONFIG}"
     popd || fail_test "Failed to set up Eventing"
   else


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

Error when running teardown-infra to teardown Knative Eventing resources.
```
>> Delete Knative Eventing from HEAD
~/knative/eventing-kafka-broker ~/knative/eventing-kafka-broker
./hack/../test/e2e-common.sh: line 67: cd: eventing: No such file or directory
ERROR: Failed to set up Eventing
```

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
