### PR TITLE
[WIP] [Prefactoring] Make methods accept contract namespaces instead of using the env var directly

### DIFF
--- a/control-plane/pkg/config/env_config.go
+++ b/control-plane/pkg/config/env_config.go
@@ -23,14 +23,24 @@ import (
 )
 
 type Env struct {
+	// DataPlaneConfigMapNamespace is the namespace of the configmap that holds the contract between the control plane
+	// and the data plane. Might be ignored in some cases such as the configmap is expected to be in the resource
+	// namespace
 	DataPlaneConfigMapNamespace string `required:"true" split_words:"true"`
-	DataPlaneConfigMapName      string `required:"true" split_words:"true"`
-	GeneralConfigMapName        string `required:"true" split_words:"true"`
-	IngressName                 string `required:"true" split_words:"true"`
-	IngressPodPort              string `required:"false" split_words:"true"`
-	SystemNamespace             string `required:"true" split_words:"true"`
-	DataPlaneConfigFormat       string `required:"true" split_words:"true"`
-	DefaultBackoffDelayMs       uint64 `required:"false" split_words:"true"`
+
+	// DataPlaneConfigMapName is the name of the configmap that holds the contract between the control plane
+	// and the data plane.
+	DataPlaneConfigMapName string `required:"true" split_words:"true"` // example: kafka-broker-triggers
+
+	// GeneralConfigMapName is the name of the configmap that holds configuration that affects the control plane
+	// and the data plane. For example, Kafka bootstrap server information could be in here for broker configuration.
+	GeneralConfigMapName string `required:"true" split_words:"true"` // example: kafka-broker-config
+
+	IngressName           string `required:"true" split_words:"true"` // example: kafka-broker-ingress
+	IngressPodPort        string `required:"false" split_words:"true"`
+	SystemNamespace       string `required:"true" split_words:"true"`
+	DataPlaneConfigFormat string `required:"true" split_words:"true"`
+	DefaultBackoffDelayMs uint64 `required:"false" split_words:"true"`
 }
 
 // ValidationOption represents a function to validate the Env configurations.

