### PR TITLE
Minor change for KafkaSource bundle setup with arm64

### DIFF
--- a/hack/data-plane.sh
+++ b/hack/data-plane.sh
@@ -131,7 +131,15 @@ function data_plane_setup() {
 }
 
 function data_plane_source_setup() {
+  pushd "${DATA_PLANE_DIR}" || return $?
+  ./mvnw install -DskipTests || fail_test "failed to install data plane"
   dispatcher_build_push || dispatcher_build_push || fail_test "failed to build dispatcher"
+  popd || return $?
+
+  if [ "$KO_DOCKER_REPO" = "kind.local" ]; then
+    kind load docker-image "${KNATIVE_KAFKA_DISPATCHER_IMAGE}"
+  fi
+
   header "Creating artifacts"
 
   echo "Dispatcher image ---> ${KNATIVE_KAFKA_DISPATCHER_IMAGE}"


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

Related to #1968 

Deploying KafkaSource bundle was failing with error:
```
/Users/ansuvarghese/knative/eventing-kafka-broker/hack/data-plane.sh: line 70: ./mvnw: No such file or directory
```