### PR TITLE
Remove old Config Kafka CM for old/legacy channel

### DIFF
--- a/control-plane/cmd/post-install/kafka_channel_post_migration_deleter.go
+++ b/control-plane/cmd/post-install/kafka_channel_post_migration_deleter.go
@@ -141,6 +141,15 @@ func (d *kafkaChannelPostMigrationDeleter) Delete(ctx context.Context) error {
 		return fmt.Errorf("failed to delete Lease %s: %w", kafkaChannelDispatcherLease, err)
 	}
 
+	// Delete configmap/config-kafka
+	const kafkaChannelConfigmap = "config-kafka"
+	err = d.k8s.
+		CoreV1().
+		ConfigMaps(system.Namespace()).
+		Delete(ctx, kafkaChannelConfigmap, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete Configmap %s: %w", kafkaChannelConfigmap, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- the `config-kafka` CM was not removed
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