--- a/control-plane/pkg/reconciler/base/reconciler.go
+++ b/control-plane/pkg/reconciler/base/reconciler.go
@@ -111,8 +111,6 @@ type ConfigMapOption func(cm *corev1.ConfigMap)
 func (r *Reconciler) GetOrCreateContractConfigMap(ctx context.Context, namespace string, options ...ConfigMapOption) (*corev1.ConfigMap, error) {
 
 	cm, err := r.KubeClient.CoreV1().
-		// We want to have the contract configmap in broker's namespace.
-		// Use the same name for the configmap though.
 		ConfigMaps(namespace).
 		Get(ctx, r.DataPlaneConfigMapName, metav1.GetOptions{})
 
@@ -127,8 +125,6 @@ func (r *Reconciler) createContractConfigMap(ctx context.Context, namespace stri
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			// We want to have the contract configmap in broker's namespace.
-			// Use the same name for the configmap though.
 			Name:      r.DataPlaneConfigMapName,
 			Namespace: namespace,
 		},

--- a/control-plane/pkg/reconciler/base/reconciler.go
+++ b/control-plane/pkg/reconciler/base/reconciler.go
@@ -221,18 +221,18 @@ func (r *Reconciler) UpdateDataPlaneConfigMap(ctx context.Context, contract *con
 	return nil
 }
 
-func (r *Reconciler) UpdateDispatcherPodsAnnotation(ctx context.Context, logger *zap.Logger, volumeGeneration uint64) error {
-	pods, errors := r.PodLister.Pods(r.SystemNamespace).List(r.dispatcherSelector())
+func (r *Reconciler) UpdateDispatcherPodsAnnotation(ctx context.Context, namespace string, logger *zap.Logger, volumeGeneration uint64) error {
+	pods, errors := r.PodLister.Pods(namespace).List(r.dispatcherSelector())
 	if errors != nil {
-		return fmt.Errorf("failed to list dispatcher pods in namespace %s: %w", r.SystemNamespace, errors)
+		return fmt.Errorf("failed to list dispatcher pods in namespace %s: %w", namespace, errors)
 	}
 	return r.UpdatePodsAnnotation(ctx, logger, "dispatcher", volumeGeneration, pods)
 }
 
-func (r *Reconciler) UpdateReceiverPodsAnnotation(ctx context.Context, logger *zap.Logger, volumeGeneration uint64) error {
-	pods, errors := r.PodLister.Pods(r.SystemNamespace).List(r.ReceiverSelector())
+func (r *Reconciler) UpdateReceiverPodsAnnotation(ctx context.Context, namespace string, logger *zap.Logger, volumeGeneration uint64) error {
+	pods, errors := r.PodLister.Pods(namespace).List(r.ReceiverSelector())
 	if errors != nil {
-		return fmt.Errorf("failed to list receiver pods in namespace %s: %w", r.SystemNamespace, errors)
+		return fmt.Errorf("failed to list receiver pods in namespace %s: %w", namespace, errors)
 	}
 	return r.UpdatePodsAnnotation(ctx, logger, "receiver", volumeGeneration, pods)
 }

--- a/control-plane/pkg/reconciler/base/reconciler.go
+++ b/control-plane/pkg/reconciler/base/reconciler.go
@@ -108,7 +108,7 @@ func isAtLeastOneRunning(pods []*corev1.Pod) bool {
 
 type ConfigMapOption func(cm *corev1.ConfigMap)
 
-func (r *Reconciler) GetOrCreateDataPlaneConfigMap(ctx context.Context, namespace string, options ...ConfigMapOption) (*corev1.ConfigMap, error) {
+func (r *Reconciler) GetOrCreateContractConfigMap(ctx context.Context, namespace string, options ...ConfigMapOption) (*corev1.ConfigMap, error) {
 
 	cm, err := r.KubeClient.CoreV1().
 		// We want to have the contract configmap in broker's namespace.
@@ -117,13 +117,13 @@ func (r *Reconciler) GetOrCreateDataPlaneConfigMap(ctx context.Context, namespac
 		Get(ctx, r.DataPlaneConfigMapName, metav1.GetOptions{})
 
 	if apierrors.IsNotFound(err) {
-		cm, err = r.createDataPlaneConfigMap(ctx, namespace, options)
+		cm, err = r.createContractConfigMap(ctx, namespace, options)
 	}
 
 	return cm, err
 }
 
-func (r *Reconciler) createDataPlaneConfigMap(ctx context.Context, namespace string, options []ConfigMapOption) (*corev1.ConfigMap, error) {
+func (r *Reconciler) createContractConfigMap(ctx context.Context, namespace string, options []ConfigMapOption) (*corev1.ConfigMap, error) {
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
@@ -144,12 +144,12 @@ func (r *Reconciler) createDataPlaneConfigMap(ctx context.Context, namespace str
 	return r.KubeClient.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{})
 }
 
-// GetDataPlaneConfigMapData extracts contract from the given config map.
-func (r *Reconciler) GetDataPlaneConfigMapData(logger *zap.Logger, dataPlaneConfigMap *corev1.ConfigMap) (*contract.Contract, error) {
-	return GetDataPlaneConfigMapData(logger, dataPlaneConfigMap, r.DataPlaneConfigFormat)
+// GetContractConfigMapData extracts contract from the given config map.
+func (r *Reconciler) GetContractConfigMapData(logger *zap.Logger, dataPlaneConfigMap *corev1.ConfigMap) (*contract.Contract, error) {
+	return GetContractConfigMapData(logger, dataPlaneConfigMap, r.DataPlaneConfigFormat)
 }
 
-func GetDataPlaneConfigMapData(logger *zap.Logger, dataPlaneConfigMap *corev1.ConfigMap, format string) (*contract.Contract, error) {
+func GetContractConfigMapData(logger *zap.Logger, dataPlaneConfigMap *corev1.ConfigMap, format string) (*contract.Contract, error) {
 
 	dataPlaneDataRaw, hasData := dataPlaneConfigMap.BinaryData[ConfigMapDataKey]
 	if !hasData || dataPlaneDataRaw == nil {

--- a/control-plane/pkg/reconciler/base/reconciler.go
+++ b/control-plane/pkg/reconciler/base/reconciler.go
@@ -87,13 +87,13 @@ type Reconciler struct {
 	ReceiverLabel   string
 }
 
-func (r *Reconciler) IsReceiverRunning() bool {
-	pods, err := r.PodLister.List(r.ReceiverSelector())
+func (r *Reconciler) IsReceiverRunning(namespace string) bool {
+	pods, err := r.PodLister.Pods(namespace).List(r.ReceiverSelector())
 	return err == nil && len(pods) > 0 && isAtLeastOneRunning(pods)
 }
 
-func (r *Reconciler) IsDispatcherRunning() bool {
-	pods, err := r.PodLister.List(r.dispatcherSelector())
+func (r *Reconciler) IsDispatcherRunning(namespace string) bool {
+	pods, err := r.PodLister.Pods(namespace).List(r.dispatcherSelector())
 	return err == nil && len(pods) > 0 && isAtLeastOneRunning(pods)
 }
 

--- a/control-plane/pkg/reconciler/base/reconciler.go
+++ b/control-plane/pkg/reconciler/base/reconciler.go
@@ -108,25 +108,25 @@ func isAtLeastOneRunning(pods []*corev1.Pod) bool {
 
 type ConfigMapOption func(cm *corev1.ConfigMap)
 
-func (r *Reconciler) GetOrCreateDataPlaneConfigMap(ctx context.Context, options ...ConfigMapOption) (*corev1.ConfigMap, error) {
+func (r *Reconciler) GetOrCreateDataPlaneConfigMap(ctx context.Context, namespace string, options ...ConfigMapOption) (*corev1.ConfigMap, error) {
 
 	cm, err := r.KubeClient.CoreV1().
-		ConfigMaps(r.DataPlaneConfigMapNamespace).
+		ConfigMaps(namespace).
 		Get(ctx, r.DataPlaneConfigMapName, metav1.GetOptions{})
 
 	if apierrors.IsNotFound(err) {
-		cm, err = r.createDataPlaneConfigMap(ctx, options)
+		cm, err = r.createDataPlaneConfigMap(ctx, namespace, options)
 	}
 
 	return cm, err
 }
 
-func (r *Reconciler) createDataPlaneConfigMap(ctx context.Context, options []ConfigMapOption) (*corev1.ConfigMap, error) {
+func (r *Reconciler) createDataPlaneConfigMap(ctx context.Context, namespace string, options []ConfigMapOption) (*corev1.ConfigMap, error) {
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.DataPlaneConfigMapName,
-			Namespace: r.DataPlaneConfigMapNamespace,
+			Namespace: namespace,
 		},
 		BinaryData: map[string][]byte{
 			ConfigMapDataKey: []byte(""),
@@ -137,7 +137,7 @@ func (r *Reconciler) createDataPlaneConfigMap(ctx context.Context, options []Con
 		opt(cm)
 	}
 
-	return r.KubeClient.CoreV1().ConfigMaps(r.DataPlaneConfigMapNamespace).Create(ctx, cm, metav1.CreateOptions{})
+	return r.KubeClient.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{})
 }
 
 // GetDataPlaneConfigMapData extracts contract from the given config map.

--- a/control-plane/pkg/reconciler/base/reconciler.go
+++ b/control-plane/pkg/reconciler/base/reconciler.go
@@ -111,6 +111,8 @@ type ConfigMapOption func(cm *corev1.ConfigMap)
 func (r *Reconciler) GetOrCreateDataPlaneConfigMap(ctx context.Context, namespace string, options ...ConfigMapOption) (*corev1.ConfigMap, error) {
 
 	cm, err := r.KubeClient.CoreV1().
+		// We want to have the contract configmap in broker's namespace.
+		// Use the same name for the configmap though.
 		ConfigMaps(namespace).
 		Get(ctx, r.DataPlaneConfigMapName, metav1.GetOptions{})
 
@@ -125,6 +127,8 @@ func (r *Reconciler) createDataPlaneConfigMap(ctx context.Context, namespace str
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
+			// We want to have the contract configmap in broker's namespace.
+			// Use the same name for the configmap though.
 			Name:      r.DataPlaneConfigMapName,
 			Namespace: namespace,
 		},

--- a/control-plane/pkg/reconciler/base/reconciler_test.go
+++ b/control-plane/pkg/reconciler/base/reconciler_test.go
@@ -92,19 +92,19 @@ func TestIsDispatcherNotRunning(t *testing.T) {
 	require.False(t, r.IsDispatcherRunning("ns"))
 }
 
-func TestGetOrCreateDataPlaneConfigMap(t *testing.T) {
+func TestGetOrCreateContractConfigMap(t *testing.T) {
 	ctx, _ := reconcilertesting.SetupFakeContext(t)
 
 	r := &base.Reconciler{
 		KubeClient: kubeclient.Get(ctx),
 	}
 
-	cm, err := r.GetOrCreateDataPlaneConfigMap(ctx, "knative-eventing")
+	cm, err := r.GetOrCreateContractConfigMap(ctx, "knative-eventing")
 	require.Nil(t, err)
 	require.NotNil(t, cm)
 }
 
-func TestGetDataPlaneConfigMapDataEmptyConfigMap(t *testing.T) {
+func TestGetContractConfigMapDataEmptyConfigMap(t *testing.T) {
 	ctx, _ := reconcilertesting.SetupFakeContext(t)
 
 	r := &base.Reconciler{
@@ -113,14 +113,14 @@ func TestGetDataPlaneConfigMapDataEmptyConfigMap(t *testing.T) {
 
 	cm := &corev1.ConfigMap{}
 
-	ct, err := r.GetDataPlaneConfigMapData(logging.FromContext(ctx).Desugar(), cm)
+	ct, err := r.GetContractConfigMapData(logging.FromContext(ctx).Desugar(), cm)
 	require.Nil(t, err)
 	require.NotNil(t, ct)
 	require.Equal(t, uint64(0), ct.Generation)
 	require.Len(t, ct.Resources, 0)
 }
 
-func TestGetDataPlaneConfigMapData(t *testing.T) {
+func TestGetContractConfigMapData(t *testing.T) {
 	ctx, _ := reconcilertesting.SetupFakeContext(t)
 
 	r := &base.Reconciler{
@@ -140,7 +140,7 @@ func TestGetDataPlaneConfigMapData(t *testing.T) {
 		},
 	}
 
-	got, err := r.GetDataPlaneConfigMapData(logging.FromContext(ctx).Desugar(), cm)
+	got, err := r.GetContractConfigMapData(logging.FromContext(ctx).Desugar(), cm)
 	require.Nil(t, err)
 	require.NotNil(t, got)
 	require.Len(t, got.Resources, len(ct.Resources))
@@ -181,7 +181,7 @@ func TestUpdateDataPlaneConfigMap(t *testing.T) {
 	require.Nil(t, err)
 }
 
-func TestGetDataPlaneConfigMapDataCorrupted(t *testing.T) {
+func TestGetContractConfigMapDataCorrupted(t *testing.T) {
 	ctx, _ := reconcilertesting.SetupFakeContext(t)
 
 	r := &base.Reconciler{
@@ -195,7 +195,7 @@ func TestGetDataPlaneConfigMapDataCorrupted(t *testing.T) {
 		},
 	}
 
-	got, err := r.GetDataPlaneConfigMapData(logging.FromContext(ctx).Desugar(), cm)
+	got, err := r.GetContractConfigMapData(logging.FromContext(ctx).Desugar(), cm)
 	require.NotNil(t, err)
 	require.Equal(t, uint64(0), got.Generation)
 }

--- a/control-plane/pkg/reconciler/base/reconciler_test.go
+++ b/control-plane/pkg/reconciler/base/reconciler_test.go
@@ -211,7 +211,7 @@ func TestUpdateReceiverPodAnnotation(t *testing.T) {
 		ReceiverLabel: base.SinkReceiverLabel,
 	}
 
-	err := r.UpdateReceiverPodsAnnotation(ctx, logging.FromContext(ctx).Desugar(), 1)
+	err := r.UpdateReceiverPodsAnnotation(ctx, "ns", logging.FromContext(ctx).Desugar(), 1)
 	require.Nil(t, err)
 }
 
@@ -228,7 +228,7 @@ func TestUpdateDispatcherPodAnnotation(t *testing.T) {
 		DispatcherLabel: label,
 	}
 
-	err := r.UpdateDispatcherPodsAnnotation(ctx, logging.FromContext(ctx).Desugar(), 1)
+	err := r.UpdateDispatcherPodsAnnotation(ctx, "ns", logging.FromContext(ctx).Desugar(), 1)
 	require.Nil(t, err)
 }
 

--- a/control-plane/pkg/reconciler/base/reconciler_test.go
+++ b/control-plane/pkg/reconciler/base/reconciler_test.go
@@ -52,7 +52,7 @@ func TestIsReceiverRunning(t *testing.T) {
 		ReceiverLabel: base.BrokerReceiverLabel,
 	}
 
-	require.True(t, r.IsReceiverRunning())
+	require.True(t, r.IsReceiverRunning("ns"))
 }
 
 func TestIsReceiverNotRunning(t *testing.T) {
@@ -63,7 +63,7 @@ func TestIsReceiverNotRunning(t *testing.T) {
 		ReceiverLabel: base.BrokerReceiverLabel,
 	}
 
-	require.False(t, r.IsReceiverRunning())
+	require.False(t, r.IsReceiverRunning("ns"))
 }
 
 func TestIsDispatcherRunning(t *testing.T) {
@@ -78,7 +78,7 @@ func TestIsDispatcherRunning(t *testing.T) {
 		DispatcherLabel: label,
 	}
 
-	require.True(t, r.IsDispatcherRunning())
+	require.True(t, r.IsDispatcherRunning("ns"))
 }
 
 func TestIsDispatcherNotRunning(t *testing.T) {
@@ -89,7 +89,7 @@ func TestIsDispatcherNotRunning(t *testing.T) {
 		DispatcherLabel: base.BrokerDispatcherLabel,
 	}
 
-	require.False(t, r.IsDispatcherRunning())
+	require.False(t, r.IsDispatcherRunning("ns"))
 }
 
 func TestGetOrCreateDataPlaneConfigMap(t *testing.T) {

--- a/control-plane/pkg/reconciler/base/reconciler_test.go
+++ b/control-plane/pkg/reconciler/base/reconciler_test.go
@@ -99,7 +99,7 @@ func TestGetOrCreateDataPlaneConfigMap(t *testing.T) {
 		KubeClient: kubeclient.Get(ctx),
 	}
 
-	cm, err := r.GetOrCreateDataPlaneConfigMap(ctx)
+	cm, err := r.GetOrCreateDataPlaneConfigMap(ctx, "knative-eventing")
 	require.Nil(t, err)
 	require.NotNil(t, cm)
 }

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -88,7 +88,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 		Recorder:   controller.GetEventRecorder(ctx),
 	}
 
-	if !r.IsReceiverRunning(r.Env.SystemNamespace) || !r.IsDispatcherRunning(r.Env.SystemNamespace) {
+	if !r.IsReceiverRunning(r.Reconciler.SystemNamespace) || !r.IsDispatcherRunning(r.Reconciler.SystemNamespace) {
 		return statusConditionManager.DataPlaneNotAvailable()
 	}
 	statusConditionManager.DataPlaneAvailable()
@@ -186,7 +186,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 	// the update even if here eventually means seconds or minutes after the actual update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		logger.Error("Failed to update receiver pod annotation", zap.Error(
 			statusConditionManager.FailedToUpdateReceiverPodsAnnotation(err),
 		))
@@ -196,7 +196,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 	logger.Debug("Updated receiver pod annotation")
 
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 		// Since the dispatcher side is the consumer side, we don't lose availability, and we can consider the Broker
 		// ready. So, log out the error and move on to the next step.
@@ -303,11 +303,11 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 	// Note: if there aren't changes to be done at the pod annotation level, we just skip the update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -131,7 +131,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 	}
 
 	// Get contract config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
+	contractConfigMap, err := r.GetOrCreateContractConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return statusConditionManager.FailedToGetConfigMap(err)
 	}
@@ -139,7 +139,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 	logger.Debug("Got contract config map")
 
 	// Get contract data.
-	ct, err := r.GetDataPlaneConfigMapData(logger, contractConfigMap)
+	ct, err := r.GetContractConfigMapData(logger, contractConfigMap)
 	if err != nil && ct == nil {
 		return statusConditionManager.FailedToGetDataFromConfigMap(err)
 	}
@@ -147,7 +147,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 	logger.Debug("Got contract data from config map", zap.Any(base.ContractLogKey, ct))
 
 	// Get resource configuration.
-	brokerResource, err := r.reconcilerBrokerResource(ctx, topic, broker, secret, topicConfig)
+	brokerResource, err := r.getBrokerContractResource(ctx, topic, broker, secret, topicConfig)
 	if err != nil {
 		return statusConditionManager.FailedToResolveConfig(err)
 	}
@@ -278,7 +278,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 	logger := kafkalogging.CreateFinalizeMethodLogger(ctx, broker)
 
 	// Get contract config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
+	contractConfigMap, err := r.GetOrCreateContractConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to get contract config map %s: %w", r.DataPlaneConfigMapAsString(), err)
 	}
@@ -286,7 +286,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 	logger.Debug("Got contract config map")
 
 	// Get contract data.
-	ct, err := r.GetDataPlaneConfigMapData(logger, contractConfigMap)
+	ct, err := r.GetContractConfigMapData(logger, contractConfigMap)
 	if err != nil {
 		return fmt.Errorf("failed to get contract: %w", err)
 	}
@@ -457,7 +457,7 @@ func rebuildCMFromAnnotations(br *eventing.Broker) *corev1.ConfigMap {
 	return cm
 }
 
-func (r *Reconciler) reconcilerBrokerResource(ctx context.Context, topic string, broker *eventing.Broker, secret *corev1.Secret, config *kafka.TopicConfig) (*contract.Resource, error) {
+func (r *Reconciler) getBrokerContractResource(ctx context.Context, topic string, broker *eventing.Broker, secret *corev1.Secret, config *kafka.TopicConfig) (*contract.Resource, error) {
 	resource := &contract.Resource{
 		Uid:    string(broker.UID),
 		Topics: []string{topic},

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -88,7 +88,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 		Recorder:   controller.GetEventRecorder(ctx),
 	}
 
-	if !r.IsReceiverRunning() || !r.IsDispatcherRunning() {
+	if !r.IsReceiverRunning(r.Env.SystemNamespace) || !r.IsDispatcherRunning(r.Env.SystemNamespace) {
 		return statusConditionManager.DataPlaneNotAvailable()
 	}
 	statusConditionManager.DataPlaneAvailable()

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -186,7 +186,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 	// the update even if here eventually means seconds or minutes after the actual update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 		logger.Error("Failed to update receiver pod annotation", zap.Error(
 			statusConditionManager.FailedToUpdateReceiverPodsAnnotation(err),
 		))
@@ -196,7 +196,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 	logger.Debug("Updated receiver pod annotation")
 
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 		// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 		// Since the dispatcher side is the consumer side, we don't lose availability, and we can consider the Broker
 		// ready. So, log out the error and move on to the next step.
@@ -303,11 +303,11 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 	// Note: if there aren't changes to be done at the pod annotation level, we just skip the update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -131,7 +131,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 	}
 
 	// Get contract config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx)
+	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return statusConditionManager.FailedToGetConfigMap(err)
 	}
@@ -278,7 +278,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 	logger := kafkalogging.CreateFinalizeMethodLogger(ctx, broker)
 
 	// Get contract config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx)
+	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to get contract config map %s: %w", r.DataPlaneConfigMapAsString(), err)
 	}

--- a/control-plane/pkg/reconciler/broker/controller.go
+++ b/control-plane/pkg/reconciler/broker/controller.go
@@ -76,7 +76,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher, env *config.E
 
 	logger := logging.FromContext(ctx)
 
-	_, err := reconciler.GetOrCreateDataPlaneConfigMap(ctx)
+	_, err := reconciler.GetOrCreateDataPlaneConfigMap(ctx, reconciler.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		logger.Fatal("Failed to get or create data plane config map",
 			zap.String("configmap", env.DataPlaneConfigMapAsString()),
@@ -105,7 +105,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher, env *config.E
 	}
 
 	configmapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterWithNameAndNamespace(env.DataPlaneConfigMapNamespace, env.DataPlaneConfigMapName),
+		FilterFunc: controller.FilterWithNameAndNamespace(reconciler.Reconciler.DataPlaneConfigMapNamespace, env.DataPlaneConfigMapName),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				globalResync(obj)

--- a/control-plane/pkg/reconciler/broker/controller.go
+++ b/control-plane/pkg/reconciler/broker/controller.go
@@ -76,7 +76,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher, env *config.E
 
 	logger := logging.FromContext(ctx)
 
-	_, err := reconciler.GetOrCreateDataPlaneConfigMap(ctx, reconciler.Reconciler.DataPlaneConfigMapNamespace)
+	_, err := reconciler.GetOrCreateContractConfigMap(ctx, reconciler.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		logger.Fatal("Failed to get or create data plane config map",
 			zap.String("configmap", env.DataPlaneConfigMapAsString()),

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -111,7 +111,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 	}
 
 	// do not proceed, if data plane is not available
-	if !r.IsReceiverRunning() || !r.IsDispatcherRunning() {
+	if !r.IsReceiverRunning(r.Env.SystemNamespace) || !r.IsDispatcherRunning(r.Env.SystemNamespace) {
 		return statusConditionManager.DataPlaneNotAvailable()
 	}
 	statusConditionManager.DataPlaneAvailable()

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -109,13 +109,13 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 	}
 
 	// do not proceed, if data plane is not available
-	if !r.IsReceiverRunning(r.Env.SystemNamespace) || !r.IsDispatcherRunning(r.Env.SystemNamespace) {
+	if !r.IsReceiverRunning(r.Reconciler.SystemNamespace) || !r.IsDispatcherRunning(r.Reconciler.SystemNamespace) {
 		return statusConditionManager.DataPlaneNotAvailable()
 	}
 	statusConditionManager.DataPlaneAvailable()
 
 	// get the channel configmap
-	channelConfigMap, err := r.channelConfigMap(r.Env.SystemNamespace)
+	channelConfigMap, err := r.channelConfigMap(r.Reconciler.SystemNamespace)
 	if err != nil {
 		return statusConditionManager.FailedToResolveConfig(err)
 	}
@@ -250,7 +250,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 	// the update even if here eventually means seconds or minutes after the actual update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		logger.Error("Failed to update receiver pod annotation", zap.Error(
 			statusConditionManager.FailedToUpdateReceiverPodsAnnotation(err),
 		))
@@ -259,7 +259,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 	logger.Debug("Updated receiver pod annotation")
 
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 		// Since the dispatcher side is the consumer side, we don't lose availability, and we can consider the Channel
 		// ready. So, log out the error and move on to the next step.
@@ -278,7 +278,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 		return subscriptionError
 	}
 
-	channelService, err := r.reconcileChannelService(ctx, r.Env.SystemNamespace, channel)
+	channelService, err := r.reconcileChannelService(ctx, r.Reconciler.SystemNamespace, channel)
 	if err != nil {
 		logger.Error("Error reconciling the backwards compatibility channel service.", zap.Error(err))
 		return err
@@ -351,11 +351,11 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 	// Note: if there aren't changes to be done at the pod annotation level, we just skip the update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 
@@ -379,7 +379,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 	}
 
 	// get the channel configmap
-	channelConfigMap, err := r.channelConfigMap(r.Env.SystemNamespace)
+	channelConfigMap, err := r.channelConfigMap(r.Reconciler.SystemNamespace)
 	if err != nil {
 		return err
 	}

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -38,12 +38,10 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/retry"
 
+	v1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
-	"knative.dev/pkg/system"
-
-	v1 "knative.dev/eventing/pkg/apis/duck/v1"
 
 	messagingv1beta1 "knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
 	"knative.dev/eventing-kafka/pkg/channel/consolidated/reconciler/controller/resources"

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -195,14 +195,14 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 	statusConditionManager.TopicReady(topic)
 
 	// Get data plane config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
+	contractConfigMap, err := r.GetOrCreateContractConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return statusConditionManager.FailedToResolveConfig(err)
 	}
 	logger.Debug("Got contract config map")
 
 	// Get data plane config data.
-	ct, err := r.GetDataPlaneConfigMapData(logger, contractConfigMap)
+	ct, err := r.GetContractConfigMapData(logger, contractConfigMap)
 	if err != nil || ct == nil {
 		return statusConditionManager.FailedToGetDataFromConfigMap(err)
 	}
@@ -314,14 +314,14 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 	logger := kafkalogging.CreateFinalizeMethodLogger(ctx, channel)
 
 	// Get contract config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
+	contractConfigMap, err := r.GetOrCreateContractConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to get contract config map %s: %w", r.DataPlaneConfigMapAsString(), err)
 	}
 	logger.Debug("Got contract config map")
 
 	// Get contract data.
-	ct, err := r.GetDataPlaneConfigMapData(logger, contractConfigMap)
+	ct, err := r.GetContractConfigMapData(logger, contractConfigMap)
 	if err != nil && ct == nil {
 		return fmt.Errorf("failed to get contract: %w", err)
 	}

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -195,7 +195,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 	statusConditionManager.TopicReady(topic)
 
 	// Get data plane config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx)
+	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return statusConditionManager.FailedToResolveConfig(err)
 	}
@@ -314,7 +314,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 	logger := kafkalogging.CreateFinalizeMethodLogger(ctx, channel)
 
 	// Get contract config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx)
+	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to get contract config map %s: %w", r.DataPlaneConfigMapAsString(), err)
 	}

--- a/control-plane/pkg/reconciler/channel/controller.go
+++ b/control-plane/pkg/reconciler/channel/controller.go
@@ -75,7 +75,7 @@ func NewController(ctx context.Context, configs *config.Env) *controller.Impl {
 
 	logger := logging.FromContext(ctx)
 
-	_, err := reconciler.GetOrCreateDataPlaneConfigMap(ctx, reconciler.Reconciler.DataPlaneConfigMapNamespace)
+	_, err := reconciler.GetOrCreateContractConfigMap(ctx, reconciler.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		logger.Fatal("Failed to get or create data plane config map",
 			zap.String("configmap", configs.DataPlaneConfigMapAsString()),

--- a/control-plane/pkg/reconciler/channel/controller.go
+++ b/control-plane/pkg/reconciler/channel/controller.go
@@ -75,7 +75,7 @@ func NewController(ctx context.Context, configs *config.Env) *controller.Impl {
 
 	logger := logging.FromContext(ctx)
 
-	_, err := reconciler.GetOrCreateDataPlaneConfigMap(ctx)
+	_, err := reconciler.GetOrCreateDataPlaneConfigMap(ctx, reconciler.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		logger.Fatal("Failed to get or create data plane config map",
 			zap.String("configmap", configs.DataPlaneConfigMapAsString()),

--- a/control-plane/pkg/reconciler/channel/v2/channelv2.go
+++ b/control-plane/pkg/reconciler/channel/v2/channelv2.go
@@ -194,14 +194,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, channel *messagingv1beta
 	statusConditionManager.TopicReady(topic)
 
 	// Get data plane config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
+	contractConfigMap, err := r.GetOrCreateContractConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return statusConditionManager.FailedToResolveConfig(err)
 	}
 	logger.Debug("Got contract config map")
 
 	// Get data plane config data.
-	ct, err := r.GetDataPlaneConfigMapData(logger, contractConfigMap)
+	ct, err := r.GetContractConfigMapData(logger, contractConfigMap)
 	if err != nil || ct == nil {
 		return statusConditionManager.FailedToGetDataFromConfigMap(err)
 	}
@@ -342,14 +342,14 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, channel *messagingv1beta1
 	logger := kafkalogging.CreateFinalizeMethodLogger(ctx, channel)
 
 	// Get contract config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
+	contractConfigMap, err := r.GetOrCreateContractConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to get contract config map %s: %w", r.DataPlaneConfigMapAsString(), err)
 	}
 	logger.Debug("Got contract config map")
 
 	// Get contract data.
-	ct, err := r.GetDataPlaneConfigMapData(logger, contractConfigMap)
+	ct, err := r.GetContractConfigMapData(logger, contractConfigMap)
 	if err != nil && ct == nil {
 		return fmt.Errorf("failed to get contract: %w", err)
 	}

--- a/control-plane/pkg/reconciler/channel/v2/channelv2.go
+++ b/control-plane/pkg/reconciler/channel/v2/channelv2.go
@@ -119,7 +119,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, channel *messagingv1beta
 	}
 
 	// Get the channel configmap
-	channelConfigMap, err := r.channelConfigMap(r.Env.SystemNamespace)
+	channelConfigMap, err := r.channelConfigMap(r.Reconciler.SystemNamespace)
 	if err != nil {
 		return statusConditionManager.FailedToResolveConfig(err)
 	}
@@ -257,7 +257,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, channel *messagingv1beta
 	// the update even if here eventually means seconds or minutes after the actual update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		logger.Error("Failed to update receiver pod annotation", zap.Error(
 			statusConditionManager.FailedToUpdateReceiverPodsAnnotation(err),
 		))
@@ -266,7 +266,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, channel *messagingv1beta
 	logger.Debug("Updated receiver pod annotation")
 
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 		// Since the dispatcher side is the consumer side, we don't lose availability, and we can consider the Channel
 		// ready. So, log out the error and move on to the next step.
@@ -280,7 +280,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, channel *messagingv1beta
 		logger.Debug("Updated dispatcher pod annotation")
 	}
 
-	channelService, err := r.reconcileChannelService(ctx, r.Env.SystemNamespace, channel)
+	channelService, err := r.reconcileChannelService(ctx, r.Reconciler.SystemNamespace, channel)
 	if err != nil {
 		logger.Error("Error reconciling the backwards compatibility channel service.", zap.Error(err))
 		return err
@@ -379,11 +379,11 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, channel *messagingv1beta1
 	// Note: if there aren't changes to be done at the pod annotation level, we just skip the update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 
@@ -407,7 +407,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, channel *messagingv1beta1
 	}
 
 	// get the channel configmap
-	channelConfigMap, err := r.channelConfigMap(r.Env.SystemNamespace)
+	channelConfigMap, err := r.channelConfigMap(r.Reconciler.SystemNamespace)
 	if err != nil {
 		return err
 	}

--- a/control-plane/pkg/reconciler/channel/v2/channelv2.go
+++ b/control-plane/pkg/reconciler/channel/v2/channelv2.go
@@ -39,16 +39,14 @@ import (
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/resolver"
 
+	messagingv1beta1 "knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
+	"knative.dev/eventing-kafka/pkg/common/constants"
 	v1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/reconciler"
-	"knative.dev/pkg/system"
-
-	messagingv1beta1 "knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
-	"knative.dev/eventing-kafka/pkg/common/constants"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"

--- a/control-plane/pkg/reconciler/channel/v2/channelv2.go
+++ b/control-plane/pkg/reconciler/channel/v2/channelv2.go
@@ -194,7 +194,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, channel *messagingv1beta
 	statusConditionManager.TopicReady(topic)
 
 	// Get data plane config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx)
+	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return statusConditionManager.FailedToResolveConfig(err)
 	}
@@ -342,7 +342,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, channel *messagingv1beta1
 	logger := kafkalogging.CreateFinalizeMethodLogger(ctx, channel)
 
 	// Get contract config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx)
+	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to get contract config map %s: %w", r.DataPlaneConfigMapAsString(), err)
 	}

--- a/control-plane/pkg/reconciler/consumer/consumer.go
+++ b/control-plane/pkg/reconciler/consumer/consumer.go
@@ -338,7 +338,7 @@ func (r Reconciler) schedule(ctx context.Context, logger *zap.Logger, c *kafkain
 
 	b := r.commonReconciler(p, cmName)
 
-	cm, err := b.GetOrCreateDataPlaneConfigMap(ctx, podOwnerReference(p))
+	cm, err := b.GetOrCreateDataPlaneConfigMap(ctx, b.DataPlaneConfigMapNamespace, podOwnerReference(p))
 	if err != nil {
 		return false, fmt.Errorf("failed to get or create data plane ConfigMap %s/%s: %w", p.GetNamespace(), cmName, err)
 	}

--- a/control-plane/pkg/reconciler/consumer/consumer.go
+++ b/control-plane/pkg/reconciler/consumer/consumer.go
@@ -338,7 +338,7 @@ func (r Reconciler) schedule(ctx context.Context, logger *zap.Logger, c *kafkain
 
 	b := r.commonReconciler(p, cmName)
 
-	cm, err := b.GetOrCreateDataPlaneConfigMap(ctx, b.DataPlaneConfigMapNamespace, podOwnerReference(p))
+	cm, err := b.GetOrCreateContractConfigMap(ctx, b.DataPlaneConfigMapNamespace, podOwnerReference(p))
 	if err != nil {
 		return false, fmt.Errorf("failed to get or create data plane ConfigMap %s/%s: %w", p.GetNamespace(), cmName, err)
 	}
@@ -351,7 +351,7 @@ func (r Reconciler) schedule(ctx context.Context, logger *zap.Logger, c *kafkain
 		return false, nil
 	}
 
-	ct, err := b.GetDataPlaneConfigMapData(logger, cm)
+	ct, err := b.GetContractConfigMapData(logger, cm)
 	if err != nil {
 		return false, fmt.Errorf("failed to get contract from ConfigMap %s/%s: %w", p.GetNamespace(), cmName, err)
 	}

--- a/control-plane/pkg/reconciler/sink/controller.go
+++ b/control-plane/pkg/reconciler/sink/controller.go
@@ -67,7 +67,7 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 		Env:                        configs,
 	}
 
-	_, err := reconciler.GetOrCreateDataPlaneConfigMap(ctx)
+	_, err := reconciler.GetOrCreateDataPlaneConfigMap(ctx, reconciler.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		logger.Fatal("Failed to get or create data plane config map",
 			zap.String("configmap", configs.DataPlaneConfigMapAsString()),

--- a/control-plane/pkg/reconciler/sink/controller.go
+++ b/control-plane/pkg/reconciler/sink/controller.go
@@ -67,7 +67,7 @@ func NewController(ctx context.Context, _ configmap.Watcher, configs *config.Env
 		Env:                        configs,
 	}
 
-	_, err := reconciler.GetOrCreateDataPlaneConfigMap(ctx, reconciler.Reconciler.DataPlaneConfigMapNamespace)
+	_, err := reconciler.GetOrCreateContractConfigMap(ctx, reconciler.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		logger.Fatal("Failed to get or create data plane config map",
 			zap.String("configmap", configs.DataPlaneConfigMapAsString()),

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -77,7 +77,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 		Recorder:   controller.GetEventRecorder(ctx),
 	}
 
-	if !r.IsReceiverRunning() {
+	if !r.IsReceiverRunning(r.Env.SystemNamespace) {
 		return statusConditionManager.DataPlaneNotAvailable()
 	}
 	statusConditionManager.DataPlaneAvailable()

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -146,7 +146,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 	logger.Debug("Topic created", zap.Any("topic", ks.Spec.Topic))
 
 	// Get contract config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx)
+	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return statusConditionManager.FailedToGetConfigMap(err)
 	}
@@ -256,7 +256,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, ks *eventing.KafkaSink) e
 	logger := kafkalogging.CreateFinalizeMethodLogger(ctx, ks)
 
 	// Get contract config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx)
+	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to get contract config map %s: %w", r.DataPlaneConfigMapAsString(), err)
 	}

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -222,7 +222,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 	// receivers haven't got the Sink, so update failures to receiver pods is a hard failure.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 
@@ -286,7 +286,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, ks *eventing.KafkaSink) e
 	// Note: if there aren't changes to be done at the pod annotation level, we just skip the update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -77,7 +77,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 		Recorder:   controller.GetEventRecorder(ctx),
 	}
 
-	if !r.IsReceiverRunning(r.Env.SystemNamespace) {
+	if !r.IsReceiverRunning(r.Reconciler.SystemNamespace) {
 		return statusConditionManager.DataPlaneNotAvailable()
 	}
 	statusConditionManager.DataPlaneAvailable()
@@ -222,7 +222,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 	// receivers haven't got the Sink, so update failures to receiver pods is a hard failure.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 
@@ -286,7 +286,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, ks *eventing.KafkaSink) e
 	// Note: if there aren't changes to be done at the pod annotation level, we just skip the update.
 
 	// Update volume generation annotation of receiver pods
-	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateReceiverPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		return err
 	}
 

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -146,7 +146,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 	logger.Debug("Topic created", zap.Any("topic", ks.Spec.Topic))
 
 	// Get contract config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
+	contractConfigMap, err := r.GetOrCreateContractConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return statusConditionManager.FailedToGetConfigMap(err)
 	}
@@ -154,7 +154,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 	logger.Debug("Got contract config map")
 
 	// Get contract data.
-	ct, err := r.GetDataPlaneConfigMapData(logger, contractConfigMap)
+	ct, err := r.GetContractConfigMapData(logger, contractConfigMap)
 	if err != nil && ct == nil {
 		return statusConditionManager.FailedToGetDataFromConfigMap(err)
 	}
@@ -256,7 +256,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, ks *eventing.KafkaSink) e
 	logger := kafkalogging.CreateFinalizeMethodLogger(ctx, ks)
 
 	// Get contract config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
+	contractConfigMap, err := r.GetOrCreateContractConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to get contract config map %s: %w", r.DataPlaneConfigMapAsString(), err)
 	}
@@ -264,7 +264,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, ks *eventing.KafkaSink) e
 	logger.Debug("Got contract config map")
 
 	// Get contract data.
-	ct, err := r.GetDataPlaneConfigMapData(logger, contractConfigMap)
+	ct, err := r.GetContractConfigMapData(logger, contractConfigMap)
 	if err != nil {
 		return fmt.Errorf("failed to get contract: %w", err)
 	}

--- a/control-plane/pkg/reconciler/trigger/trigger.go
+++ b/control-plane/pkg/reconciler/trigger/trigger.go
@@ -116,7 +116,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, trigger *eventing.Trigge
 	}
 
 	// Get data plane config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx)
+	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return statusConditionManager.failedToGetDataPlaneConfigMap(err)
 	}
@@ -202,7 +202,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, trigger *eventing.Trigger
 	}
 
 	// Get data plane config map.
-	dataPlaneConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx)
+	dataPlaneConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to get data plane config map %s: %w", r.Env.DataPlaneConfigMapAsString(), err)
 	}

