### PR TITLE
Bind and close Kafka client metrics provider asynchronously

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/AsyncCloseable.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/AsyncCloseable.java
@@ -79,38 +79,4 @@ public interface AsyncCloseable extends Closeable {
         v -> compose(closeableIterator)
       );
   }
-
-  /**
-   * Wrap the provided blocking {@link AutoCloseable} into an {@link AsyncCloseable}.
-   * This is going to use the current context when the close is invoked.
-   *
-   * @param closeable the closeable to wrap
-   * @return the wrapped closeable
-   */
-  static AsyncCloseable wrapAutoCloseable(AutoCloseable closeable) {
-    return () -> {
-      Context context = Vertx.currentContext();
-
-      if (context == null) {
-        // I'm not on the event loop, I can just execute this as is!
-        try {
-          closeable.close();
-          return Future.succeededFuture();
-        } catch (Exception e) {
-          return Future.failedFuture(e);
-        }
-      }
-
-      // I'm on the event loop, I need to execute blocking.
-      return context.executeBlocking(promise -> {
-        try {
-          closeable.close();
-          promise.complete();
-        } catch (Exception e) {
-          promise.fail(e);
-        }
-      });
-    };
-  }
-
 }

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/IngressProducerReconcilableStore.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/IngressProducerReconcilableStore.java
@@ -137,14 +137,14 @@ public class IngressProducerReconcilableStore implements IngressReconcilerListen
         producerProps
       );
 
-      if(isRootPath(ingress.getPath()) && Strings.isNullOrEmpty(ingress.getHost())){
+      if (isRootPath(ingress.getPath()) && Strings.isNullOrEmpty(ingress.getHost())) {
         throw new IllegalArgumentException("Ingress path and host is blank. One of them should be defined. Resource UID: " + resource.getUid());
       }
 
-      if(!isRootPath(ingress.getPath())){
+      if (!isRootPath(ingress.getPath())) {
         this.pathMapper.put(ingress.getPath(), ingressInfo);
       }
-      if (!Strings.isNullOrEmpty(ingress.getHost())){
+      if (!Strings.isNullOrEmpty(ingress.getHost())) {
         this.hostMapper.put(ingress.getHost(), ingressInfo);
       }
       this.ingressInfos.put(resource.getUid(), ingressInfo);
@@ -183,20 +183,20 @@ public class IngressProducerReconcilableStore implements IngressReconcilerListen
       return rc.getValue().close()
         .onSuccess(r -> {
           // Remove ingress info from the maps
-          if(!isRootPath(ingressInfo.getPath())){
+          if (!isRootPath(ingressInfo.getPath())) {
             this.pathMapper.remove(ingressInfo.getPath());
           }
-          if(!Strings.isNullOrEmpty(ingressInfo.getHost())){
+          if (!Strings.isNullOrEmpty(ingressInfo.getHost())) {
             this.hostMapper.remove(ingressInfo.getHost());
           }
           this.ingressInfos.remove(resource.getUid());
         });
     }
     // Remove ingress info from the maps
-    if(!isRootPath(ingressInfo.getPath())){
+    if (!isRootPath(ingressInfo.getPath())) {
       this.pathMapper.remove(ingressInfo.getPath());
     }
-    if(!Strings.isNullOrEmpty(ingressInfo.getHost())){
+    if (!Strings.isNullOrEmpty(ingressInfo.getHost())) {
       this.hostMapper.remove(ingressInfo.getHost());
     }
     this.ingressInfos.remove(resource.getUid());
@@ -217,7 +217,7 @@ public class IngressProducerReconcilableStore implements IngressReconcilerListen
     private static final Logger logger = LoggerFactory.getLogger(ProducerHolder.class);
 
     private final KafkaProducer<String, CloudEvent> producer;
-    private final AutoCloseable producerMeterBinder;
+    private final AsyncCloseable producerMeterBinder;
 
     ProducerHolder(final KafkaProducer<String, CloudEvent> producer) {
       this.producer = producer;
@@ -241,10 +241,9 @@ public class IngressProducerReconcilableStore implements IngressReconcilerListen
     }
 
     private Future<Void> closeNow() {
-      return AsyncCloseable.compose(
-        producer::close,
-        AsyncCloseable.wrapAutoCloseable(this.producerMeterBinder)
-      ).close();
+      return AsyncCloseable
+        .compose(this.producerMeterBinder, producer::close)
+        .close();
     }
   }
 


### PR DESCRIPTION
The binding and closing process of the metrics reporter is blocking,
so that blocks our data plane verticle deployer.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>
