### PR TITLE
Adding KafkaSink to storage version migrator

### DIFF
--- a/control-plane/config/post-install/200-storage-version-migrator-cluster-role.yaml
+++ b/control-plane/config/post-install/200-storage-version-migrator-cluster-role.yaml
@@ -59,6 +59,19 @@ rules:
       - "patch"
       - "watch"
   - apiGroups:
+      - "eventing.knative.dev"
+    resources:
+      - "kafkasinks"
+      - "kafkasinks/finalizers"
+      - "kafkasinks/status"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "patch"
+      - "watch"
+  - apiGroups:
       - ""
     resources:
       - "namespaces"

--- a/control-plane/config/post-install/500-storage-version-migrator.yaml
+++ b/control-plane/config/post-install/500-storage-version-migrator.yaml
@@ -42,3 +42,4 @@ spec:
           args:
             - "kafkasources.sources.knative.dev"
             - "kafkachannels.messaging.knative.dev"
+            - "kafkasinks.eventing.knative.dev"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- adding `kafkasinks.eventing.knative.dev` to `storage-version-migrator` as a NOOP

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