--- a/control-plane/pkg/reconciler/trigger/trigger.go
+++ b/control-plane/pkg/reconciler/trigger/trigger.go
@@ -162,7 +162,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, trigger *eventing.Trigge
 		}
 
 		// Update volume generation annotation of dispatcher pods
-		if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+		if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 			// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 			// Since the dispatcher side is the consumer side, we don't lose availability, and we can consider the Trigger
 			// ready. So, log out the error and move on to the next step.
@@ -254,7 +254,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, trigger *eventing.Trigger
 	logger.Debug("Updated data plane config map", zap.String("configmap", r.Env.DataPlaneConfigMapAsString()))
 
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Reconciler.SystemNamespace, logger, ct.Generation); err != nil {
 		// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 		// The delete trigger will eventually be seen by the data plane pods, so log out the error and move on to the
 		// next step.

--- a/control-plane/pkg/reconciler/trigger/trigger.go
+++ b/control-plane/pkg/reconciler/trigger/trigger.go
@@ -162,7 +162,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, trigger *eventing.Trigge
 		}
 
 		// Update volume generation annotation of dispatcher pods
-		if err := r.UpdateDispatcherPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+		if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 			// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 			// Since the dispatcher side is the consumer side, we don't lose availability, and we can consider the Trigger
 			// ready. So, log out the error and move on to the next step.
