### PR TITLE
[clean up] Removing config map finalizer left overs

### DIFF
--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
 	clientgotesting "k8s.io/client-go/testing"
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
 	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
@@ -50,8 +49,6 @@ const (
 
 	TriggerName      = "test-trigger"
 	TriggerNamespace = "test-namespace"
-
-	ConfigMapFinalizerName = "kafka.brokers.eventing.knative.dev/" + BrokerNamespace + "-" + BrokerName
 )
 
 func BrokerTopic() string {
@@ -153,18 +150,6 @@ func BrokerConfig(bootstrapServers string, numPartitions, replicationFactor int,
 		opt(cm)
 	}
 	return cm
-}
-
-func BrokerConfigFinalizer(finalizerName string) CMOption {
-	return func(cm *corev1.ConfigMap) {
-		cm.Finalizers = append(cm.Finalizers, finalizerName)
-	}
-}
-
-func BrokerConfigFinalizerRemove(finalizerName string) CMOption {
-	return func(cm *corev1.ConfigMap) {
-		cm.Finalizers = sets.NewString(cm.Finalizers...).Delete(finalizerName).List()
-	}
 }
 
 func BrokerAuthConfig(name string) CMOption {


### PR DESCRIPTION

Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-  addressing todo and remove remove cm finalizer, since it was already released

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
