### PR TITLE
Security: add SASL + mTLS support

### DIFF
--- a/docs/channel/README.md
+++ b/docs/channel/README.md
@@ -98,7 +98,7 @@ implementations.
     - `PLAINTEXT`: No authentication and encryption are used.
     - `SSL`: Only encryption is used
     - `SASL_PLAINTEXT`: Only authentication is used
-    - `SASL_SSL`: Both authentication and encryption are used
+    - `SASL_SSL`: Both authentication and encryption are used. If user certificate and key are informed SASL and mutual TLS authentication methods are used.
 
    ```sh
     ca_cert_secret="my-cluster-cluster-ca-cert"
@@ -132,6 +132,18 @@ implementations.
       --from-literal=password="$SASL_PASSWD" \
       --from-literal=user="my-sasl-user" \
       --from-literal=protocol="SASL_PLAINTEXT" \
+      --from-literal=sasl.mechanism="SCRAM-SHA-512" \
+      --dry-run=client -o yaml | kubectl apply -n knative-eventing -f -
+
+    # Or, SSL with SASL and mTLS authentication
+    # (note: although this example is provided, Strimzi does not support SASL + mTLS authentication)
+    kubectl create secret --namespace knative-eventing generic sasl-mtls-secret \
+      --from-literal=ca.crt="$STRIMZI_CRT" \
+      --from-literal=user.crt="$TLSUSER_CRT" \
+      --from-literal=user.key="$TLSUSER_KEY" \
+      --from-literal=password="$SASL_PASSWD" \
+      --from-literal=user="my-sasl-user" \
+      --from-literal=protocol="SASL_SSL" \
       --from-literal=sasl.mechanism="SCRAM-SHA-512" \
       --dry-run=client -o yaml | kubectl apply -n knative-eventing -f -
    ```


### PR DESCRIPTION
Fixes https://github.com/knative-sandbox/eventing-kafka-broker/issues/2325

Note: Strimzi [does not support SASL + mTLS configuration](https://github.com/strimzi/strimzi-kafka-operator/issues/5331).

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Adds support for SASL + mTLS authentication (at the same time)

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Adds support for SASL + mTLS authentication for Brokers and Sinks

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
SASL and mTLS authentication can now be used at the same time. In order to do so create a secret that provides fields for both authentication methods, including client certificate and key, and configure the `SASL_SSL` protocol.

Breaking Change: if an existing Broker/Sink is configured as `SASL_SSL` and its secret configures the client certificate and key, the behavior  prior to this release would create a SASL + SSL configured component, while after this release it would create a SASL + mTLS authenticated object.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
