### PR TITLE
Ignore trailing slashes for path-based routing

### DIFF
--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/IngressProducerReconcilableStore.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/IngressProducerReconcilableStore.java
@@ -89,7 +89,7 @@ public class IngressProducerReconcilableStore implements IngressReconcilerListen
     // That means, we support these modes:
     // - Request coming to "/path" --> path is used for matching
     // - Request coming to "/" --> hostname is used for matching
-    final var p = pathMapper.get(path);
+    final var p = pathMapper.get(removeTrailingSlash(path));
     if (p != null) {
       return p;
     }
@@ -111,6 +111,13 @@ public class IngressProducerReconcilableStore implements IngressReconcilerListen
     // the old implementations.
 
     return hostMapper.get(host);
+  }
+
+  private String removeTrailingSlash(final String path) {
+    if (path.endsWith("/")) {
+      return path.substring(0, path.length() - 1);
+    }
+    return path;
   }
 
   @Override

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/IngressProducerReconcilableStoreTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/IngressProducerReconcilableStoreTest.java
@@ -406,6 +406,7 @@ public class IngressProducerReconcilableStoreTest {
 
           // only use path when the path is registered
           assertThat(store.resolve("http://host1", "/hello1").getKafkaProducer()).isSameAs(producer1);
+          assertThat(store.resolve("http://host1", "/hello1/").getKafkaProducer()).isSameAs(producer1);
           assertThat(store.resolve("http://host2", "/hello1").getKafkaProducer()).isSameAs(producer1);
           assertThat(store.resolve("http://host1", "/hello3").getKafkaProducer()).isSameAs(producer3);
           assertThat(store.resolve("http://host2", "/hello3").getKafkaProducer()).isSameAs(producer3);


### PR DESCRIPTION
Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Part of https://github.com/knative/eventing/issues/6467

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Kafka Broker and KafkaSink ignore a trailing slash in the HTTP path.
```