### PR TITLE
Propagate non-ready consumers top level condition in ConsumerGroup

### DIFF
--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_lifecycle.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_lifecycle.go
@@ -52,6 +52,16 @@ func (cg *ConsumerGroup) MarkReconcileConsumersFailed(reason string, err error) 
 	return err
 }
 
+func (cg *ConsumerGroup) MarkReconcileConsumersFailedCondition(condition *apis.Condition) error {
+	cg.GetConditionSet().Manage(cg.GetStatus()).MarkFalse(
+		ConditionConsumerGroupConsumers,
+		condition.GetReason(),
+		condition.GetMessage(),
+	)
+
+	return fmt.Errorf("consumers aren't ready, %v: %v", condition.GetReason(), condition.GetMessage())
+}
+
 func (cg *ConsumerGroup) MarkReconcileConsumersSucceeded() {
 	cg.GetConditionSet().Manage(cg.GetStatus()).MarkTrue(ConditionConsumerGroupConsumers)
 }

--- a/control-plane/pkg/reconciler/testing/objects_consumer.go
+++ b/control-plane/pkg/reconciler/testing/objects_consumer.go
@@ -19,6 +19,7 @@ package testing
 import (
 	"context"
 	"fmt"
+	"io"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -293,6 +294,18 @@ func ConsumerForTrigger() ConsumerGroupOption {
 func ConsumerReady() ConsumerOption {
 	return func(c *kafkainternals.Consumer) {
 		c.MarkBindSucceeded()
+		c.MarkReconcileContractSucceeded()
+		c.Status.SubscriberURI = ConsumerSubscriberURI
+
+		if c.HasDeadLetterSink() {
+			c.Status.DeadLetterSinkURI = ConsumerDeadLetterSinkURI
+		}
+	}
+}
+
+func ConsumerNotReady() ConsumerOption {
+	return func(c *kafkainternals.Consumer) {
+		_ = c.MarkBindFailed(io.EOF)
 		c.MarkReconcileContractSucceeded()
 		c.Status.SubscriberURI = ConsumerSubscriberURI
 


### PR DESCRIPTION
When a Consumer wasn't ready, we would get a generic error
on the user-facing API which isn't optimal to debug the issue.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>