### PR TITLE
Add -XX:+CrashOnOutOfMemoryError flag

### DIFF
--- a/data-plane/config/broker/500-dispatcher.yaml
+++ b/data-plane/config/broker/500-dispatcher.yaml
@@ -116,6 +116,7 @@ spec:
           command:
             - "java"
           args:
+            - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"

--- a/data-plane/config/broker/500-receiver.yaml
+++ b/data-plane/config/broker/500-receiver.yaml
@@ -117,6 +117,7 @@ spec:
           command:
             - "java"
           args:
+            - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"

--- a/data-plane/config/brokerv2/500-dispatcher.yaml
+++ b/data-plane/config/brokerv2/500-dispatcher.yaml
@@ -119,6 +119,7 @@ spec:
           command:
             - "java"
           args:
+            - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"

--- a/data-plane/config/channel/500-dispatcher.yaml
+++ b/data-plane/config/channel/500-dispatcher.yaml
@@ -116,6 +116,7 @@ spec:
           command:
             - "java"
           args:
+            - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"

--- a/data-plane/config/channel/500-receiver.yaml
+++ b/data-plane/config/channel/500-receiver.yaml
@@ -117,6 +117,7 @@ spec:
           command:
             - "java"
           args:
+            - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"

--- a/data-plane/config/channelv2/500-dispatcher.yaml
+++ b/data-plane/config/channelv2/500-dispatcher.yaml
@@ -119,6 +119,7 @@ spec:
           command:
             - "java"
           args:
+            - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"

--- a/data-plane/config/sink/500-receiver.yaml
+++ b/data-plane/config/sink/500-receiver.yaml
@@ -117,6 +117,7 @@ spec:
           command:
             - "java"
           args:
+            - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"

--- a/data-plane/config/source/500-dispatcher.yaml
+++ b/data-plane/config/source/500-dispatcher.yaml
@@ -116,6 +116,7 @@ spec:
           command:
             - "java"
           args:
+            - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"

--- a/data-plane/config/sourcev2/500-dispatcher.yaml
+++ b/data-plane/config/sourcev2/500-dispatcher.yaml
@@ -119,6 +119,7 @@ spec:
           command:
             - "java"
           args:
+            - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"


### PR DESCRIPTION
Sometimes there are OOM errors when memory limits are set,
so by specifying this flag we get:
- a readable report of what happened
- the pod is restarted instead of leaving the JVM in a broken
  state

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>