### PR TITLE
Increase default HTTP client max pool size

### DIFF
--- a/data-plane/config/broker/100-config-kafka-broker-data-plane.yaml
+++ b/data-plane/config/broker/100-config-kafka-broker-data-plane.yaml
@@ -175,5 +175,6 @@ data:
     # ssl.trustmanager.algorithm
   config-kafka-broker-webclient.properties: |
     idleTimeout=10000
+    maxPoolSize=100
   config-kafka-broker-httpserver.properties: |
     idleTimeout=0

--- a/data-plane/config/channel/100-config-kafka-channel-data-plane.yaml
+++ b/data-plane/config/channel/100-config-kafka-channel-data-plane.yaml
@@ -174,5 +174,6 @@ data:
     # ssl.trustmanager.algorithm
   config-kafka-channel-webclient.properties: |
     idleTimeout=10000
+    maxPoolSize=100
   config-kafka-channel-httpserver.properties: |
     idleTimeout=0

--- a/data-plane/config/source/100-config-kafka-source-data-plane.yaml
+++ b/data-plane/config/source/100-config-kafka-source-data-plane.yaml
@@ -157,4 +157,4 @@ data:
     # ssl.trustmanager.algorithm
   config-kafka-source-webclient.properties: |
     idleTimeout=10000
-    # maxPoolSize=50
+    maxPoolSize=100


### PR DESCRIPTION
During some perf-testing for KafkaSource, we've observed
that the Vert.x's default for `maxPoolSize` is too low
for parallel event dispatch.

This is just changing the default values to improve the out
of the box experience and the common use case, people can
still change it.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>