### PR TITLE
GH actions - E2E tests for namespaced broker

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -26,6 +26,7 @@ jobs:
 
         broker-class:
           - Kafka
+          - KafkaNamespaced
 
         test-suite:
           - ./test/e2e
@@ -49,6 +50,20 @@ jobs:
             kind-image-sha: sha256:0df8215895129c0d3221cda19847d1296c4f29ec93487339149333bd9d899e5a
           - test-suite: ./test/e2e_channel
             extra-test-flags: -channels=messaging.knative.dev/v1beta1:KafkaChannel
+
+        exclude:
+          - test-suite: ./test/e2e
+            broker-class: KafkaNamespaced
+          - test-suite: ./test/e2e_sink
+            broker-class: KafkaNamespaced
+          - test-suite: ./test/e2e_source
+            broker-class: KafkaNamespaced
+          - test-suite: ./test/e2e_channel
+            broker-class: KafkaNamespaced
+          - test-suite: ./test/e2e_new_channel
+            broker-class: KafkaNamespaced
+          - test-suite: ./test/experimental
+            broker-class: KafkaNamespaced
 
     env:
       GOPATH: ${{ github.workspace }}

--- a/control-plane/cmd/kafka-controller/main.go
+++ b/control-plane/cmd/kafka-controller/main.go
@@ -76,22 +76,21 @@ func main() {
 			},
 		},
 
-		// TODO: enable later
-		//// Namespaced broker controller
-		//injection.NamedControllerConstructor{
-		//	Name: "broker-namespaced-controller",
-		//	ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
-		//		return broker.NewNamespacedController(ctx, watcher, brokerEnv)
-		//	},
-		//},
-		//
-		//// Namespaced trigger controller
-		//injection.NamedControllerConstructor{
-		//	Name: "trigger-namespaced-controller",
-		//	ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
-		//		return trigger.NewNamespacedController(ctx, watcher, brokerEnv)
-		//	},
-		//},
+		// Namespaced broker controller
+		injection.NamedControllerConstructor{
+			Name: "broker-namespaced-controller",
+			ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
+				return broker.NewNamespacedController(ctx, watcher, brokerEnv)
+			},
+		},
+
+		// Namespaced trigger controller
+		injection.NamedControllerConstructor{
+			Name: "trigger-namespaced-controller",
+			ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
+				return trigger.NewNamespacedController(ctx, watcher, brokerEnv)
+			},
+		},
 
 		// Channel controller
 		injection.NamedControllerConstructor{

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -27,7 +27,21 @@ if [ "${EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO:-""}" != "" ]; then
   success
 fi
 
+# TODO: going to be reverted once we have the Prow changes in https://github.com/knative/test-infra
 export BROKER_CLASS="Kafka"
+
+if [[ -z "${BROKER_CLASS}" ]]; then
+  fail_test "Broker class is not defined. Specify it with 'BROKER_CLASS' env var."
+else
+  echo "BROKER_CLASS is set to '${BROKER_CLASS}'. Running tests for that broker class."
+fi
+
+if [ "${BROKER_CLASS}" == "KafkaNamespaced" ]; then
+  # if flag exists, only test tests that are relevant to namespaced KafkaBroker
+  echo "BROKER_CLASS is set to 'KafkaNamespaced'. Only running the relevant tests."
+  go_test_e2e -timeout=1h ./test/e2e_broker/... || fail_test "E2E suite failed (directory: ./e2e_broker/...)"
+  success
+fi
 
 go_test_e2e -timeout=1h ./test/e2e/...        || fail_test "E2E suite failed (directory: ./e2e/...)"
 go_test_e2e -timeout=1h ./test/e2e_broker/... || fail_test "E2E suite failed (directory: ./e2e_broker/...)"

--- a/test/reconciler-tests.sh
+++ b/test/reconciler-tests.sh
@@ -27,7 +27,21 @@ if [ "${EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO:-""}" != "" ]; then
   success
 fi
 
+# TODO: going to be reverted once we have the Prow changes in https://github.com/knative/test-infra
 export BROKER_CLASS="Kafka"
+
+if [[ -z "${BROKER_CLASS}" ]]; then
+  fail_test "Broker class is not defined. Specify it with 'BROKER_CLASS' env var."
+else
+  echo "BROKER_CLASS is set to '${BROKER_CLASS}'. Running tests for that broker class."
+fi
+
+if [ "${BROKER_CLASS}" == "KafkaNamespaced" ]; then
+  # if flag exists, only test tests that are relevant to namespaced KafkaBroker
+  echo "BROKER_CLASS is set to 'KafkaNamespaced'. Only running the relevant tests."
+  go_test_e2e -timeout=1h ./test/e2e_new/... || fail_test "E2E (new) suite failed"
+  success
+fi
 
 go_test_e2e -timeout=1h ./test/e2e_new/... || fail_test "E2E (new) suite failed"
 

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -42,6 +42,7 @@ set -Eeuo pipefail
 TIMEOUT=${TIMEOUT:-100m}
 GO_TEST_VERBOSITY="${GO_TEST_VERBOSITY:-standard-verbose}"
 
+# TODO: we don't support upgrade tests for namespaced KafkaBroker right now
 export BROKER_CLASS="Kafka"
 
 EVENTING_KAFKA_BROKER_UPGRADE_TESTS_FINISHEDSLEEP="5m" \


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- GH actions - E2E tests for namespaced broker
- Broker class is still hardcoded to `Kafka` in Prow e2e tests
- Gonna remove the hardcoding in a separate PR when https://github.com/knative/test-infra/pull/3466 is merged

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
