### PR TITLE
Enable the tests that got commented out, by accident

### DIFF
--- a/test/e2e_new/dls_test.go
+++ b/test/e2e_new/dls_test.go
@@ -49,8 +49,8 @@ func TestDeadLetterSink(t *testing.T) {
 	)
 
 	env.Test(ctx, t, SendsEventErrorWithoutRetries())
-	//env.Test(ctx, t, SendsEventWithRetries())
-	//env.Test(ctx, t, SendsEventNoRetries())
+	env.Test(ctx, t, SendsEventWithRetries())
+	env.Test(ctx, t, SendsEventNoRetries())
 }
 
 func SendsEventWithRetries() *feature.Feature {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

As per title