### PR TITLE
KafkaSink is binary now

### DIFF
--- a/control-plane/config/eventing-kafka-broker/100-sink/100-kafka-sink.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-sink/100-kafka-sink.yaml
@@ -73,15 +73,15 @@ spec:
                 contentMode:
                   description: |
                     CloudEvent content mode of Kafka messages sent to the topic.
-                    Possible values: [structured, binary] (default: structured)
+                    Possible values: [binary, structured] (default: binary)
                     - https://github.com/cloudevents/spec/blob/v1.0/spec.md#message
-                      - https://github.com/cloudevents/spec/blob/v1.0/kafka-protocol-binding.md#33-structured-content-mode
                       - https://github.com/cloudevents/spec/blob/v1.0/kafka-protocol-binding.md#32-binary-content-mode
+                      - https://github.com/cloudevents/spec/blob/v1.0/kafka-protocol-binding.md#33-structured-content-mode
                   type: string
                   enum:
-                    - structured
                     - binary
-                  default: structured
+                    - structured
+                  default: binary
                 auth:
                   description: 'Auth configurations'
                   type: object

--- a/control-plane/pkg/apis/eventing/v1alpha1/kafka_sink_defaults.go
+++ b/control-plane/pkg/apis/eventing/v1alpha1/kafka_sink_defaults.go
@@ -25,7 +25,7 @@ func (ks *KafkaSink) SetDefaults(ctx context.Context) {
 
 // SetDefaults sets KafkaSinkSpec defaults.
 func (kss *KafkaSinkSpec) SetDefaults(ctx context.Context) {
-	defaultMode := ModeStructured
+	defaultMode := ModeBinary
 
 	if kss.ContentMode == nil || *kss.ContentMode == "" {
 		kss.ContentMode = &defaultMode

--- a/control-plane/pkg/apis/eventing/v1alpha1/kafka_sink_defaults_test.go
+++ b/control-plane/pkg/apis/eventing/v1alpha1/kafka_sink_defaults_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestKafkaSinkSpecSetDefaults(t *testing.T) {
 
-	defaultMode := ModeStructured
+	defaultMode := ModeBinary
 
 	tests := []struct {
 		name string
@@ -33,7 +33,7 @@ func TestKafkaSinkSpecSetDefaults(t *testing.T) {
 		want *KafkaSinkSpec
 	}{
 		{
-			name: "structured content mode by default",
+			name: "binary content mode by default",
 			spec: &KafkaSinkSpec{},
 			want: &KafkaSinkSpec{
 				ContentMode: &defaultMode,

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -172,8 +172,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 		Uid:    string(ks.UID),
 		Topics: []string{ks.Spec.Topic},
 		Ingress: &contract.Ingress{
-			ContentMode: coreconfig.ContentModeFromString(*ks.Spec.ContentMode),
-			Path:        receiver.PathFromObject(ks),
+			Path: receiver.PathFromObject(ks),
 		},
 		BootstrapServers: kafka.BootstrapServersCommaSeparated(ks.Spec.BootstrapServers),
 		Reference: &contract.Reference{

--- a/control-plane/pkg/reconciler/sink/kafka_sink_test.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink_test.go
@@ -131,7 +131,7 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 						{
 							Uid:              SinkUUID,
 							Topics:           []string{SinkTopic()},
-							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_STRUCTURED, Path: receiver.Path(SinkNamespace, SinkName)},
+							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_BINARY, Path: receiver.Path(SinkNamespace, SinkName)},
 							BootstrapServers: bootstrapServers,
 							Reference:        SinkReference(),
 						},
@@ -188,7 +188,7 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 							Topics:           []string{SinkTopic()},
 							BootstrapServers: bootstrapServers,
 							Reference:        SinkReference(),
-							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_STRUCTURED, Path: receiver.Path(SinkNamespace, SinkName)},
+							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_BINARY, Path: receiver.Path(SinkNamespace, SinkName)},
 							Auth: &contract.Resource_AuthSecret{
 								AuthSecret: &contract.Reference{
 									Uuid:      SecretUUID,
@@ -256,7 +256,7 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 							BootstrapServers: bootstrapServers,
 							Reference:        SinkReference(),
 							Ingress: &contract.Ingress{
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 								Path:        receiver.Path(SinkNamespace, SinkName),
 							},
 						},
@@ -369,7 +369,7 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 						{
 							Uid:              SinkUUID,
 							Topics:           []string{"my-topic-1"},
-							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_STRUCTURED, Path: receiver.Path(SinkNamespace, SinkName)},
+							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_BINARY, Path: receiver.Path(SinkNamespace, SinkName)},
 							BootstrapServers: "kafka-broker:10000",
 							Reference:        SinkReference(),
 						},
@@ -476,7 +476,7 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 						{
 							Uid:              SinkUUID,
 							Topics:           []string{SinkTopic()},
-							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_STRUCTURED, Path: receiver.Path(SinkNamespace, SinkName)},
+							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_BINARY, Path: receiver.Path(SinkNamespace, SinkName)},
 							BootstrapServers: bootstrapServers,
 							Reference:        SinkReference(),
 						},
@@ -526,7 +526,7 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 						{
 							Uid:              SinkUUID,
 							Topics:           []string{SinkTopic()},
-							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_STRUCTURED, Path: receiver.Path(SinkNamespace, SinkName)},
+							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_BINARY, Path: receiver.Path(SinkNamespace, SinkName)},
 							BootstrapServers: bootstrapServers,
 							Reference:        SinkReference(),
 						},
