### PR TITLE
Fix flaky processing latency assertion

### DIFF
--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherTest.java
@@ -422,9 +422,8 @@ public class RecordDispatcherTest {
           .summaries()
           .stream()
           .reduce((a, b) -> b)
-          .get()
-          .max()
-      ).isGreaterThan(0)
+          .isPresent()
+      ).isTrue()
     );
   }
 


### PR DESCRIPTION
The processing latency is sometimes too small that the distribution
produces 0 anyway.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>