### PR TITLE
`pod.Status.Phase == apiv1.PodRunning` is not a good way to test if pods are Running

### DIFF
--- a/control-plane/pkg/reconciler/base/reconciler.go
+++ b/control-plane/pkg/reconciler/base/reconciler.go
@@ -101,7 +101,16 @@ func (r *Reconciler) IsDispatcherRunning() bool {
 
 func isAtLeastOneRunning(pods []*corev1.Pod) bool {
 	for _, pod := range pods {
-		if pod.Status.Phase == corev1.PodRunning {
+		if isReady(pod) {
+			return true
+		}
+	}
+	return false
+}
+
+func isReady(pod *corev1.Pod) bool {
+	for _, c := range pod.Status.Conditions {
+		if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
 			return true
 		}
 	}

--- a/control-plane/pkg/reconciler/base/reconciler_test.go
+++ b/control-plane/pkg/reconciler/base/reconciler_test.go
@@ -284,7 +284,10 @@ func addRunningPod(store cache.Store, kc kubernetes.Interface, label string) {
 			Namespace: "ns",
 			Labels:    map[string]string{"app": label},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
 	}
 
 	if err := store.Add(pod); err != nil {

--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -303,7 +303,8 @@ func BrokerDispatcherPod(namespace string, annotations map[string]string) runtim
 			},
 		},
 		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
 		},
 	}
 }
@@ -323,7 +324,8 @@ func BrokerReceiverPod(namespace string, annotations map[string]string) runtime.
 			},
 		},
 		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
 		},
 	}
 }

--- a/control-plane/pkg/reconciler/testing/objects_channel.go
+++ b/control-plane/pkg/reconciler/testing/objects_channel.go
@@ -135,7 +135,8 @@ func ChannelReceiverPod(namespace string, annotations map[string]string) runtime
 			},
 		},
 		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
 		},
 	}
 }
@@ -155,7 +156,8 @@ func ChannelDispatcherPod(namespace string, annotations map[string]string) runti
 			},
 		},
 		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
 		},
 	}
 }

--- a/control-plane/pkg/reconciler/testing/objects_sink.go
+++ b/control-plane/pkg/reconciler/testing/objects_sink.go
@@ -150,7 +150,8 @@ func SinkReceiverPod(namespace string, annotations map[string]string) runtime.Ob
 			},
 		},
 		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
 		},
 	}
 }

--- a/control-plane/pkg/reconciler/testing/objects_source.go
+++ b/control-plane/pkg/reconciler/testing/objects_source.go
@@ -143,7 +143,8 @@ func SourceDispatcherPod(namespace string, annotations map[string]string) runtim
 			},
 		},
 		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
 		},
 	}
 }


### PR DESCRIPTION
See https://github.com/kubernetes/client-go/issues/815

I'm using the logic used by https://pkg.go.dev/k8s.io/kubernetes/pkg/api/v1/pod#IsPodReady
but that function is not in a library package so it can't be reused.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>
