### PR TITLE
Checking if received config has data or not

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -341,6 +341,13 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 	}
 
 	_, brokerConfig, err := r.brokerConfigMap(logger, broker)
+
+	// If the broker config data is empty we simply return,
+	// as the configuration may already be gone
+	if len(brokerConfig.Data) == 0 {
+		return nil
+	}
+
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}

--- a/control-plane/pkg/reconciler/broker/broker_test.go
+++ b/control-plane/pkg/reconciler/broker/broker_test.go
@@ -1994,6 +1994,32 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 			},
 		},
 		{
+			Name: "Reconciled normal - no ConfigMap and no annotations",
+			Objects: []runtime.Object{
+				NewDeletedBrokerWithoutConfigMapAnnotations(),
+				NewConfigMapFromContract(&contract.Contract{
+					Resources: []*contract.Resource{
+						{
+							Uid:     BrokerUUID,
+							Topics:  []string{BrokerTopic()},
+							Ingress: &contract.Ingress{Path: receiver.Path(BrokerNamespace, BrokerName)},
+						},
+					},
+					Generation: 1,
+				}, env.DataPlaneConfigMapNamespace, env.DataPlaneConfigMapName, env.DataPlaneConfigFormat),
+			},
+			Key: testKey,
+			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapUpdate(env.DataPlaneConfigMapNamespace, env.DataPlaneConfigMapName, env.DataPlaneConfigFormat, &contract.Contract{
+					Resources:  []*contract.Resource{},
+					Generation: 2,
+				}),
+			},
+			OtherTestData: map[string]interface{}{
+				testProber: probertesting.MockProber(prober.StatusNotReady),
+			},
+		},
+		{
 			Name: "Reconciled failed - probe not ready",
 			Objects: []runtime.Object{
 				NewDeletedBroker(),

--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -106,6 +106,17 @@ func NewDeletedBroker(options ...reconcilertesting.BrokerOption) runtime.Object 
 	)
 }
 
+func NewDeletedBrokerWithoutConfigMapAnnotations(options ...reconcilertesting.BrokerOption) runtime.Object {
+	return NewBroker(
+		append(
+			options,
+			func(broker *eventing.Broker) {
+				WithDeletedTimeStamp(broker)
+			},
+		)...,
+	)
+}
+
 func WithDelivery(mutations ...func(spec *eventingduck.DeliverySpec)) func(*eventing.Broker) {
 	service := NewService()
 

--- a/test/e2e_new/broker_test.go
+++ b/test/e2e_new/broker_test.go
@@ -57,3 +57,17 @@ func TestBrokerConfigMapDeletedFirst(t *testing.T) {
 
 	env.Test(ctx, t, features.BrokerConfigMapDeletedFirst())
 }
+
+func TestBrokerConfigMapDoesNotExist(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, features.BrokerConfigMapDoesNotExist())
+}

--- a/test/e2e_new/features/broker_deleted_recreated.go
+++ b/test/e2e_new/features/broker_deleted_recreated.go
@@ -18,9 +18,12 @@ package features
 
 import (
 	"k8s.io/apimachinery/pkg/types"
+
+	"knative.dev/pkg/system"
+
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/trigger"
-	"knative.dev/pkg/system"
+
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/resources/svc"
@@ -61,6 +64,19 @@ func BrokerConfigMapDeletedFirst() *feature.Feature {
 	)
 
 	f.Requirement("delete Broker ConfigMap", featuressteps.DeleteConfigMap(cmName))
+
+	f.Assert("delete broker", featuressteps.DeleteBroker(brokerName))
+
+	return f
+}
+
+// BrokerConfigMapDoesNotExist tests that a broker can be deleted without the ConfigMap existing.
+func BrokerConfigMapDoesNotExist() *feature.Feature {
+	f := feature.NewFeatureNamed("delete broker ConfigMap first")
+
+	brokerName := feature.MakeRandomK8sName("broker")
+
+	f.Setup("install broker", broker.Install(brokerName, append(broker.WithEnvConfig(), broker.WithConfig("doesNotExist"))...))
 
 	f.Assert("delete broker", featuressteps.DeleteBroker(brokerName))
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #2566

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- When finalizing the broker and the actual configuration can not be correctly received (e.g. an empty ConfigMap), we move on, to prevent blocking the finalization of the broker, as without deletion is stuck
- Adding a rekt test for the fix 
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
When finalizing the broker and the actual configuration can not be correctly received (e.g. an empty ConfigMap), we move on, to prevent blocking the finalization of the broker, as without deletion is stuck
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
