### PR TITLE
Fix high memory usage for dispatcher pods

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/500-controller.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/500-controller.yaml
@@ -133,6 +133,8 @@ spec:
 
             - name: BROKER_DEFAULT_BACKOFF_DELAY_MS
               value: "1000" # 1 second
+            - name: CHANNEL_DEFAULT_BACKOFF_DELAY_MS
+              value: "1000" # 1 second
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/data-plane/THIRD-PARTY.txt
+++ b/data-plane/THIRD-PARTY.txt
@@ -1,5 +1,5 @@
 
-Lists of 158 third-party dependencies.
+Lists of 157 third-party dependencies.
      (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Classic Module (ch.qos.logback:logback-classic:1.2.11 - http://logback.qos.ch/logback-classic)
      (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Core Module (ch.qos.logback:logback-core:1.2.11 - http://logback.qos.ch/logback-core)
      (The Apache Software License, Version 2.0) Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.13.2 - http://github.com/FasterXML/jackson)
@@ -103,7 +103,6 @@ Lists of 158 third-party dependencies.
      (The Apache Software License, Version 2.0) Prometheus Java Span Context Supplier - OpenTelemetry (io.prometheus:simpleclient_tracer_otel:0.12.0 - http://github.com/prometheus/client_java/simpleclient_tracer/simpleclient_tracer_otel)
      (The Apache Software License, Version 2.0) Prometheus Java Span Context Supplier - OpenTelemetry Agent (io.prometheus:simpleclient_tracer_otel_agent:0.12.0 - http://github.com/prometheus/client_java/simpleclient_tracer/simpleclient_tracer_otel_agent)
      (Eclipse Public License - v 1.0) (The Apache Software License, Version 2.0) vertx-auth-common (io.vertx:vertx-auth-common:4.2.5 - http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-ext/vertx-ext-parent/vertx-auth/vertx-auth-common)
-     (Eclipse Public License - v 1.0) (The Apache Software License, Version 2.0) vertx-circuit-breaker (io.vertx:vertx-circuit-breaker:4.2.5 - http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-ext/vertx-ext-parent/vertx-circuit-breaker)
      (Eclipse Public License - v 2.0) (The Apache Software License, Version 2.0) Vert.x Core (io.vertx:vertx-core:4.2.5 - http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-core)
      (Eclipse Public License - v 1.0) (The Apache Software License, Version 2.0) Vert.x JUnit 5 support :: Core (io.vertx:vertx-junit5:4.2.5 - http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-ext/vertx-ext-parent/vertx-junit5)
      (Eclipse Public License - v 1.0) (The Apache Software License, Version 2.0) Vert.x Kafka Client (io.vertx:vertx-kafka-client:4.2.5 - http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-ext/vertx-ext-parent/vertx-kafka-client)

--- a/data-plane/dispatcher/pom.xml
+++ b/data-plane/dispatcher/pom.xml
@@ -43,16 +43,6 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-kafka-client</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-circuit-breaker</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hdrhistogram</groupId>
-          <artifactId>HdrHistogram</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
     <dependency>
       <groupId>io.vertx</groupId>

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
@@ -90,9 +90,10 @@ public final class WebClientCloudEventSender implements CloudEventSender {
   }
 
   private Future<HttpResponse<Buffer>> send(final CloudEvent event, final int retryCounter) {
-    logger.debug("Sending event {} {}",
+    logger.debug("Sending event {} {} {}",
       keyValue("id", event.getId()),
-      keyValue("subscriberURI", target)
+      keyValue("subscriberURI", target),
+      keyValue("retry", retryCounter)
     );
 
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
@@ -338,18 +338,6 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
     return new WebClientCloudEventSender(vertx, WebClient.create(vertx, this.webClientOptions), target, egress);
   }
 
-  /* package visibility for test */
-  public static Function<Integer, Long> computeRetryPolicy(final EgressConfig egress) {
-    if (egress != null && egress.getBackoffDelay() > 0) {
-      final var delay = egress.getBackoffDelay();
-      return switch (egress.getBackoffPolicy()) {
-        case Linear -> retryCount -> delay * retryCount;
-        case Exponential, UNRECOGNIZED -> retryCount -> delay * Math.round(Math.pow(2, retryCount));
-      };
-    }
-    return retry -> 0L; // Default Vert.x retry policy, it means don't retry
-  }
-
   private static boolean hasDeadLetterSink(final EgressConfig egressConfig) {
     return !(egressConfig == null || egressConfig.getDeadLetter().isEmpty());
   }
@@ -371,7 +359,7 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
   }
 
   private static long maxProcessingTimeMs(final EgressConfig egressConfig) {
-    final var retryPolicy = computeRetryPolicy(egressConfig);
+    final var retryPolicy = WebClientCloudEventSender.computeRetryPolicy(egressConfig);
     final var retry = egressConfig.getRetry();
     final var timeout = egressConfig.getTimeout();
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
@@ -350,7 +350,7 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
       .closeHandler(r -> logger.info("Circuit breaker closed {}", keyValue("target", target)));
 
     return new WebClientCloudEventSender(
-      WebClient.create(vertx, this.webClientOptions), circuitBreaker, circuitBreakerOptions, target
+      vertx, WebClient.create(vertx, this.webClientOptions), circuitBreaker, circuitBreakerOptions, target, egress
     );
   }
 
@@ -386,7 +386,7 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
   }
 
   /* package visibility for test */
-  static Function<Integer, Long> computeRetryPolicy(final EgressConfig egress) {
+  public static Function<Integer, Long> computeRetryPolicy(final EgressConfig egress) {
     if (egress != null && egress.getBackoffDelay() > 0) {
       final var delay = egress.getBackoffDelay();
       return switch (egress.getBackoffPolicy()) {

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSenderTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSenderTest.java
@@ -15,21 +15,33 @@
  */
 package dev.knative.eventing.kafka.broker.dispatcher.impl.http;
 
+import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
+import io.cloudevents.core.builder.CloudEventBuilder;
 import io.vertx.circuitbreaker.CircuitBreaker;
 import io.vertx.circuitbreaker.CircuitBreakerOptions;
+import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.net.URI;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static dev.knative.eventing.kafka.broker.dispatcher.impl.http.WebClientCloudEventSender.isRetryableStatusCode;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -40,7 +52,7 @@ import static org.mockito.Mockito.when;
 public class WebClientCloudEventSenderTest {
 
   @Test
-  public void shouldCloseCircuitBreakerAndWebClient(final VertxTestContext context) {
+  public void shouldCloseCircuitBreakerAndWebClient(final Vertx vertx, final VertxTestContext context) {
 
     final var circuitBreaker = mock(CircuitBreaker.class);
     when(circuitBreaker.close()).thenReturn(circuitBreaker);
@@ -49,8 +61,8 @@ public class WebClientCloudEventSenderTest {
     doNothing().when(webClient).close();
 
     final var consumerRecordSender = new WebClientCloudEventSender(
-      webClient, circuitBreaker, new CircuitBreakerOptions(), "http://localhost:12345"
-    );
+      vertx, webClient, circuitBreaker, new CircuitBreakerOptions(), "http://localhost:12345",
+      DataPlaneContract.EgressConfig.getDefaultInstance());
 
     consumerRecordSender.close()
       .onFailure(context::failNow)
@@ -59,6 +71,124 @@ public class WebClientCloudEventSenderTest {
         verify(webClient, times(1)).close();
         context.completeNow();
       }));
+  }
+
+  @Test
+  @Timeout(value = 20000)
+  public void shouldRetry(final Vertx vertx, final VertxTestContext context) throws ExecutionException, InterruptedException {
+
+    final var port = 12345;
+    final var retry = 5;
+    final var event = CloudEventBuilder.v1()
+      .withId(UUID.randomUUID().toString())
+      .withSource(URI.create("/api/v1/orders"))
+      .withType("dev.knative.eventing.created")
+      .build();
+
+    final var counter = new LongAdder();
+
+    vertx.createHttpServer()
+      .requestHandler(r -> {
+        if (r.getHeader("Ce-Id").equalsIgnoreCase(event.getId())) {
+          counter.increment();
+        }
+        if (counter.intValue() == 5) {
+          r.response().setStatusCode(200).end();
+        } else {
+          r.response().setStatusCode(500).end();
+        }
+      })
+      .listen(port, "localhost")
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get();
+
+    final var sender = new WebClientCloudEventSender(
+      vertx,
+      WebClient.create(vertx),
+      CircuitBreaker.create("localhost" + port, vertx),
+      new CircuitBreakerOptions().setTimeout(1000L),
+      "http://localhost:" + port,
+      DataPlaneContract.EgressConfig.newBuilder()
+        .setBackoffDelay(100L)
+        .setBackoffPolicy(DataPlaneContract.BackoffPolicy.Linear)
+        .setRetry(retry)
+        .build()
+    );
+
+    final var success = new AtomicBoolean(false);
+
+    sender.send(event)
+      .onFailure(context::failNow)
+      .onSuccess(v -> success.set(true));
+
+    await().untilTrue(success);
+    await().untilAdder(counter, is(equalTo(5L)));
+
+    // Verify that after some time counter is still equal to 5.
+    Thread.sleep(10000L);
+    await().untilAdder(counter, is(equalTo(5L)));
+
+    sender.close().onSuccess(v -> context.completeNow());
+  }
+
+  @Test
+  @Timeout(value = 20000)
+  public void shouldRetryAndFail(final Vertx vertx, final VertxTestContext context) throws ExecutionException, InterruptedException {
+
+    final var port = 12345;
+    final var retry = 5;
+    final var event = CloudEventBuilder.v1()
+      .withId(UUID.randomUUID().toString())
+      .withSource(URI.create("/api/v1/orders"))
+      .withType("dev.knative.eventing.created")
+      .build();
+
+    final var counter = new LongAdder();
+
+    vertx.createHttpServer()
+      .requestHandler(r -> {
+        if (r.getHeader("Ce-Id").equalsIgnoreCase(event.getId())) {
+          counter.increment();
+        }
+        if (counter.intValue() > retry+1) {
+          r.response().setStatusCode(200).end();
+        } else {
+          r.response().setStatusCode(500).end();
+        }
+      })
+      .listen(port, "localhost")
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get();
+
+    final var sender = new WebClientCloudEventSender(
+      vertx,
+      WebClient.create(vertx),
+      CircuitBreaker.create("localhost" + port, vertx),
+      new CircuitBreakerOptions().setTimeout(1000L),
+      "http://localhost:" + port,
+      DataPlaneContract.EgressConfig.newBuilder()
+        .setBackoffDelay(100L)
+        .setBackoffPolicy(DataPlaneContract.BackoffPolicy.Linear)
+        .setRetry(retry)
+        .build()
+    );
+
+    final var success = new AtomicBoolean(true);
+
+    sender.send(event)
+      .onFailure(v -> success.set(false))
+      .onSuccess(v -> success.set(true));
+
+    await().untilFalse(success);
+    await().untilAdder(counter, is(equalTo(6L)));
+
+    // Verify that after some time counter is still equal to 6.
+    Thread.sleep(10000L);
+    await().untilAdder(counter, is(equalTo(6L)));
+
+    sender.close().onSuccess(v -> context.completeNow());
   }
 
   @ParameterizedTest

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSenderTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSenderTest.java
@@ -233,11 +233,11 @@ public class WebClientCloudEventSenderTest {
       .onSuccess(v -> success.set(true));
 
     await().untilFalse(success);
-    await().untilAdder(counter, is(equalTo(retry+1)));
+    await().untilAdder(counter, is(equalTo(retry+1L)));
 
     // Verify that after some time counter is still equal to 6.
     Thread.sleep(10000L);
-    await().untilAdder(counter, is(equalTo(retry+1)));
+    await().untilAdder(counter, is(equalTo(retry+1L)));
 
     sender.close().onSuccess(v -> context.completeNow());
   }

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSenderTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSenderTest.java
@@ -233,11 +233,11 @@ public class WebClientCloudEventSenderTest {
       .onSuccess(v -> success.set(true));
 
     await().untilFalse(success);
-    await().untilAdder(counter, is(equalTo(6L)));
+    await().untilAdder(counter, is(equalTo(retry+1)));
 
     // Verify that after some time counter is still equal to 6.
     Thread.sleep(10000L);
-    await().untilAdder(counter, is(equalTo(6L)));
+    await().untilAdder(counter, is(equalTo(retry+1)));
 
     sender.close().onSuccess(v -> context.completeNow());
   }

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSenderTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSenderTest.java
@@ -203,10 +203,10 @@ public class WebClientCloudEventSenderTest {
         if (r.getHeader("Ce-Id").equalsIgnoreCase(event.getId())) {
           counter.increment();
         }
-        if (counter.intValue() > retry+1) {
+        if (counter.intValue() > retry + 1) {
           r.response().setStatusCode(200).end();
         } else {
-          vertx.setTimer(timeout+500, v -> r.response().setStatusCode(200).end());
+          vertx.setTimer(timeout + 500, v -> r.response().setStatusCode(200).end());
         }
       })
       .listen(port, "localhost")

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImplTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImplTest.java
@@ -181,58 +181,6 @@ public class ConsumerVerticleFactoryImplTest {
   }
 
   @Test
-  public void linearBackoffPolicy() {
-
-    final var policy = ConsumerVerticleFactoryImpl.computeRetryPolicy(EgressConfig.newBuilder()
-      .setRetry(10)
-      .setBackoffPolicy(BackoffPolicy.Linear)
-      .setBackoffDelay(100)
-      .build());
-
-    final var delay = policy.apply(5);
-
-    assertThat(delay).isEqualTo(100 * 5);
-  }
-
-  @Test
-  public void exponentialBackoffPolicy() {
-
-    final var policy = ConsumerVerticleFactoryImpl.computeRetryPolicy(EgressConfig.newBuilder()
-      .setRetry(10)
-      .setBackoffPolicy(BackoffPolicy.Exponential)
-      .setBackoffDelay(100)
-      .build());
-
-    final var delay = policy.apply(5);
-
-    assertThat(delay).isEqualTo((long) (100 * Math.pow(2, 5)));
-  }
-
-  @Test
-  public void exponentialBackoffPolicyByDefault() {
-
-    final var policy = ConsumerVerticleFactoryImpl.computeRetryPolicy(EgressConfig.newBuilder()
-      .setRetry(10)
-      .setBackoffPolicy(BackoffPolicy.Exponential)
-      .setBackoffDelay(100)
-      .build());
-
-    final var delay = policy.apply(5);
-
-    assertThat(delay).isEqualTo((long) (100 * Math.pow(2, 5)));
-  }
-
-  @Test
-  public void noRetry() {
-
-    final var policy = ConsumerVerticleFactoryImpl.computeRetryPolicy(null);
-
-    final var delay = policy.apply(Double.valueOf(Math.random()).intValue());
-
-    assertThat(delay).isEqualTo(0);
-  }
-
-  @Test
   public void getNoopResponseHandler() {
     final var kafkaCounter = new AtomicInteger(0);
     final var httpCounter = new AtomicInteger(0);

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -132,11 +132,6 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
-        <artifactId>vertx-circuit-breaker</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
         <artifactId>vertx-opentelemetry</artifactId>
         <version>${vertx.version}</version>
       </dependency>


### PR DESCRIPTION
Fixes #2345

See for more details https://github.com/vert-x3/vertx-circuit-breaker/issues/58#issuecomment-1161414029 for the testing of this patch.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove vertx-circuit-breaker since it's overkill for our use case
- Move to a custom retry logic

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Fix high memory usage for dispatcher pods under load
```
