### PR TITLE
[Prefactoring] Make some methods accept namespaces instead of using system namespace

### DIFF
--- a/control-plane/pkg/reconciler/base/reconciler.go
+++ b/control-plane/pkg/reconciler/base/reconciler.go
@@ -221,18 +221,18 @@ func (r *Reconciler) UpdateDataPlaneConfigMap(ctx context.Context, contract *con
 	return nil
 }
 
-func (r *Reconciler) UpdateDispatcherPodsAnnotation(ctx context.Context, logger *zap.Logger, volumeGeneration uint64) error {
-	pods, errors := r.PodLister.Pods(r.SystemNamespace).List(r.dispatcherSelector())
+func (r *Reconciler) UpdateDispatcherPodsAnnotation(ctx context.Context, namespace string, logger *zap.Logger, volumeGeneration uint64) error {
+	pods, errors := r.PodLister.Pods(namespace).List(r.dispatcherSelector())
 	if errors != nil {
-		return fmt.Errorf("failed to list dispatcher pods in namespace %s: %w", r.SystemNamespace, errors)
+		return fmt.Errorf("failed to list dispatcher pods in namespace %s: %w", namespace, errors)
 	}
 	return r.UpdatePodsAnnotation(ctx, logger, "dispatcher", volumeGeneration, pods)
 }
 
-func (r *Reconciler) UpdateReceiverPodsAnnotation(ctx context.Context, logger *zap.Logger, volumeGeneration uint64) error {
-	pods, errors := r.PodLister.Pods(r.SystemNamespace).List(r.ReceiverSelector())
+func (r *Reconciler) UpdateReceiverPodsAnnotation(ctx context.Context, namespace string, logger *zap.Logger, volumeGeneration uint64) error {
+	pods, errors := r.PodLister.Pods(namespace).List(r.ReceiverSelector())
 	if errors != nil {
-		return fmt.Errorf("failed to list receiver pods in namespace %s: %w", r.SystemNamespace, errors)
+		return fmt.Errorf("failed to list receiver pods in namespace %s: %w", namespace, errors)
 	}
 	return r.UpdatePodsAnnotation(ctx, logger, "receiver", volumeGeneration, pods)
 }

--- a/control-plane/pkg/reconciler/base/reconciler.go
+++ b/control-plane/pkg/reconciler/base/reconciler.go
@@ -87,13 +87,13 @@ type Reconciler struct {
 	ReceiverLabel   string
 }
 
-func (r *Reconciler) IsReceiverRunning() bool {
-	pods, err := r.PodLister.List(r.ReceiverSelector())
+func (r *Reconciler) IsReceiverRunning(namespace string) bool {
+	pods, err := r.PodLister.Pods(namespace).List(r.ReceiverSelector())
 	return err == nil && len(pods) > 0 && isAtLeastOneRunning(pods)
 }
 
-func (r *Reconciler) IsDispatcherRunning() bool {
-	pods, err := r.PodLister.List(r.dispatcherSelector())
+func (r *Reconciler) IsDispatcherRunning(namespace string) bool {
+	pods, err := r.PodLister.Pods(namespace).List(r.dispatcherSelector())
 	return err == nil && len(pods) > 0 && isAtLeastOneRunning(pods)
 }
 

--- a/control-plane/pkg/reconciler/base/reconciler_test.go
+++ b/control-plane/pkg/reconciler/base/reconciler_test.go
@@ -211,7 +211,7 @@ func TestUpdateReceiverPodAnnotation(t *testing.T) {
 		ReceiverLabel: base.SinkReceiverLabel,
 	}
 
-	err := r.UpdateReceiverPodsAnnotation(ctx, logging.FromContext(ctx).Desugar(), 1)
+	err := r.UpdateReceiverPodsAnnotation(ctx, "ns", logging.FromContext(ctx).Desugar(), 1)
 	require.Nil(t, err)
 }
 
@@ -228,7 +228,7 @@ func TestUpdateDispatcherPodAnnotation(t *testing.T) {
 		DispatcherLabel: label,
 	}
 
-	err := r.UpdateDispatcherPodsAnnotation(ctx, logging.FromContext(ctx).Desugar(), 1)
+	err := r.UpdateDispatcherPodsAnnotation(ctx, "ns", logging.FromContext(ctx).Desugar(), 1)
 	require.Nil(t, err)
 }
 

--- a/control-plane/pkg/reconciler/base/reconciler_test.go
+++ b/control-plane/pkg/reconciler/base/reconciler_test.go
@@ -52,7 +52,7 @@ func TestIsReceiverRunning(t *testing.T) {
 		ReceiverLabel: base.BrokerReceiverLabel,
 	}
 
-	require.True(t, r.IsReceiverRunning())
+	require.True(t, r.IsReceiverRunning("ns"))
 }
 
 func TestIsReceiverNotRunning(t *testing.T) {
@@ -63,7 +63,7 @@ func TestIsReceiverNotRunning(t *testing.T) {
 		ReceiverLabel: base.BrokerReceiverLabel,
 	}
 
-	require.False(t, r.IsReceiverRunning())
+	require.False(t, r.IsReceiverRunning("ns"))
 }
 
 func TestIsDispatcherRunning(t *testing.T) {
@@ -78,7 +78,7 @@ func TestIsDispatcherRunning(t *testing.T) {
 		DispatcherLabel: label,
 	}
 
-	require.True(t, r.IsDispatcherRunning())
+	require.True(t, r.IsDispatcherRunning("ns"))
 }
 
 func TestIsDispatcherNotRunning(t *testing.T) {
@@ -89,7 +89,7 @@ func TestIsDispatcherNotRunning(t *testing.T) {
 		DispatcherLabel: base.BrokerDispatcherLabel,
 	}
 
-	require.False(t, r.IsDispatcherRunning())
+	require.False(t, r.IsDispatcherRunning("ns"))
 }
 
 func TestGetOrCreateDataPlaneConfigMap(t *testing.T) {

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -88,7 +88,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 		Recorder:   controller.GetEventRecorder(ctx),
 	}
 
-	if !r.IsReceiverRunning(r.Env.SystemNamespace) || !r.IsDispatcherRunning(r.Env.SystemNamespace) {
+	if !r.IsReceiverRunning(r.Reconciler.SystemNamespace) || !r.IsDispatcherRunning(r.Reconciler.SystemNamespace) {
 		return statusConditionManager.DataPlaneNotAvailable()
 	}
 	statusConditionManager.DataPlaneAvailable()
@@ -186,7 +186,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 	// the update even if here eventually means seconds or minutes after the actual update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		logger.Error("Failed to update receiver pod annotation", zap.Error(
 			statusConditionManager.FailedToUpdateReceiverPodsAnnotation(err),
 		))