@@ -254,7 +254,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, trigger *eventing.Trigger
 	logger.Debug("Updated data plane config map", zap.String("configmap", r.Env.DataPlaneConfigMapAsString()))
 
 	// Update volume generation annotation of dispatcher pods
-	if err := r.UpdateDispatcherPodsAnnotation(ctx, logger, ct.Generation); err != nil {
+	if err := r.UpdateDispatcherPodsAnnotation(ctx, r.Env.SystemNamespace, logger, ct.Generation); err != nil {
 		// Failing to update dispatcher pods annotation leads to config map refresh delayed by several seconds.
 		// The delete trigger will eventually be seen by the data plane pods, so log out the error and move on to the
 		// next step.

--- a/control-plane/pkg/reconciler/trigger/trigger.go
+++ b/control-plane/pkg/reconciler/trigger/trigger.go
@@ -116,7 +116,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, trigger *eventing.Trigge
 	}
 
 	// Get data plane config map.
-	contractConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
+	contractConfigMap, err := r.GetOrCreateContractConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return statusConditionManager.failedToGetDataPlaneConfigMap(err)
 	}
@@ -124,7 +124,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, trigger *eventing.Trigge
 	logger.Debug("Got contract config map")
 
 	// Get data plane config data.
-	ct, err := r.GetDataPlaneConfigMapData(logger, contractConfigMap)
+	ct, err := r.GetContractConfigMapData(logger, contractConfigMap)
 	if err != nil || ct == nil {
 		return statusConditionManager.failedToGetDataPlaneConfigFromConfigMap(err)
 	}
