### PR TITLE
Check for kafka/network errors on finalizeKind, to unblock the borker deletion if the cluster is not reachable

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -386,10 +386,17 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 
 		// get security option for Sarama with secret info in it
 		securityOption := security.NewSaramaSecurityOptionFromSecret(secret)
-		if err := r.finalizeNonExternalBrokerTopic(broker, securityOption, topicConfig, logger); err != nil {
+		err = r.finalizeNonExternalBrokerTopic(broker, securityOption, topicConfig, logger)
+
+		// if finalizeNonExternalBrokerTopic returns error that kafka is not reachable,
+		// we return nil, and clean up the broker
+		if err != nil {
+			if strings.Contains(err.Error(), "cannot obtain Kafka") {
+				logger.Error("Error reaching Kafka cluster", zap.Error(err))
+				return nil
+			}
 			return err
 		}
-
 	}
 
 	if err := r.removeFinalizerSecret(ctx, finalizerSecret(broker), secret); err != nil {

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -57,6 +58,32 @@ const (
 	ConsumerConfigKey = "config-kafka-broker-consumer.properties"
 )
 
+type Counter struct {
+	counterLock sync.RWMutex
+	counterMap  map[string]int
+}
+
+func NewCounter() *Counter {
+	return &Counter{
+		counterLock: sync.RWMutex{},
+		counterMap:  make(map[string]int),
+	}
+}
+
+func (c Counter) Inc(brokerUUID string) int {
+	c.counterLock.Lock()
+	defer c.counterLock.Unlock()
+	c.counterMap[brokerUUID]++
+
+	return c.counterMap[brokerUUID]
+}
+
+func (c Counter) Del(brokerUUID string) {
+	c.counterLock.Lock()
+	defer c.counterLock.Unlock()
+	delete(c.counterMap, brokerUUID)
+}
+
 type Reconciler struct {
 	*base.Reconciler
 	*config.Env
@@ -71,7 +98,8 @@ type Reconciler struct {
 
 	BootstrapServers string
 
-	Prober prober.Prober
+	Prober  prober.Prober
+	Counter *Counter
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, broker *eventing.Broker) reconciler.Event {
@@ -388,12 +416,22 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 		securityOption := security.NewSaramaSecurityOptionFromSecret(secret)
 		err = r.finalizeNonExternalBrokerTopic(broker, securityOption, topicConfig, logger)
 
-		// if finalizeNonExternalBrokerTopic returns error that kafka is not reachable,
-		// we return nil, and clean up the broker
+		// if finalizeNonExternalBrokerTopic returns error that kafka is not reachable!
 		if err != nil {
 			if strings.Contains(err.Error(), "cannot obtain Kafka") {
-				logger.Error("Error reaching Kafka cluster", zap.Error(err))
-				return nil
+
+				// If the kafka cluster is not reachable we give it a few more retries, to see if there was
+				// some temporary network issue and requeue the finalization.
+				// If we tried often enough and the kafka cluster is still not reachable,
+				// we return nil and delete the broker
+				brokerUUID := string(broker.GetUID())
+				if r.Counter.Inc(brokerUUID) <= 5 {
+					return controller.NewRequeueAfter(5 * time.Second)
+				} else {
+					r.Counter.Del(brokerUUID) // clean up the reference from the counter
+					logger.Error("Error reaching Kafka cluster", zap.Error(err))
+					return nil
+				}
 			}
 			return err
 		}

--- a/control-plane/pkg/reconciler/broker/controller.go
+++ b/control-plane/pkg/reconciler/broker/controller.go
@@ -71,6 +71,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher, env *config.E
 		NewKafkaClusterAdminClient: sarama.NewClusterAdmin,
 		ConfigMapLister:            configmapInformer.Lister(),
 		Env:                        env,
+		Counter:                    NewCounter(),
 	}
 
 	logger := logging.FromContext(ctx)

--- a/test/e2e_new/broker_test.go
+++ b/test/e2e_new/broker_test.go
@@ -85,3 +85,17 @@ func TestTriggerLatestOffset(t *testing.T) {
 
 	env.Test(ctx, t, features.TriggerLatestOffset())
 }
+
+func TestBrokerCannotReachKafkaCluster(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, features.BrokerCannotReachKafkaCluster())
+}


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #2569

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- If apache kafka is not reachble, we do not longer block the finalization of the broker 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
If apache kafka is not reachble, we do not longer block the finalization/deletion of the knative kafka broker 
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
