### PR TITLE
Use HTTP for readinessProbe

### DIFF
--- a/data-plane/config/brokerv2/500-dispatcher.yaml
+++ b/data-plane/config/brokerv2/500-dispatcher.yaml
@@ -137,8 +137,10 @@ spec:
             timeoutSeconds: 1
           readinessProbe:
             failureThreshold: 3
-            tcpSocket:
+            httpGet:
               port: 9090
+              path: /metrics
+              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1

--- a/data-plane/config/channelv2/500-dispatcher.yaml
+++ b/data-plane/config/channelv2/500-dispatcher.yaml
@@ -138,8 +138,10 @@ spec:
             timeoutSeconds: 1
           readinessProbe:
             failureThreshold: 3
-            tcpSocket:
+            httpGet:
               port: 9090
+              path: /metrics
+              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1

--- a/data-plane/config/source/500-dispatcher.yaml
+++ b/data-plane/config/source/500-dispatcher.yaml
@@ -138,8 +138,10 @@ spec:
             timeoutSeconds: 1
           readinessProbe:
             failureThreshold: 3
-            tcpSocket:
+            httpGet:
               port: 9090
+              path: /metrics
+              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- use `HTTP` instead of _raw_ `TCP` for readinessProbe of source and V2 dispatchers 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
