### PR TITLE
Do not create scheduler for channel & trigger (till we move to v2)

### DIFF
--- a/control-plane/pkg/reconciler/consumergroup/controller.go
+++ b/control-plane/pkg/reconciler/consumergroup/controller.go
@@ -95,9 +95,9 @@ func NewController(ctx context.Context) *controller.Impl {
 	}
 
 	schedulers := map[string]scheduler.Scheduler{
-		KafkaSourceScheduler:  createKafkaScheduler(ctx, c, kafkainternals.SourceStatefulSetName),
-		KafkaTriggerScheduler: createKafkaScheduler(ctx, c, kafkainternals.BrokerStatefulSetName),
-		KafkaChannelScheduler: createKafkaScheduler(ctx, c, kafkainternals.ChannelStatefulSetName),
+		KafkaSourceScheduler: createKafkaScheduler(ctx, c, kafkainternals.SourceStatefulSetName),
+		//KafkaTriggerScheduler: createKafkaScheduler(ctx, c, kafkainternals.BrokerStatefulSetName), //To be added with trigger/v2 reconciler version only
+		//KafkaChannelScheduler: createKafkaScheduler(ctx, c, kafkainternals.ChannelStatefulSetName), //To be added with channel/v2 reconciler version only
 	}
 
 	r := &Reconciler{


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

Controller logs were getting filled with info logs for channel & trigger due to absence of v2 sts dispatchers (that will be added only when we move to HA v2 version). We currently only have source HA STS dispatchers that run the replica scheduler. So commenting this out temporarily.

```
{"level":"info","ts":"2022-06-09T07:52:03.927Z","logger":"kafka-broker-controller","caller":"state/state.go:178","msg":"failed to get statefulset","knative.dev/pod":"kafka-controller-7bcd565879-9lc6c","error":"statefulsets.apps \"kafka-channel-dispatcher\" not found"}
{"level":"info","ts":"2022-06-09T07:52:03.927Z","logger":"kafka-broker-controller","caller":"statefulset/autoscaler.go:122","msg":"error while refreshing scheduler state (will retry){error 26 0  statefulsets.apps \"kafka-channel-dispatcher\" not found}","knative.dev/pod":"kafka-controller-7bcd565879-9lc6c"}
{"level":"info","ts":"2022-06-09T07:52:03.927Z","logger":"kafka-broker-controller","caller":"state/state.go:178","msg":"failed to get statefulset","knative.dev/pod":"kafka-controller-7bcd565879-9lc6c","error":"statefulsets.apps \"kafka-broker-dispatcher\" not found"}
{"level":"info","ts":"2022-06-09T07:52:03.927Z","logger":"kafka-broker-controller","caller":"statefulset/autoscaler.go:122","msg":"error while refreshing scheduler state (will retry){error 26 0  statefulsets.apps \"kafka-broker-dispatcher\" not found}","knative.dev/pod":"kafka-controller-7bcd565879-9lc6c"}
```

/cc @matzew @pierDipi 