@@ -202,7 +202,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, trigger *eventing.Trigger
 	}
 
 	// Get data plane config map.
-	dataPlaneConfigMap, err := r.GetOrCreateDataPlaneConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
+	dataPlaneConfigMap, err := r.GetOrCreateContractConfigMap(ctx, r.Reconciler.DataPlaneConfigMapNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to get data plane config map %s: %w", r.Env.DataPlaneConfigMapAsString(), err)
 	}
@@ -210,7 +210,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, trigger *eventing.Trigger
 	logger.Debug("Got data plane config map")
 
 	// Get contract data.
-	ct, err := r.GetDataPlaneConfigMapData(logger, dataPlaneConfigMap)
+	ct, err := r.GetContractConfigMapData(logger, dataPlaneConfigMap)
 	if err != nil {
 		return fmt.Errorf("failed to get contract: %w", err)
 	}

--- a/test/pkg/observability/watch_config_map.go
+++ b/test/pkg/observability/watch_config_map.go
@@ -80,7 +80,7 @@ type diffLogger struct {
 
 func (d *diffLogger) logDiff(cm *corev1.ConfigMap) {
 
-	ct, err := base.GetDataPlaneConfigMapData(d.logger, cm, d.format)
+	ct, err := base.GetContractConfigMapData(d.logger, cm, d.format)
 	if err != nil {
 		d.logger.Error(
 			"failed to get data plane config map data",


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Prefactoring for KafkaBroker with dataplane-per-broker-resource
- Make methods accept contract namespaces instead of using the env var directly
- Based on https://github.com/knative-sandbox/eventing-kafka-broker/pull/2334

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