@@ -599,7 +599,7 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 						{
 							Uid:              SinkUUID,
 							Topics:           []string{SinkTopic()},
-							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_STRUCTURED, Path: receiver.Path(SinkNamespace, SinkName)},
+							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_BINARY, Path: receiver.Path(SinkNamespace, SinkName)},
 							BootstrapServers: bootstrapServers,
 							Reference:        SinkReference(),
 						},
@@ -648,7 +648,7 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 							Topics:           []string{SinkTopic()},
 							BootstrapServers: bootstrapServers,
 							Reference:        SinkReference(),
-							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_STRUCTURED},
+							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_BINARY},
 						},
 					},
 				}, &env),
@@ -671,7 +671,7 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 						{
 							Uid:              SinkUUID,
 							Topics:           []string{SinkTopic()},
-							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_STRUCTURED, Path: receiver.Path(SinkNamespace, SinkName)},
+							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_BINARY, Path: receiver.Path(SinkNamespace, SinkName)},
 							BootstrapServers: bootstrapServers,
 							Reference:        SinkReference(),
 						},
@@ -749,7 +749,7 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 						{
 							Uid:              SinkUUID,
 							Topics:           []string{SinkTopic()},
-							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_STRUCTURED, Path: receiver.Path(SinkNamespace, SinkName)},
+							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_BINARY, Path: receiver.Path(SinkNamespace, SinkName)},
 							BootstrapServers: bootstrapServers,
 							Reference:        SinkReference(),
 						},
@@ -804,7 +804,7 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 						{
 							Uid:              SinkUUID,
 							Topics:           []string{SinkTopic()},
-							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_STRUCTURED, Path: receiver.Path(SinkNamespace, SinkName)},
+							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_BINARY, Path: receiver.Path(SinkNamespace, SinkName)},
 							BootstrapServers: bootstrapServers,
 							Reference:        SinkReference(),
 						},
@@ -864,7 +864,7 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 						{
 							Uid:              SinkUUID,
 							Topics:           []string{SinkTopic()},
-							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_STRUCTURED, Path: receiver.Path(SinkNamespace, SinkName)},
+							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_BINARY, Path: receiver.Path(SinkNamespace, SinkName)},
 							BootstrapServers: bootstrapServers,
 							Reference:        SinkReference(),
 						},
@@ -918,7 +918,7 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 						{
 							Uid:              SinkUUID,
 							Topics:           []string{SinkTopic()},
-							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_STRUCTURED, Path: receiver.Path(SinkNamespace, SinkName)},
+							Ingress:          &contract.Ingress{ContentMode: contract.ContentMode_BINARY, Path: receiver.Path(SinkNamespace, SinkName)},
 							BootstrapServers: bootstrapServers,
 							Reference:        SinkReference(),
 						},
@@ -991,7 +991,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 							Topics: []string{"topic"},
 							Ingress: &contract.Ingress{
 								Path:        "path",
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 							},
 							BootstrapServers: bootstrapServers,
 						},
