### PR TITLE
Force include all Kafka clients classes

### DIFF
--- a/data-plane/dispatcher/pom.xml
+++ b/data-plane/dispatcher/pom.xml
@@ -156,6 +156,12 @@
                     <include>**</include>
                   </includes>
                 </filter>
+                <filter>
+                  <artifact>org.apache.kafka:kafka-clients</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
               </filters>
             </configuration>
           </execution>

--- a/data-plane/receiver/pom.xml
+++ b/data-plane/receiver/pom.xml
@@ -148,6 +148,12 @@
                     <include>**</include>
                   </includes>
                 </filter>
+                <filter>
+                  <artifact>org.apache.kafka:kafka-clients</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
               </filters>
             </configuration>
           </execution>


### PR DESCRIPTION
I'm getting StikyAssignor ClassNotFound when building the data plane
without `Jib` by running `./mvnw package` and using the jar
`data-plane/dispatcher/target/dispatcher-1.0-SNAPSHOT.jar`.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>
