### PR TITLE
Test gcloud authentication 

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+gcloud auth list
+
 source $(dirname $0)/e2e-common.sh
 
 if ! ${SKIP_INITIALIZE}; then


### PR DESCRIPTION
Test PR.

There is something weird going on with google authentication.

https://storage.googleapis.com/knative-prow/pr-logs/pull/knative-sandbox_eventing-kafka-broker/2300/channel-integration-tests-sasl-plain_eventing-kafka-broker_main/1536398575720730624/build-log.txt

We authenticate properly as you can see on 8, but further down, you get errors about Workload Identity which we haven't enabled yet.