### PR TITLE
when no user cert and key then do user.skip

### DIFF
--- a/control-plane/pkg/security/secret.go
+++ b/control-plane/pkg/security/secret.go
@@ -165,18 +165,20 @@ func sslConfig(protocol string, data map[string][]byte) kafka.ConfigOption {
 			if err != nil {
 				return fmt.Errorf("[protocol %s] %w", protocol, err)
 			}
-
+			userKeyCert, userKeyExists := data[UserKey]
+			userCert, userCertExists := data[UserCertificate]
+			if !skipClientAuth && !userKeyExists && !userCertExists {
+				skipClientAuth = true
+			}
 			if !skipClientAuth {
-				userKeyCert, ok := data[UserKey]
-				if !ok {
+				if !userKeyExists {
 					return fmt.Errorf(
 						`[protocol %s] required user key (key: %s) - use "%s: true" to disable client auth`,
 						protocol, UserKey, UserSkip,
 					)
 				}
 
-				userCert, ok := data[UserCertificate]
-				if !ok {
+				if !userCertExists {
 					return fmt.Errorf(
 						`[protocol %s] required user key (key: %s) - use "%s: true" to disable client auth`,
 						protocol, UserCertificate, UserSkip,

--- a/control-plane/pkg/security/secret_test.go
+++ b/control-plane/pkg/security/secret_test.go
@@ -245,6 +245,23 @@ func TestSSLNoClientAuth(t *testing.T) {
 	ca, _, _ := loadCerts(t)
 
 	secret := map[string][]byte{
+		"protocol": []byte("SSL"),
+		"ca.crt":   ca,
+	}
+	config := sarama.NewConfig()
+
+	err := kafka.Options(config, secretData(secret))
+
+	assert.Nil(t, err)
+	assert.True(t, config.Net.TLS.Enable)
+	assert.NotNil(t, config.Net.TLS.Config.RootCAs)
+	assert.Greater(t, len(config.Net.TLS.Config.RootCAs.Subjects()), 0)
+}
+
+func TestSSLNoClientAuthUserSkip(t *testing.T) {
+	ca, _, _ := loadCerts(t)
+
+	secret := map[string][]byte{
 		"protocol":  []byte("SSL"),
 		"user.skip": []byte("true"),
 		"ca.crt":    ca,

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/CredentialsValidator.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/CredentialsValidator.java
@@ -37,6 +37,9 @@ class CredentialsValidator {
       if (credentials.skipClientAuth()) {
         return null;
       }
+      if (allBlank(credentials.userCertificate(), credentials.userKey())) {
+        return null;
+      }
       if (anyBlank(credentials.userCertificate(), credentials.userKey())) {
         return "Security protocol " + securityProtocol.name + ": invalid user certificate or user key or CA certificates";
       }
@@ -90,4 +93,14 @@ class CredentialsValidator {
     }
     return false;
   }
+
+  private static boolean allBlank(final String... stores) {
+    for (final var s : stores) {
+      if (!isBlank(s)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
 }


### PR DESCRIPTION
Fixes #2162

## Proposed Changes
- Allow Kafka Source configuration with no user cert and key (equivalent to user.skip true)
