### PR TITLE
Being explicit about authorization for our test kafkausers

### DIFF
--- a/test/kafka/kafka-ephemeral.yaml
+++ b/test/kafka/kafka-ephemeral.yaml
@@ -49,6 +49,8 @@ spec:
         tls: false
         authentication:
           type: scram-sha-512
+    authorization:
+      type: simple
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Being explicit about authorization for our test kafkausers. Because: In newer versions of (like 0.27+) Strimzi changed the approach from silently ignoring it to rejecting `KafkaUser` with `Authorization` when the cluster has it (Authorization) disabled.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
