### PR TITLE
`TAG` is readonly during the release

### DIFF
--- a/hack/data-plane.sh
+++ b/hack/data-plane.sh
@@ -52,8 +52,6 @@ function receiver_build_push() {
   header "Building receiver ..."
 
   local receiver="${KNATIVE_KAFKA_BROKER_RECEIVER:-${KO_DOCKER_REPO}/knative-kafka-broker-receiver}"
-  export TAG
-  TAG="$(git rev-parse HEAD)"
   export KNATIVE_KAFKA_RECEIVER_IMAGE="${receiver}:${TAG}"
 
   ./mvnw package jib:build -pl ${RECEIVER_DIRECTORY} -DskipTests || return $?
@@ -63,8 +61,6 @@ function dispatcher_build_push() {
   header "Building dispatcher ..."
 
   local dispatcher="${KNATIVE_KAFKA_BROKER_DISPATCHER:-${KO_DOCKER_REPO}/knative-kafka-broker-dispatcher}"
-  export TAG
-  TAG="$(git rev-parse HEAD)"
   export KNATIVE_KAFKA_DISPATCHER_IMAGE="${dispatcher}:${TAG}"
 
   ./mvnw package jib:build -pl "${DISPATCHER_DIRECTORY}" -DskipTests || return $?

--- a/hack/label.sh
+++ b/hack/label.sh
@@ -15,6 +15,6 @@
 # limitations under the License.
 
 # Update release labels
-export TAG=${TAG:-"devel"}
+export TAG=${TAG:-$(git rev-parse HEAD)}
 echo "Updating release labels to kafka.eventing.knative.dev/release: \"${TAG}\""
 export LABEL_YAML_CMD=(sed -e "s|kafka.eventing.knative.dev/release: devel|kafka.eventing.knative.dev/release: \"${TAG}\"|")


### PR DESCRIPTION
Fix errors during nightly builds [1]

[1] https://prow.knative.dev/view/gs/knative-prow/logs/nightly_eventing-kafka-broker_main_periodic/1538816108792909824

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>