### PR TITLE
[release-1.4] Disable Sarama metrics since they are not exposed (#2225)

### DIFF
--- a/control-plane/pkg/kafka/client.go
+++ b/control-plane/pkg/kafka/client.go
@@ -18,7 +18,13 @@ package kafka
 
 import (
 	"github.com/Shopify/sarama"
+	"github.com/rcrowley/go-metrics"
 )
+
+func init() {
+	// Disable Sarama metrics
+	metrics.UseNilMetrics = true
+}
 
 type ConfigOption func(config *sarama.Config) error
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pierdipi/sacura v0.0.0-20210302185533-982357fc042b
+	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/rickb777/date v1.14.1
 	github.com/stretchr/testify v1.7.0
 	github.com/xdg-go/scram v1.1.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -345,6 +345,7 @@ github.com/prometheus/procfs/internal/util
 github.com/prometheus/statsd_exporter/pkg/mapper
 github.com/prometheus/statsd_exporter/pkg/mapper/fsm
 # github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
+## explicit
 github.com/rcrowley/go-metrics
 # github.com/rickb777/date v1.14.1
 ## explicit


### PR DESCRIPTION
Cherry-pick of https://github.com/knative-sandbox/eventing-kafka-broker/pull/2225

Sarama metrics consume a lot of memory but we don't use/expose them.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>