@@ -196,7 +196,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 	logger.Debug("Updated receiver pod annotation")
 
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 		// Since the dispatcher side is the consumer side, we don't lose availability, and we can consider the Broker
 		// ready. So, log out the error and move on to the next step.
@@ -303,11 +303,11 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 	// Note: if there aren't changes to be done at the pod annotation level, we just skip the update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -88,7 +88,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 		Recorder:   controller.GetEventRecorder(ctx),
 	}
 
-	if !r.IsReceiverRunning() || !r.IsDispatcherRunning() {
+	if !r.IsReceiverRunning(r.Env.SystemNamespace) || !r.IsDispatcherRunning(r.Env.SystemNamespace) {
 		return statusConditionManager.DataPlaneNotAvailable()
 	}
 	statusConditionManager.DataPlaneAvailable()

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -186,7 +186,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 	// the update even if here eventually means seconds or minutes after the actual update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 		logger.Error("Failed to update receiver pod annotation", zap.Error(
 			statusConditionManager.FailedToUpdateReceiverPodsAnnotation(err),
 		))
@@ -196,7 +196,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 	logger.Debug("Updated receiver pod annotation")
 
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 		// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 		// Since the dispatcher side is the consumer side, we don't lose availability, and we can consider the Broker
 		// ready. So, log out the error and move on to the next step.
@@ -303,11 +303,11 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 	// Note: if there aren't changes to be done at the pod annotation level, we just skip the update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -111,7 +111,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 	}
 
 	// do not proceed, if data plane is not available