@@ -1000,7 +1000,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 							Topics: []string{"topic"},
 							Ingress: &contract.Ingress{
 								Path:        "path",
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 							},
 							BootstrapServers: bootstrapServers,
 						},
@@ -1017,7 +1017,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 							Topics: []string{"topic"},
 							Ingress: &contract.Ingress{
 								Path:        "path",
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 							},
 							BootstrapServers: bootstrapServers,
 						},
@@ -1042,7 +1042,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 							Topics: []string{"topic"},
 							Ingress: &contract.Ingress{
 								Path:        "path",
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 							},
 							BootstrapServers: bootstrapServers,
 						},
@@ -1051,7 +1051,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 							Topics: []string{"topic-2"},
 							Ingress: &contract.Ingress{
 								Path:        "path",
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 							},
 							BootstrapServers: bootstrapServers,
 						},
@@ -1068,7 +1068,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 							Topics: []string{"topic"},
 							Ingress: &contract.Ingress{
 								Path:        "path",
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 							},
 							BootstrapServers: bootstrapServers,
 						},
@@ -1093,7 +1093,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 							Topics: []string{"topic"},
 							Ingress: &contract.Ingress{
 								Path:        "path",
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 							},
 							BootstrapServers: bootstrapServers,
 						},
@@ -1102,7 +1102,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 							Topics: []string{"topic-2"},
 							Ingress: &contract.Ingress{
 								Path:        "path",
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 							},
 							BootstrapServers: bootstrapServers,
 						},
@@ -1119,7 +1119,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 							Topics: []string{"topic"},
 							Ingress: &contract.Ingress{
 								Path:        "path",
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 							},
 							BootstrapServers: bootstrapServers,
 						},
@@ -1144,7 +1144,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 							Topics: []string{"topic"},
 							Ingress: &contract.Ingress{
 								Path:        "path",
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 							},
 							BootstrapServers: bootstrapServers,
 						},
@@ -1153,7 +1153,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 							Topics: []string{"topic-2"},
 							Ingress: &contract.Ingress{
 								Path:        "path",
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 							},
 							BootstrapServers: bootstrapServers,
 						},
@@ -1170,7 +1170,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 							Topics: []string{"topic"},
 							Ingress: &contract.Ingress{
 								Path:        "path",
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 							},
 							BootstrapServers: bootstrapServers,
 						},
@@ -1200,7 +1200,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 							Topics: []string{"topic"},
 							Ingress: &contract.Ingress{
 								Path:        "path",
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 							},
 							BootstrapServers: bootstrapServers,
 						},
@@ -1209,7 +1209,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 							Topics: []string{"topic-2"},
 							Ingress: &contract.Ingress{
 								Path:        "path",
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 							},
 							BootstrapServers: bootstrapServers,
 						},
@@ -1235,7 +1235,7 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 							Topics: []string{"topic"},
 							Ingress: &contract.Ingress{
 								Path:        "path",
-								ContentMode: contract.ContentMode_STRUCTURED,
+								ContentMode: contract.ContentMode_BINARY,
 							},
 							BootstrapServers: bootstrapServers,
 						},

--- a/test/e2e_new/resources/kafkasink/kafkasink_test.go
+++ b/test/e2e_new/resources/kafkasink/kafkasink_test.go
@@ -67,7 +67,7 @@ func Example_full() {
 		"topic":            "my-topic",
 		"bootstrapServers": []string{"my-bootstrap-server:8082"},
 	}
-	kafkasink.WithContentMode(eventingv1alpha1.ModeBinary)(cfg)
+	kafkasink.WithContentMode(eventingv1alpha1.ModeStructured)(cfg)
 	kafkasink.WithReplicationFactor(3)(cfg)
 	kafkasink.WithNumPartitions(10)(cfg)
 	kafkasink.WithAuthSecretName("abc")(cfg)
@@ -88,7 +88,7 @@ func Example_full() {
 	//   topic: "my-topic"
 	//   bootstrapServers:
 	//     - "my-bootstrap-server:8082"
-	//   contentMode: binary
+	//   contentMode: structured
 	//   numPartitions: 10
 	//   replicationFactor: 3
 	//   auth:


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- align the `KafkaSink` with the rest of the components and default to CE binary mode

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
The KafkaSink now uses CloudEvent binary content mode as default
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

* PR for docs: https://github.com/knative/docs/pull/5084