### PR TITLE
Fix ownerRef cannot be set on resources you cannot delete

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
@@ -25,6 +25,12 @@ rules:
       - "*"
     resources:
       - configmaps
+    verbs:
+      - delete
+  - apiGroups:
+      - "*"
+    resources:
+      - configmaps
       - services
     verbs:
       - get


### PR DESCRIPTION
In OpenShift, I'm getting the above error when creating a
KafkaSource without the patch.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>