### PR TITLE
[WIP] Avoid waiting for `Consumer.close` when removing resources

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/BaseConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/BaseConsumerVerticle.java
@@ -74,8 +74,13 @@ public abstract class BaseConsumerVerticle extends AbstractVerticle {
     logger.info("Stopping consumer");
 
     AsyncCloseable
-      .compose(this.recordDispatcher, this.closeable, this.consumer::close)
+      .compose(this.recordDispatcher, this.closeable)
       .close(stopPromise);
+
+    stopPromise.future()
+      .onComplete(v -> this.consumer.close()
+        .onFailure(cause -> logger.error("Failed to close consumer {}", keyValue("topics", topics), cause))
+      );
   }
 
   public void setConsumer(KafkaConsumer<Object, CloudEvent> consumer) {


### PR DESCRIPTION
In an E2E test run, we saw that failing to close a consumer
will cause the reconciler to stop reconciling resources.

  - [1] the data plane reconciler saw that we need to remove a
    resource
  - since the previous removal never "completes" (as we're
    waiting for the callback to complete), newer contract
    generations [2] are never reconciled

[1]

```
{"@timestamp":"2022-06-06T11:46:44.775Z","@version":"1","message":"Set new contract contractGeneration=107","logger_name":"dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler","thread_name":"vert.x-eventloop-thread-0","level":"INFO","level_value":20000,"contractGeneration":107}
{"@timestamp":"2022-06-06T11:46:44.775Z","@version":"1","message":"Reconciling contract contractGeneration=107","logger_name":"dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler","thread_name":"vert.x-eventloop-thread-0","level":"INFO","level_value":20000,"contractGeneration":107}
{"@timestamp":"2022-06-06T11:46:44.775Z","@version":"1","message":"Reconcile egress diff DiffResult{added=[], intersection=[], removed=[d5f66d67-03f1-440e-a7b1-d8408107b5dc]}","logger_name":"dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerImpl","thread_name":"vert.x-eventloop-thread-0","level":"INFO","level_value":20000}
{"@timestamp":"2022-06-06T11:46:44.775Z","@version":"1","message":"Stopping consumer","logger_name":"dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.BaseConsumerVerticle","thread_name":"vert.x-eventloop-thread-0","level":"INFO","level_value":20000}
```

in particular, only one egress (KafkaSource) was removed at contract generation 107
```
Reconcile egress diff DiffResult{added=[], intersection=[], removed=[d5f66d67-03f1-440e-a7b1-d8408107b5dc]
```

[2]
```
{"@timestamp":"2022-06-06T11:46:55.564Z","@version":"1","message":"Set new contract contractGeneration=108","logger_name":"dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler","thread_name":"vert.x-eventloop-thread-0","level":"INFO","level_value":20000,"contractGeneration":108}
{"@timestamp":"2022-06-06T11:46:56.27Z","@version":"1","message":"Set new contract contractGeneration=109","logger_name":"dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler","thread_name":"vert.x-eventloop-thread-0","level":"INFO","level_value":20000,"contractGeneration":109}
{"@timestamp":"2022-06-06T11:46:57.28Z","@version":"1","message":"Set new contract contractGeneration=110","logger_name":"dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler","thread_name":"vert.x-eventloop-thread-0","level":"INFO","level_value":20000,"contractGeneration":110}
{"@timestamp":"2022-06-06T11:47:02.216Z","@version":"1","message":"Set new contract contractGeneration=111","logger_name":"dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler","thread_name":"vert.x-eventloop-thread-0","level":"INFO","level_value":20000,"contractGeneration":111}
{"@timestamp":"2022-06-06T11:47:10.103Z","@version":"1","message":"Set new contract contractGeneration=112","logger_name":"dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler","thread_name":"vert.x-eventloop-thread-0","level":"INFO","level_value":20000,"contractGeneration":112}
```

we will never see:
```
Reconciling contract contractGeneration=108 or
Reconciling contract contractGeneration=109
```

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