-	if !r.IsReceiverRunning() || !r.IsDispatcherRunning() {
+	if !r.IsReceiverRunning(r.Env.SystemNamespace) || !r.IsDispatcherRunning(r.Env.SystemNamespace) {
 		return statusConditionManager.DataPlaneNotAvailable()
 	}
 	statusConditionManager.DataPlaneAvailable()

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -109,13 +109,13 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 	}
 
 	// do not proceed, if data plane is not available
-	if !r.IsReceiverRunning(r.Env.SystemNamespace) || !r.IsDispatcherRunning(r.Env.SystemNamespace) {
+	if !r.IsReceiverRunning(r.Reconciler.SystemNamespace) || !r.IsDispatcherRunning(r.Reconciler.SystemNamespace) {
 		return statusConditionManager.DataPlaneNotAvailable()
 	}
 	statusConditionManager.DataPlaneAvailable()
 
 	// get the channel configmap
-	channelConfigMap, err := r.channelConfigMap(r.Env.SystemNamespace)
+	channelConfigMap, err := r.channelConfigMap(r.Reconciler.SystemNamespace)
 	if err != nil {
 		return statusConditionManager.FailedToResolveConfig(err)
 	}
@@ -250,7 +250,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 	// the update even if here eventually means seconds or minutes after the actual update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		logger.Error("Failed to update receiver pod annotation", zap.Error(
 			statusConditionManager.FailedToUpdateReceiverPodsAnnotation(err),
 		))
@@ -259,7 +259,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 	logger.Debug("Updated receiver pod annotation")
 
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 		// Since the dispatcher side is the consumer side, we don't lose availability, and we can consider the Channel
 		// ready. So, log out the error and move on to the next step.
@@ -278,7 +278,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 		return subscriptionError
 	}
 
-	channelService, err := r.reconcileChannelService(ctx, r.Env.SystemNamespace, channel)
+	channelService, err := r.reconcileChannelService(ctx, r.Reconciler.SystemNamespace, channel)
 	if err != nil {
 		logger.Error("Error reconciling the backwards compatibility channel service.", zap.Error(err))
 		return err
@@ -351,11 +351,11 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 	// Note: if there aren't changes to be done at the pod annotation level, we just skip the update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 
@@ -379,7 +379,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 	}
 
 	// get the channel configmap
-	channelConfigMap, err := r.channelConfigMap(r.Env.SystemNamespace)
+	channelConfigMap, err := r.channelConfigMap(r.Reconciler.SystemNamespace)
 	if err != nil {
 		return err
 	}

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -38,12 +38,10 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/retry"
 
+	v1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
-	"knative.dev/pkg/system"
-
-	v1 "knative.dev/eventing/pkg/apis/duck/v1"
 
 	messagingv1beta1 "knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
 	"knative.dev/eventing-kafka/pkg/channel/consolidated/reconciler/controller/resources"

--- a/control-plane/pkg/reconciler/channel/v2/channelv2.go
+++ b/control-plane/pkg/reconciler/channel/v2/channelv2.go
@@ -119,7 +119,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, channel *messagingv1beta
 	}
 
 	// Get the channel configmap
-	channelConfigMap, err := r.channelConfigMap(r.Env.SystemNamespace)
+	channelConfigMap, err := r.channelConfigMap(r.Reconciler.SystemNamespace)
 	if err != nil {
 		return statusConditionManager.FailedToResolveConfig(err)
 	}
@@ -257,7 +257,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, channel *messagingv1beta
 	// the update even if here eventually means seconds or minutes after the actual update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		logger.Error("Failed to update receiver pod annotation", zap.Error(
 			statusConditionManager.FailedToUpdateReceiverPodsAnnotation(err),
 		))
@@ -266,7 +266,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, channel *messagingv1beta
 	logger.Debug("Updated receiver pod annotation")
 
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 		// Since the dispatcher side is the consumer side, we don't lose availability, and we can consider the Channel
 		// ready. So, log out the error and move on to the next step.
@@ -280,7 +280,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, channel *messagingv1beta
 		logger.Debug("Updated dispatcher pod annotation")
 	}
 
