### PR TITLE
Ignore artifacts files only in the root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,18 +28,18 @@ data-plane/**/build/
 **/.vscode/
 
 ## Ignore released file
-eventing-kafka-controller.yaml
-eventing-kafka-source.yaml
-eventing-kafka-broker.yaml
-eventing-kafka-channel.yaml
-eventing-kafka-sink.yaml
+/eventing-kafka-controller.yaml
+/eventing-kafka-source.yaml
+/eventing-kafka-broker.yaml
+/eventing-kafka-channel.yaml
+/eventing-kafka-sink.yaml
 
-eventing-kafka-post-install.yaml
+/eventing-kafka-post-install.yaml
 
-eventing-kafka-controller-prometheus-operator.yaml
-eventing-kafka-source-prometheus-operator.yaml
-eventing-kafka-channel-prometheus-operator.yaml
-eventing-kafka-broker-prometheus-operator.yaml
-eventing-kafka-sink-prometheus-operator.yaml
+/eventing-kafka-controller-prometheus-operator.yaml
+/eventing-kafka-source-prometheus-operator.yaml
+/eventing-kafka-channel-prometheus-operator.yaml
+/eventing-kafka-broker-prometheus-operator.yaml
+/eventing-kafka-sink-prometheus-operator.yaml
 
-eventing-kafka-source-bundle.yaml
+/eventing-kafka-source-bundle.yaml


### PR DESCRIPTION
Without the `/` it will ignore files with the same name in all
directories

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>