### PR TITLE
Fix backtick in Channel docs

### DIFF
--- a/docs/channel/README.md
+++ b/docs/channel/README.md
@@ -264,7 +264,7 @@ See [configuring dataplane](#configuring-dataplane) section for more details.
 
 The new channel implementation requires the secret to have
 - A new key in the secret called `protocol`
-- Key called `sasl.mechanism` instead of `saslType
+- Key called `sasl.mechanism` instead of `saslType`
 
 New channel implementation still supports the old secret format by inferring the `protocol` and `sasl.mechanism` from the values
 in the old secret. However, this fallback will be deprecated and it is advised that you manually adjust your secrets to have these


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fix backtick in Channel docs
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