-	channelService, err := r.reconcileChannelService(ctx, r.Env.SystemNamespace, channel)
+	channelService, err := r.reconcileChannelService(ctx, r.Reconciler.SystemNamespace, channel)
 	if err != nil {
 		logger.Error("Error reconciling the backwards compatibility channel service.", zap.Error(err))
 		return err
@@ -379,11 +379,11 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, channel *messagingv1beta1
 	// Note: if there aren't changes to be done at the pod annotation level, we just skip the update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 
@@ -407,7 +407,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, channel *messagingv1beta1
 	}
 
 	// get the channel configmap
-	channelConfigMap, err := r.channelConfigMap(r.Env.SystemNamespace)
+	channelConfigMap, err := r.channelConfigMap(r.Reconciler.SystemNamespace)
 	if err != nil {
 		return err
 	}

--- a/control-plane/pkg/reconciler/channel/v2/channelv2.go
+++ b/control-plane/pkg/reconciler/channel/v2/channelv2.go
@@ -39,16 +39,14 @@ import (
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/resolver"
 
+	messagingv1beta1 "knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
+	"knative.dev/eventing-kafka/pkg/common/constants"
 	v1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/reconciler"
-	"knative.dev/pkg/system"
-
-	messagingv1beta1 "knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
-	"knative.dev/eventing-kafka/pkg/common/constants"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -77,7 +77,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 		Recorder:   controller.GetEventRecorder(ctx),
 	}
 
-	if !r.IsReceiverRunning() {
+	if !r.IsReceiverRunning(r.Env.SystemNamespace) {
 		return statusConditionManager.DataPlaneNotAvailable()
 	}
 	statusConditionManager.DataPlaneAvailable()

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -222,7 +222,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 	// receivers haven't got the Sink, so update failures to receiver pods is a hard failure.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 
@@ -286,7 +286,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, ks *eventing.KafkaSink) e
 	// Note: if there aren't changes to be done at the pod annotation level, we just skip the update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -77,7 +77,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 		Recorder:   controller.GetEventRecorder(ctx),
 	}
 
-	if !r.IsReceiverRunning(r.Env.SystemNamespace) {
+	if !r.IsReceiverRunning(r.Reconciler.SystemNamespace) {
 		return statusConditionManager.DataPlaneNotAvailable()
 	}
 	statusConditionManager.DataPlaneAvailable()
@@ -222,7 +222,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 	// receivers haven't got the Sink, so update failures to receiver pods is a hard failure.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 
@@ -286,7 +286,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, ks *eventing.KafkaSink) e
 	// Note: if there aren't changes to be done at the pod annotation level, we just skip the update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 

--- a/control-plane/pkg/reconciler/trigger/trigger.go
+++ b/control-plane/pkg/reconciler/trigger/trigger.go
@@ -162,7 +162,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, trigger *eventing.Trigge
 		}
 
 		// Update volume generation annotation of dispatcher pods
-		if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+		if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 			// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 			// Since the dispatcher side is the consumer side, we don't lose availability, and we can consider the Trigger
 			// ready. So, log out the error and move on to the next step.
@@ -254,7 +254,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, trigger *eventing.Trigger
 	logger.Debug("Updated data plane config map", zap.String("configmap", r.Env.DataPlaneConfigMapAsString()))
 
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 		// The delete trigger will eventually be seen by the data plane pods, so log out the error and move on to the
 		// next step.

--- a/control-plane/pkg/reconciler/trigger/trigger.go
+++ b/control-plane/pkg/reconciler/trigger/trigger.go
@@ -162,7 +162,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, trigger *eventing.Trigge
 		}
 
 		// Update volume generation annotation of dispatcher pods
-		if err := r.UpdateDispatcherPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+		if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 			// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 			// Since the dispatcher side is the consumer side, we don't lose availability, and we can consider the Trigger
 			// ready. So, log out the error and move on to the next step.
@@ -254,7 +254,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, trigger *eventing.Trigger
 	logger.Debug("Updated data plane config map", zap.String("configmap", r.Env.DataPlaneConfigMapAsString()))
 
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 		// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 		// The delete trigger will eventually be seen by the data plane pods, so log out the error and move on to the
 		// next step.


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Prefactoring for KafkaBroker with dataplane-per-broker-resource
- Make some methods accept namespaces instead of using system namespace
-

Bases on https://github.com/knative-sandbox/eventing-kafka-broker/pull/2332

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
