### PR TITLE
use builtin MacOS sed in data-plane script

### DIFF
--- a/hack/data-plane.sh
+++ b/hack/data-plane.sh
@@ -154,8 +154,13 @@ function data_plane_build_push() {
 function replace_images() {
   local file=$1
 
-  sed -i "s|\${KNATIVE_KAFKA_DISPATCHER_IMAGE}|${KNATIVE_KAFKA_DISPATCHER_IMAGE}|g" "${file}" &&
-    sed -i "s|\${KNATIVE_KAFKA_RECEIVER_IMAGE}|${KNATIVE_KAFKA_RECEIVER_IMAGE}|g" "${file}"
+  if [[ $OSTYPE == 'darwin'* ]]; then
+    sed -i '' "s|\${KNATIVE_KAFKA_DISPATCHER_IMAGE}|${KNATIVE_KAFKA_DISPATCHER_IMAGE}|g" "${file}" &&
+      sed -i "s|\${KNATIVE_KAFKA_RECEIVER_IMAGE}|${KNATIVE_KAFKA_RECEIVER_IMAGE}|g" "${file}"
+  else
+    sed -i "s|\${KNATIVE_KAFKA_DISPATCHER_IMAGE}|${KNATIVE_KAFKA_DISPATCHER_IMAGE}|g" "${file}" &&
+      sed -i "s|\${KNATIVE_KAFKA_RECEIVER_IMAGE}|${KNATIVE_KAFKA_RECEIVER_IMAGE}|g" "${file}"
+  fi
 
   return $?
 }
@@ -209,7 +214,10 @@ function data_plane_sourcev2_setup() {
 
   ko resolve ${KO_FLAGS} -Rf ${SOURCEV2_DATA_PLANE_CONFIG_DIR} | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_SOURCE_BUNDLE_ARTIFACT}"
 
-  sed -i "s|\${KNATIVE_KAFKA_DISPATCHER_IMAGE}|${KNATIVE_KAFKA_DISPATCHER_IMAGE}|g" "${EVENTING_KAFKA_SOURCE_BUNDLE_ARTIFACT}"
-
+  if [[ $OSTYPE == 'darwin'* ]]; then
+    sed -i '' "s|\${KNATIVE_KAFKA_DISPATCHER_IMAGE}|${KNATIVE_KAFKA_DISPATCHER_IMAGE}|g" "${EVENTING_KAFKA_SOURCE_BUNDLE_ARTIFACT}"
+  else
+    sed -i "s|\${KNATIVE_KAFKA_DISPATCHER_IMAGE}|${KNATIVE_KAFKA_DISPATCHER_IMAGE}|g" "${EVENTING_KAFKA_SOURCE_BUNDLE_ARTIFACT}"
+  fi
   return $?
 }

--- a/hack/data-plane.sh
+++ b/hack/data-plane.sh
@@ -59,6 +59,12 @@ if ! function_exists header; then
   }
 fi
 
+# Use GNU tools on macOS. Requires the 'grep' and 'gnu-sed' Homebrew formulae.
+if [ "$(uname)" == "Darwin" ]; then
+  sed=gsed
+  grep=ggrep
+fi
+
 function image_push() {
   if ${SKIP_PUSH}; then
     return
@@ -154,13 +160,8 @@ function data_plane_build_push() {
 function replace_images() {
   local file=$1
 
-  if [[ $OSTYPE == 'darwin'* ]]; then
-    sed -i '' "s|\${KNATIVE_KAFKA_DISPATCHER_IMAGE}|${KNATIVE_KAFKA_DISPATCHER_IMAGE}|g" "${file}" &&
-      sed -i "s|\${KNATIVE_KAFKA_RECEIVER_IMAGE}|${KNATIVE_KAFKA_RECEIVER_IMAGE}|g" "${file}"
-  else
-    sed -i "s|\${KNATIVE_KAFKA_DISPATCHER_IMAGE}|${KNATIVE_KAFKA_DISPATCHER_IMAGE}|g" "${file}" &&
-      sed -i "s|\${KNATIVE_KAFKA_RECEIVER_IMAGE}|${KNATIVE_KAFKA_RECEIVER_IMAGE}|g" "${file}"
-  fi
+  sed -i "s|\${KNATIVE_KAFKA_DISPATCHER_IMAGE}|${KNATIVE_KAFKA_DISPATCHER_IMAGE}|g" "${file}" &&
+    sed -i "s|\${KNATIVE_KAFKA_RECEIVER_IMAGE}|${KNATIVE_KAFKA_RECEIVER_IMAGE}|g" "${file}"
 
   return $?
 }
@@ -214,10 +215,7 @@ function data_plane_sourcev2_setup() {
 
   ko resolve ${KO_FLAGS} -Rf ${SOURCEV2_DATA_PLANE_CONFIG_DIR} | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_SOURCE_BUNDLE_ARTIFACT}"
 
-  if [[ $OSTYPE == 'darwin'* ]]; then
-    sed -i '' "s|\${KNATIVE_KAFKA_DISPATCHER_IMAGE}|${KNATIVE_KAFKA_DISPATCHER_IMAGE}|g" "${EVENTING_KAFKA_SOURCE_BUNDLE_ARTIFACT}"
-  else
-    sed -i "s|\${KNATIVE_KAFKA_DISPATCHER_IMAGE}|${KNATIVE_KAFKA_DISPATCHER_IMAGE}|g" "${EVENTING_KAFKA_SOURCE_BUNDLE_ARTIFACT}"
-  fi
+  sed -i "s|\${KNATIVE_KAFKA_DISPATCHER_IMAGE}|${KNATIVE_KAFKA_DISPATCHER_IMAGE}|g" "${EVENTING_KAFKA_SOURCE_BUNDLE_ARTIFACT}"
+
   return $?
 }


### PR DESCRIPTION
Fixes #2137

Build ./hack/run.sh fails with sed error in MacOS 

## Proposed Changes
- use builtin MacOS sed in data-plane script - that should *always* work even in gsed is not installed

