### PR TITLE
Set TerminationMessagePolicy=FallbackToLogsOnError in a test image

### DIFF
--- a/test/pkg/kafka/verify_num_partitions_replication.go
+++ b/test/pkg/kafka/verify_num_partitions_replication.go
@@ -66,9 +66,10 @@ func VerifyNumPartitionAndReplicationFactor(
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:            name,
-							Image:           pkgtest.ImagePath(partitionReplicationVerifierImage),
-							ImagePullPolicy: corev1.PullIfNotPresent,
+							Name:                     name,
+							Image:                    pkgtest.ImagePath(partitionReplicationVerifierImage),
+							ImagePullPolicy:          corev1.PullIfNotPresent,
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 							Env: []corev1.EnvVar{
 								{
 									Name:  "BOOTSTRAP_SERVERS",


### PR DESCRIPTION
Set TerminationMessagePolicy=FallbackToLogsOnError for partition-replication-factor-verifier so that we can see the failure in the pod status

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Set TerminationMessagePolicy=FallbackToLogsOnError for partition-replication-factor-verifier so that we can see the failure in the pod status
- Otherwise we just see the pod crash and there are no logs for the pod
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
