### PR TITLE
Fallback mechanism for the old external topic annotation for broker

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -49,6 +49,9 @@ const (
 	// TopicPrefix is the Kafka Broker topic prefix - (topic name: knative-broker-<broker-namespace>-<broker-name>).
 	TopicPrefix = "knative-broker-"
 
+	// NOTE: this may go away in a future release
+	LegacyExternalTopicAnnotation = "x-kafka.eventing.knative.dev/external.topic"
+
 	// ExternalTopicAnnotation for using external kafka topic for the broker
 	ExternalTopicAnnotation = "kafka.eventing.knative.dev/external.topic"
 )
@@ -494,5 +497,9 @@ func (r *Reconciler) reconcilerBrokerResource(ctx context.Context, topic string,
 
 func isExternalTopic(broker *eventing.Broker) (string, bool) {
 	topicAnnotationValue, ok := broker.Annotations[ExternalTopicAnnotation]
+	if !ok {
+		// fallback to the old annotation
+		topicAnnotationValue, ok = broker.Annotations[LegacyExternalTopicAnnotation]
+	}
 	return topicAnnotationValue, ok
 }

--- a/control-plane/pkg/reconciler/broker/broker_test.go
+++ b/control-plane/pkg/reconciler/broker/broker_test.go
@@ -242,6 +242,73 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 			},
 		},
 		{
+			Name: "Reconciled normal - with external topic - legacy annotation",
+			Objects: []runtime.Object{
+				NewBroker(
+					WithLegacyExternalTopic(ExternalTopicName),
+				),
+				BrokerConfig(bootstrapServers, 20, 5),
+				NewConfigMapWithBinaryData(&env, nil),
+				NewService(),
+				BrokerReceiverPod(env.SystemNamespace, map[string]string{
+					base.VolumeGenerationAnnotationKey: "0",
+					"annotation_to_preserve":           "value_to_preserve",
+				}),
+				BrokerDispatcherPod(env.SystemNamespace, map[string]string{
+					base.VolumeGenerationAnnotationKey: "0",
+					"annotation_to_preserve":           "value_to_preserve",
+				}),
+			},
+			Key: testKey,
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
+			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapUpdate(&env, &contract.Contract{
+					Resources: []*contract.Resource{
+						{
+							Uid:              BrokerUUID,
+							Topics:           []string{ExternalTopicName},
+							Ingress:          &contract.Ingress{Path: receiver.Path(BrokerNamespace, BrokerName)},
+							BootstrapServers: bootstrapServers,
+							Reference:        BrokerReference(),
+						},
+					},
+					Generation: 1,
+				}),
+				BrokerReceiverPodUpdate(env.SystemNamespace, map[string]string{
+					base.VolumeGenerationAnnotationKey: "1",
+					"annotation_to_preserve":           "value_to_preserve",
+				}),
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
+					base.VolumeGenerationAnnotationKey: "1",
+					"annotation_to_preserve":           "value_to_preserve",
+				}),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: NewBroker(
+						WithLegacyExternalTopic(ExternalTopicName),
+						reconcilertesting.WithInitBrokerConditions,
+						StatusBrokerConfigMapUpdatedReady(&env),
+						StatusBrokerDataPlaneAvailable,
+						StatusBrokerConfigParsed,
+						StatusExternalBrokerTopicReady(ExternalTopicName),
+						BrokerAddressable(&env),
+						StatusBrokerProbeSucceeded,
+						BrokerConfigMapAnnotations(),
+					),
+				},
+			},
+
+			OtherTestData: map[string]interface{}{
+				externalTopic: ExternalTopicName,
+			},
+		},
+		{
 			Name: "external topic not present or invalid",
 			Objects: []runtime.Object{
 				NewBroker(
@@ -269,6 +336,46 @@ func brokerReconciliation(t *testing.T, format string, env config.Env) {
 				{
 					Object: NewBroker(
 						WithExternalTopic("my-not-present-topic"),
+						reconcilertesting.WithInitBrokerConditions,
+						StatusBrokerDataPlaneAvailable,
+						StatusBrokerConfigParsed,
+						StatusExternalBrokerTopicNotPresentOrInvalid("my-not-present-topic"),
+						BrokerConfigMapAnnotations(),
+					),
+				},
+			},
+			OtherTestData: map[string]interface{}{
+				externalTopic: "my-not-present-topic",
+			},
+		},
+		{
+			Name: "external topic not present or invalid - legacy annotation",
+			Objects: []runtime.Object{
+				NewBroker(
+					WithLegacyExternalTopic("my-not-present-topic"),
+				),
+				BrokerConfig(bootstrapServers, 20, 5),
+				BrokerReceiverPod(env.SystemNamespace, nil),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
+			},
+			Key:     testKey,
+			WantErr: true,
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+				Eventf(
+					corev1.EventTypeWarning,
+					"InternalError",
+					"topics %v not present or invalid: invalid topic %s",
+					[]string{"my-not-present-topic"}, "my-not-present-topic",
+				),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: NewBroker(
+						WithLegacyExternalTopic("my-not-present-topic"),
 						reconcilertesting.WithInitBrokerConditions,
 						StatusBrokerDataPlaneAvailable,
 						StatusBrokerConfigParsed,

--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -144,6 +144,17 @@ func WithExternalTopic(topic string) func(*eventing.Broker) {
 	}
 }
 
+func WithLegacyExternalTopic(topic string) func(*eventing.Broker) {
+	return func(broker *eventing.Broker) {
+		annotations := broker.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string, 1)
+		}
+		annotations[LegacyExternalTopicAnnotation] = topic
+		broker.SetAnnotations(annotations)
+	}
+}
+
 type CMOption func(cm *corev1.ConfigMap)
 
 func BrokerConfig(bootstrapServers string, numPartitions, replicationFactor int, options ...CMOption) *corev1.ConfigMap {


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fallback mechanism for the old external topic annotation for broker
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
As some users of the KafkaBroker use `x-kafka.eventing.knative.dev/external.topic` annotation for specifying an external topic instead of the new annotation (`kafka.eventing.knative.dev/external.topic`), a fallback mechanism is added to support it. New annotation has precedence over the old one.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
