### PR TITLE
Fix RBAC for deletion of configmaps

### DIFF
--- a/control-plane/config/post-install/200-controller-cluster-role.yaml
+++ b/control-plane/config/post-install/200-controller-cluster-role.yaml
@@ -181,24 +181,18 @@ rules:
     verbs:
       - delete
 
+  # to be able to read the old configmap and migrate
+  # and then delete them
   - apiGroups:
       - "*"
     resources:
       - configmaps
     resourceNames:
       - config-leader-election-kafkachannel
-    verbs:
-      - delete
-
-  # to be able to read the old configmap and migrate it
-  - apiGroups:
-      - "*"
-    resources:
-      - configmaps
-    resourceNames:
       - config-kafka
     verbs:
       - get
+      - delete
 
   # to be able update config in the new configmap
   - apiGroups:


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fix RBAC issue
- Post migration deleter was not able to delete some configmaps
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
