### PR TITLE
Enable namespaced broker again

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -25,7 +25,7 @@ jobs:
 
         broker-class:
           - Kafka
-#          - KafkaNamespaced
+          - KafkaNamespaced
 
         test-suite:
           - ./test/e2e
@@ -50,19 +50,19 @@ jobs:
           - test-suite: ./test/e2e_channel
             extra-test-flags: -channels=messaging.knative.dev/v1beta1:KafkaChannel
 
-#        exclude:
-#          - test-suite: ./test/e2e
-#            broker-class: KafkaNamespaced
-#          - test-suite: ./test/e2e_sink
-#            broker-class: KafkaNamespaced
-#          - test-suite: ./test/e2e_source
-#            broker-class: KafkaNamespaced
-#          - test-suite: ./test/e2e_channel
-#            broker-class: KafkaNamespaced
-#          - test-suite: ./test/e2e_new_channel
-#            broker-class: KafkaNamespaced
-#          - test-suite: ./test/experimental
-#            broker-class: KafkaNamespaced
+        exclude:
+          - test-suite: ./test/e2e
+            broker-class: KafkaNamespaced
+          - test-suite: ./test/e2e_sink
+            broker-class: KafkaNamespaced
+          - test-suite: ./test/e2e_source
+            broker-class: KafkaNamespaced
+          - test-suite: ./test/e2e_channel
+            broker-class: KafkaNamespaced
+          - test-suite: ./test/e2e_new_channel
+            broker-class: KafkaNamespaced
+          - test-suite: ./test/experimental
+            broker-class: KafkaNamespaced
 
     env:
       KO_DOCKER_REPO: localhost:5001

--- a/control-plane/cmd/kafka-controller/main.go
+++ b/control-plane/cmd/kafka-controller/main.go
@@ -76,21 +76,21 @@ func main() {
 			},
 		},
 
-		//// Namespaced broker controller
-		//injection.NamedControllerConstructor{
-		//	Name: "broker-namespaced-controller",
-		//	ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
-		//		return broker.NewNamespacedController(ctx, watcher, brokerEnv)
-		//	},
-		//},
-		//
-		//// Namespaced trigger controller
-		//injection.NamedControllerConstructor{
-		//	Name: "trigger-namespaced-controller",
-		//	ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
-		//		return trigger.NewNamespacedController(ctx, watcher, brokerEnv)
-		//	},
-		//},
+		// Namespaced broker controller
+		injection.NamedControllerConstructor{
+			Name: "broker-namespaced-controller",
+			ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
+				return broker.NewNamespacedController(ctx, watcher, brokerEnv)
+			},
+		},
+
+		// Namespaced trigger controller
+		injection.NamedControllerConstructor{
+			Name: "trigger-namespaced-controller",
+			ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
+				return trigger.NewNamespacedController(ctx, watcher, brokerEnv)
+			},
+		},
 
 		// Channel controller
 		injection.NamedControllerConstructor{

--- a/control-plane/cmd/kafka-controller/main.go
+++ b/control-plane/cmd/kafka-controller/main.go
@@ -78,7 +78,7 @@ func main() {
 
 		// Namespaced broker controller
 		injection.NamedControllerConstructor{
-			Name: "broker-namespaced-controller",
+			Name: "namespaced-broker-controller",
 			ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
 				return broker.NewNamespacedController(ctx, watcher, brokerEnv)
 			},
@@ -86,7 +86,7 @@ func main() {
 
 		// Namespaced trigger controller
 		injection.NamedControllerConstructor{
-			Name: "trigger-namespaced-controller",
+			Name: "namespaced-trigger-controller",
 			ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
 				return trigger.NewNamespacedController(ctx, watcher, brokerEnv)
 			},

--- a/control-plane/pkg/reconciler/broker/namespaced_broker.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_broker.go
@@ -83,6 +83,12 @@ func (r *NamespacedReconciler) ReconcileKind(ctx context.Context, broker *eventi
 		prober.GetIPForService(types.NamespacedName{Namespace: broker.Namespace, Name: r.Env.IngressName}),
 	)
 
+	if broker.Spec.Config != nil && broker.Spec.Config.Namespace != "" && broker.Spec.Config.Namespace != broker.Namespace {
+		return propagateErrorCondition(broker,
+			fmt.Errorf("broker with %q class need the config in the same namespace with the broker. broker.spec.config.namespace=%q, broker.namespace=%q",
+				kafka.NamespacedBrokerClass, broker.Spec.Config.Namespace, broker.Namespace))
+	}
+
 	br := r.createReconcilerForBrokerInstance(broker)
 
 	manifest, err := r.getManifest(ctx, broker)

--- a/control-plane/pkg/reconciler/broker/namespaced_broker.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_broker.go
@@ -71,7 +71,8 @@ type NamespacedReconciler struct {
 
 	BootstrapServers string
 
-	Prober prober.Prober
+	Prober  prober.Prober
+	Counter *Counter
 
 	IPsLister          prober.IPListerWithMapping
 	ManifestivalClient mf.Client
@@ -141,7 +142,7 @@ func (r *NamespacedReconciler) createReconcilerForBrokerInstance(broker *eventin
 		NewKafkaClusterAdminClient: r.NewKafkaClusterAdminClient,
 		BootstrapServers:           r.BootstrapServers,
 		Prober:                     r.Prober,
-		Counter:                    NewCounter(),
+		Counter:                    r.Counter,
 	}
 }
 

--- a/control-plane/pkg/reconciler/broker/namespaced_controller.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_controller.go
@@ -89,6 +89,7 @@ func NewNamespacedController(ctx context.Context, watcher configmap.Watcher, env
 		ClusterRoleBindingLister:   clusterrolebindinginformer.Get(ctx).Lister(),
 		DeploymentLister:           deploymentinformer.Get(ctx).Lister(),
 		Env:                        env,
+		Counter:                    NewCounter(),
 		ManifestivalClient:         mfc,
 	}
 

--- a/control-plane/pkg/reconciler/trigger/namespaced_controller.go
+++ b/control-plane/pkg/reconciler/trigger/namespaced_controller.go
@@ -19,6 +19,9 @@ package trigger
 import (
 	"context"
 
+	"github.com/Shopify/sarama"
+	"knative.dev/eventing-kafka/pkg/common/kafka/offset"
+
 	"k8s.io/client-go/tools/cache"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap"
@@ -119,6 +122,9 @@ func NewNamespacedController(ctx context.Context, watcher configmap.Watcher, con
 			},
 		},
 	})
+
+	reconciler.SecretTracker = impl.Tracker
+	secretinformer.Get(ctx).Informer().AddEventHandler(controller.HandleAll(reconciler.SecretTracker.OnChanged))
 
 	return impl
 }

--- a/control-plane/pkg/reconciler/trigger/namespaced_controller.go
+++ b/control-plane/pkg/reconciler/trigger/namespaced_controller.go
@@ -60,8 +60,8 @@ func NewNamespacedController(ctx context.Context, watcher configmap.Watcher, con
 			KubeClient:                   kubeclient.Get(ctx),
 			PodLister:                    podinformer.Get(ctx).Lister(),
 			SecretLister:                 secretinformer.Get(ctx).Lister(),
-			DataPlaneConfigConfigMapName: configs.DataPlaneConfigConfigMapName,
 			DataPlaneConfigMapNamespace:  configs.DataPlaneConfigMapNamespace,
+			DataPlaneConfigConfigMapName: configs.DataPlaneConfigConfigMapName,
 			ContractConfigMapName:        configs.ContractConfigMapName,
 			ContractConfigMapFormat:      configs.ContractConfigMapFormat,
 			DataPlaneNamespace:           configs.SystemNamespace,
@@ -71,10 +71,13 @@ func NewNamespacedController(ctx context.Context, watcher configmap.Watcher, con
 		FlagsHolder: &FlagsHolder{
 			Flags: feature.Flags{},
 		},
-		BrokerLister:    brokerInformer.Lister(),
-		ConfigMapLister: configmapInformer.Lister(),
-		EventingClient:  eventingclient.Get(ctx),
-		Env:             configs,
+		BrokerLister:               brokerInformer.Lister(),
+		ConfigMapLister:            configmapInformer.Lister(),
+		EventingClient:             eventingclient.Get(ctx),
+		Env:                        configs,
+		NewKafkaClient:             sarama.NewClient,
+		NewKafkaClusterAdminClient: sarama.NewClusterAdmin,
+		InitOffsetsFunc:            offset.InitOffsets,
 	}
 
 	impl := triggerreconciler.NewImpl(ctx, reconciler, func(impl *controller.Impl) controller.Options {

--- a/control-plane/pkg/reconciler/trigger/namespaced_trigger.go
+++ b/control-plane/pkg/reconciler/trigger/namespaced_trigger.go
@@ -66,6 +66,8 @@ func (r *NamespacedReconciler) createReconcilerForTriggerInstance(trigger *event
 			KubeClient:                   r.Reconciler.KubeClient,
 			PodLister:                    r.Reconciler.PodLister,
 			SecretLister:                 r.Reconciler.SecretLister,
+			SecretTracker:                r.Reconciler.SecretTracker,
+			ConfigMapTracker:             r.Reconciler.ConfigMapTracker,
 			ContractConfigMapName:        r.Reconciler.ContractConfigMapName,
 			ContractConfigMapFormat:      r.Reconciler.ContractConfigMapFormat,
 			DataPlaneConfigConfigMapName: r.DataPlaneConfigConfigMapName,

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -3,7 +3,7 @@
 source $(dirname $0)/e2e-common.sh
 
 if ! ${SKIP_INITIALIZE}; then
-  initialize $@ --skip-istio-addon
+  initialize $@ --skip-istio-addon --min-nodes=4 --max-nodes=4
   save_release_artifacts || fail_test "Failed to save release artifacts"
 fi
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -28,7 +28,6 @@ if [ "${EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO:-""}" != "" ]; then
   success
 fi
 
-export BROKER_CLASS=Kafka
 if [[ -z "${BROKER_CLASS}" ]]; then
   fail_test "Broker class is not defined. Specify it with 'BROKER_CLASS' env var."
 else

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -37,9 +37,8 @@ fi
 
 if [ "${BROKER_CLASS}" == "KafkaNamespaced" ]; then
   # if flag exists, only test tests that are relevant to namespaced KafkaBroker
-  #  echo "BROKER_CLASS is set to 'KafkaNamespaced'. Only running the relevant tests."
-  #  go_test_e2e -timeout=1h ./test/e2e_broker/... || fail_test "E2E suite failed (directory: ./e2e_broker/...)"
-  echo "BROKER_CLASS is set to 'KafkaNamespaced'. Skipping tests."
+  echo "BROKER_CLASS is set to 'KafkaNamespaced'. Only running the relevant tests."
+  go_test_e2e -timeout=1h ./test/e2e_broker/... || fail_test "E2E suite failed (directory: ./e2e_broker/...)"
   success
 fi
 

--- a/test/e2e_broker/broker_redelivery_test.go
+++ b/test/e2e_broker/broker_redelivery_test.go
@@ -30,7 +30,7 @@ import (
 	"knative.dev/eventing/test/lib/resources"
 
 	kafkatesting "knative.dev/eventing-kafka-broker/test/pkg"
-	"knative.dev/eventing-kafka-broker/test/pkg/broker"
+	brokertest "knative.dev/eventing-kafka-broker/test/pkg/broker"
 )
 
 const (
@@ -38,19 +38,15 @@ const (
 )
 
 func TestBrokerRedeliveryBrokerV1BackoffLinear(t *testing.T) {
-	class, err := broker.GetKafkaClassFromEnv()
-	if err != nil {
-		t.Fatalf("error getting KafkaBroker class from env '%v'", err)
-	}
-
 	kafkatesting.RunMultiple(t, func(t *testing.T) {
 
 		helpers.BrokerRedelivery(context.Background(), t, func(client *testlib.Client, numRetries int32) string {
 
 			backoff := eventingduck.BackoffPolicyLinear
 
-			client.CreateBrokerOrFail(brokerName,
-				resources.WithBrokerClassForBroker(class),
+			brokertest.CreatorWithBrokerOptions(
+				client,
+				"v1",
 				resources.WithDeliveryForBroker(&eventingduck.DeliverySpec{
 					Retry:         &numRetries,
 					BackoffPolicy: &backoff,
@@ -64,19 +60,15 @@ func TestBrokerRedeliveryBrokerV1BackoffLinear(t *testing.T) {
 }
 
 func TestBrokerRedeliveryBrokerV1BackoffExponential(t *testing.T) {
-	class, err := broker.GetKafkaClassFromEnv()
-	if err != nil {
-		t.Fatalf("error getting KafkaBroker class from env '%v'", err)
-	}
-
 	kafkatesting.RunMultiple(t, func(t *testing.T) {
 
 		helpers.BrokerRedelivery(context.Background(), t, func(client *testlib.Client, numRetries int32) string {
 
 			backoff := eventingduck.BackoffPolicyExponential
 
-			client.CreateBrokerOrFail(brokerName,
-				resources.WithBrokerClassForBroker(class),
+			brokertest.CreatorWithBrokerOptions(
+				client,
+				"v1",
 				resources.WithDeliveryForBroker(&eventingduck.DeliverySpec{
 					Retry:         &numRetries,
 					BackoffPolicy: &backoff,

--- a/test/e2e_broker/conformance/control_plane_conformance_test.go
+++ b/test/e2e_broker/conformance/control_plane_conformance_test.go
@@ -20,29 +20,26 @@
 package conformance
 
 import (
-	"fmt"
 	"testing"
 
-	conformance "knative.dev/eventing/test/conformance/helpers"
-	testlib "knative.dev/eventing/test/lib"
-	"knative.dev/eventing/test/lib/resources"
+	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
 
 	pkgtesting "knative.dev/eventing-kafka-broker/test/pkg"
-	"knative.dev/eventing-kafka-broker/test/pkg/broker"
+	brokertest "knative.dev/eventing-kafka-broker/test/pkg/broker"
+	conformance "knative.dev/eventing/test/conformance/helpers"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 func brokerCreator(client *testlib.Client, name string) {
-
-	class, err := broker.GetKafkaClassFromEnv()
-	if err != nil {
-		panic(fmt.Sprintf("error getting KafkaBroker class from env '%v'", err))
-	}
-
-	b := client.CreateBrokerOrFail(name,
-		resources.WithBrokerClassForBroker(class),
+	brokertest.CreatorWithBrokerOptions(
+		client,
+		"v1",
+		func(b *eventing.Broker) {
+			b.Name = name
+		},
 	)
 
-	client.WaitForResourceReadyOrFail(b.Name, testlib.BrokerTypeMeta)
+	client.WaitForResourceReadyOrFail(name, testlib.BrokerTypeMeta)
 }
 
 func TestBrokerControlPlane(t *testing.T) {

--- a/test/e2e_new/broker_not_ready_test.go
+++ b/test/e2e_new/broker_not_ready_test.go
@@ -30,6 +30,7 @@ import (
 	"knative.dev/reconciler-test/pkg/knative"
 
 	brokerconfigmap "knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap/broker"
+	testpkg "knative.dev/eventing-kafka-broker/test/pkg"
 )
 
 func TestBrokerNotReadyAfterBeingReady(t *testing.T) {
@@ -55,7 +56,7 @@ func BrokerNotReadyAfterBeingReady() *feature.Feature {
 
 	f.Setup("create broker config", brokerconfigmap.Install(
 		configName,
-		brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+		brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersPlaintext),
 		brokerconfigmap.WithNumPartitions(1),
 		brokerconfigmap.WithReplicationFactor(1),
 	))

--- a/test/e2e_new/broker_test.go
+++ b/test/e2e_new/broker_test.go
@@ -31,7 +31,8 @@ import (
 )
 
 func TestBrokerDeletedRecreated(t *testing.T) {
-	t.Parallel()
+	// this test is observed to flake more when it is parallel
+	// t.Parallel()
 
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
@@ -45,7 +46,8 @@ func TestBrokerDeletedRecreated(t *testing.T) {
 }
 
 func TestBrokerConfigMapDeletedFirst(t *testing.T) {
-	t.Parallel()
+	// this test is observed to flake more when it is parallel
+	// t.Parallel()
 
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
@@ -59,7 +61,8 @@ func TestBrokerConfigMapDeletedFirst(t *testing.T) {
 }
 
 func TestBrokerConfigMapDoesNotExist(t *testing.T) {
-	t.Parallel()
+	// this test is observed to flake more when it is parallel
+	// t.Parallel()
 
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
@@ -73,7 +76,8 @@ func TestBrokerConfigMapDoesNotExist(t *testing.T) {
 }
 
 func TestTriggerLatestOffset(t *testing.T) {
-	t.Parallel()
+	// this test is observed to flake more when it is parallel
+	// t.Parallel()
 
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
@@ -87,7 +91,8 @@ func TestTriggerLatestOffset(t *testing.T) {
 }
 
 func TestBrokerCannotReachKafkaCluster(t *testing.T) {
-	t.Parallel()
+	// this test is observed to flake more when it is parallel
+	// t.Parallel()
 
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),

--- a/test/e2e_new/broker_test.go
+++ b/test/e2e_new/broker_test.go
@@ -21,6 +21,7 @@ package e2e_new
 
 import (
 	"testing"
+	"time"
 
 	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/environment"
@@ -28,6 +29,11 @@ import (
 	"knative.dev/reconciler-test/pkg/knative"
 
 	"knative.dev/eventing-kafka-broker/test/e2e_new/features"
+)
+
+const (
+	PollInterval = 3 * time.Second
+	PollTimeout  = 4 * time.Minute
 )
 
 func TestBrokerDeletedRecreated(t *testing.T) {
@@ -39,6 +45,7 @@ func TestBrokerDeletedRecreated(t *testing.T) {
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
+		environment.WithPollTimings(PollInterval, PollTimeout),
 		environment.Managed(t),
 	)
 
@@ -54,6 +61,7 @@ func TestBrokerConfigMapDeletedFirst(t *testing.T) {
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
+		environment.WithPollTimings(PollInterval, PollTimeout),
 		environment.Managed(t),
 	)
 
@@ -69,6 +77,7 @@ func TestBrokerConfigMapDoesNotExist(t *testing.T) {
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
+		environment.WithPollTimings(PollInterval, PollTimeout),
 		environment.Managed(t),
 	)
 
@@ -84,6 +93,7 @@ func TestTriggerLatestOffset(t *testing.T) {
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
+		environment.WithPollTimings(PollInterval, PollTimeout),
 		environment.Managed(t),
 	)
 
@@ -99,6 +109,7 @@ func TestBrokerCannotReachKafkaCluster(t *testing.T) {
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
+		environment.WithPollTimings(PollInterval, PollTimeout),
 		environment.Managed(t),
 	)
 

--- a/test/e2e_new/dls_test.go
+++ b/test/e2e_new/dls_test.go
@@ -22,6 +22,8 @@ package e2e_new
 import (
 	"testing"
 
+	brokerconfigmap "knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap/broker"
+
 	"knative.dev/reconciler-test/pkg/environment"
 
 	cetest "github.com/cloudevents/sdk-go/v2/test"
@@ -61,12 +63,21 @@ func SendsEventWithRetries() *feature.Feature {
 	deadLetterSinkName := feature.MakeRandomK8sName("dls")
 	triggerName := feature.MakeRandomK8sName("trigger")
 	brokerName := feature.MakeRandomK8sName("broker")
+	configName := feature.MakeRandomK8sName("config")
 
 	ev := cetest.FullEvent()
+
+	f.Setup("create broker config", brokerconfigmap.Install(
+		configName,
+		brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+		brokerconfigmap.WithNumPartitions(1),
+		brokerconfigmap.WithReplicationFactor(1),
+	))
 
 	f.Setup("install broker", broker.Install(
 		brokerName,
 		broker.WithBrokerClass(broker.EnvCfg.BrokerClass),
+		broker.WithConfig(configName),
 	))
 
 	f.Setup("broker is ready", broker.IsReady(brokerName))
@@ -121,12 +132,21 @@ func SendsEventErrorWithoutRetries() *feature.Feature {
 	deadLetterSinkName := feature.MakeRandomK8sName("dls")
 	triggerName := feature.MakeRandomK8sName("trigger")
 	brokerName := feature.MakeRandomK8sName("broker")
+	configName := feature.MakeRandomK8sName("config")
 
 	ev := cetest.FullEvent()
+
+	f.Setup("create broker config", brokerconfigmap.Install(
+		configName,
+		brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+		brokerconfigmap.WithNumPartitions(1),
+		brokerconfigmap.WithReplicationFactor(1),
+	))
 
 	f.Setup("install broker", broker.Install(
 		brokerName,
 		broker.WithBrokerClass(broker.EnvCfg.BrokerClass),
+		broker.WithConfig(configName),
 	))
 
 	f.Setup("broker is ready", broker.IsReady(brokerName))
@@ -182,12 +202,21 @@ func SendsEventNoRetries() *feature.Feature {
 	deadLetterSinkName := feature.MakeRandomK8sName("dls")
 	triggerName := feature.MakeRandomK8sName("trigger")
 	brokerName := feature.MakeRandomK8sName("broker")
+	configName := feature.MakeRandomK8sName("config")
 
 	ev := cetest.FullEvent()
+
+	f.Setup("create broker config", brokerconfigmap.Install(
+		configName,
+		brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+		brokerconfigmap.WithNumPartitions(1),
+		brokerconfigmap.WithReplicationFactor(1),
+	))
 
 	f.Setup("install broker", broker.Install(
 		brokerName,
 		broker.WithBrokerClass(broker.EnvCfg.BrokerClass),
+		broker.WithConfig(configName),
 	))
 
 	f.Setup("broker is ready", broker.IsReady(brokerName))

--- a/test/e2e_new/dls_test.go
+++ b/test/e2e_new/dls_test.go
@@ -23,13 +23,17 @@ import (
 	"testing"
 
 	brokerconfigmap "knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap/broker"
+	testpkg "knative.dev/eventing-kafka-broker/test/pkg"
 
 	"knative.dev/reconciler-test/pkg/environment"
 
 	cetest "github.com/cloudevents/sdk-go/v2/test"
+
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/trigger"
+
 	"knative.dev/pkg/system"
+
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
@@ -69,7 +73,7 @@ func SendsEventWithRetries() *feature.Feature {
 
 	f.Setup("create broker config", brokerconfigmap.Install(
 		configName,
-		brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+		brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersPlaintext),
 		brokerconfigmap.WithNumPartitions(1),
 		brokerconfigmap.WithReplicationFactor(1),
 	))
@@ -138,7 +142,7 @@ func SendsEventErrorWithoutRetries() *feature.Feature {
 
 	f.Setup("create broker config", brokerconfigmap.Install(
 		configName,
-		brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+		brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersPlaintext),
 		brokerconfigmap.WithNumPartitions(1),
 		brokerconfigmap.WithReplicationFactor(1),
 	))
@@ -208,7 +212,7 @@ func SendsEventNoRetries() *feature.Feature {
 
 	f.Setup("create broker config", brokerconfigmap.Install(
 		configName,
-		brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+		brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersPlaintext),
 		brokerconfigmap.WithNumPartitions(1),
 		brokerconfigmap.WithReplicationFactor(1),
 	))

--- a/test/e2e_new/dls_test.go
+++ b/test/e2e_new/dls_test.go
@@ -71,12 +71,7 @@ func SendsEventWithRetries() *feature.Feature {
 
 	ev := cetest.FullEvent()
 
-	f.Setup("create broker config", brokerconfigmap.Install(
-		configName,
-		brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersPlaintext),
-		brokerconfigmap.WithNumPartitions(1),
-		brokerconfigmap.WithReplicationFactor(1),
-	))
+	f.Setup("create broker config", createBrokerConfigForDlsTests(configName))
 
 	f.Setup("install broker", broker.Install(
 		brokerName,
@@ -140,12 +135,7 @@ func SendsEventErrorWithoutRetries() *feature.Feature {
 
 	ev := cetest.FullEvent()
 
-	f.Setup("create broker config", brokerconfigmap.Install(
-		configName,
-		brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersPlaintext),
-		brokerconfigmap.WithNumPartitions(1),
-		brokerconfigmap.WithReplicationFactor(1),
-	))
+	f.Setup("create broker config", createBrokerConfigForDlsTests(configName))
 
 	f.Setup("install broker", broker.Install(
 		brokerName,
@@ -210,12 +200,7 @@ func SendsEventNoRetries() *feature.Feature {
 
 	ev := cetest.FullEvent()
 
-	f.Setup("create broker config", brokerconfigmap.Install(
-		configName,
-		brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersPlaintext),
-		brokerconfigmap.WithNumPartitions(1),
-		brokerconfigmap.WithReplicationFactor(1),
-	))
+	f.Setup("create broker config", createBrokerConfigForDlsTests(configName))
 
 	f.Setup("install broker", broker.Install(
 		brokerName,
@@ -262,4 +247,13 @@ func SendsEventNoRetries() *feature.Feature {
 	)
 
 	return f
+}
+
+func createBrokerConfigForDlsTests(configName string) feature.StepFn {
+	return brokerconfigmap.Install(
+		configName,
+		brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersPlaintext),
+		brokerconfigmap.WithNumPartitions(1),
+		brokerconfigmap.WithReplicationFactor(1),
+	)
 }

--- a/test/e2e_new/features/broker_deleted_recreated.go
+++ b/test/e2e_new/features/broker_deleted_recreated.go
@@ -23,7 +23,6 @@ import (
 
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/trigger"
-
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/resources/svc"
@@ -32,6 +31,19 @@ import (
 	"knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap"
 	brokerconfigmap "knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap/broker"
 )
+
+func BrokerConfigmapCreated(configName string) *feature.Feature {
+	f := feature.NewFeatureNamed("broker configmap created")
+
+	f.Setup("create broker config", brokerconfigmap.Install(
+		configName,
+		brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+		brokerconfigmap.WithNumPartitions(1),
+		brokerconfigmap.WithReplicationFactor(1),
+	))
+
+	return f
+}
 
 func BrokerDeletedRecreated() *feature.Feature {
 	f := feature.NewFeatureNamed("broker deleted and recreated")

--- a/test/e2e_new/features/broker_deleted_recreated.go
+++ b/test/e2e_new/features/broker_deleted_recreated.go
@@ -30,6 +30,7 @@ import (
 	"knative.dev/eventing-kafka-broker/test/e2e_new/features/featuressteps"
 	"knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap"
 	brokerconfigmap "knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap/broker"
+	testpkg "knative.dev/eventing-kafka-broker/test/pkg"
 )
 
 func BrokerConfigmapCreated(configName string) *feature.Feature {
@@ -37,7 +38,7 @@ func BrokerConfigmapCreated(configName string) *feature.Feature {
 
 	f.Setup("create broker config", brokerconfigmap.Install(
 		configName,
-		brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+		brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersPlaintext),
 		brokerconfigmap.WithNumPartitions(1),
 		brokerconfigmap.WithReplicationFactor(1),
 	))

--- a/test/e2e_new/features/featuressteps/broker.go
+++ b/test/e2e_new/features/featuressteps/broker.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 
 	brokerconfigmap "knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap/broker"
+	testpkg "knative.dev/eventing-kafka-broker/test/pkg"
 
 	cetest "github.com/cloudevents/sdk-go/v2/test"
 	"github.com/google/uuid"
@@ -29,11 +30,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/pointer"
+
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
+
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/trigger"
+
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
+
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/eventshub/assert"
@@ -72,7 +77,7 @@ func BrokerSmokeTest(brokerName, triggerName string) feature.StepFn {
 		eventshub.Install(sink, eventshub.StartReceiver),
 		brokerconfigmap.Install(
 			configName,
-			brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+			brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersPlaintext),
 			brokerconfigmap.WithNumPartitions(1),
 			brokerconfigmap.WithReplicationFactor(1),
 		),

--- a/test/e2e_new/tracing_test.go
+++ b/test/e2e_new/tracing_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	brokerconfigmap "knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap/broker"
+
 	cetest "github.com/cloudevents/sdk-go/v2/test"
 	"github.com/openzipkin/zipkin-go/model"
 	tracinghelper "knative.dev/eventing/test/conformance/helpers/tracing"
@@ -67,14 +69,23 @@ func TracingHeadersUsingOrderedDeliveryWithTraceExported() *feature.Feature {
 	sinkName := feature.MakeRandomK8sName("sink")
 	triggerName := feature.MakeRandomK8sName("trigger")
 	brokerName := feature.MakeRandomK8sName("broker")
+	configName := feature.MakeRandomK8sName("config")
 
 	ev := cetest.FullEvent()
 	ev.SetID("full-event-ordered")
 	ev.SetSource(sourceName)
 
+	f.Setup("create broker config", brokerconfigmap.Install(
+		configName,
+		brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+		brokerconfigmap.WithNumPartitions(1),
+		brokerconfigmap.WithReplicationFactor(1),
+	))
+
 	f.Setup("install broker", broker.Install(
 		brokerName,
 		broker.WithBrokerClass(broker.EnvCfg.BrokerClass),
+		broker.WithConfig(configName),
 	))
 	f.Setup("broker is ready", broker.IsReady(brokerName))
 	f.Setup("broker is addressable", broker.IsAddressable(brokerName))
@@ -192,13 +203,22 @@ func TracingHeadersUsingUnorderedDelivery() *feature.Feature {
 	sinkName := feature.MakeRandomK8sName("sink")
 	triggerName := feature.MakeRandomK8sName("trigger")
 	brokerName := feature.MakeRandomK8sName("broker")
+	configName := feature.MakeRandomK8sName("config")
 
 	ev := cetest.FullEvent()
 	ev.SetID("full-event-unordered")
 
+	f.Setup("create broker config", brokerconfigmap.Install(
+		configName,
+		brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+		brokerconfigmap.WithNumPartitions(1),
+		brokerconfigmap.WithReplicationFactor(1),
+	))
+
 	f.Setup("install broker", broker.Install(
 		brokerName,
 		broker.WithBrokerClass(broker.EnvCfg.BrokerClass),
+		broker.WithConfig(configName),
 	))
 	f.Setup("broker is ready", broker.IsReady(brokerName))
 	f.Setup("broker is addressable", broker.IsAddressable(brokerName))
@@ -237,13 +257,22 @@ func TracingHeadersUsingUnorderedDeliveryWithMultipleTriggers() *feature.Feature
 	triggerAName := feature.MakeRandomK8sName("trigger-a")
 	triggerBName := feature.MakeRandomK8sName("trigger-b")
 	brokerName := feature.MakeRandomK8sName("broker")
+	configName := feature.MakeRandomK8sName("config")
 
 	ev := cetest.FullEvent()
 	ev.SetID("full-event-unordered")
 
+	f.Setup("create broker config", brokerconfigmap.Install(
+		configName,
+		brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+		brokerconfigmap.WithNumPartitions(1),
+		brokerconfigmap.WithReplicationFactor(1),
+	))
+
 	f.Setup("install broker", broker.Install(
 		brokerName,
 		broker.WithBrokerClass(broker.EnvCfg.BrokerClass),
+		broker.WithConfig(configName),
 	))
 	f.Setup("broker is ready", broker.IsReady(brokerName))
 	f.Setup("broker is addressable", broker.IsAddressable(brokerName))

--- a/test/e2e_new/tracing_test.go
+++ b/test/e2e_new/tracing_test.go
@@ -26,13 +26,18 @@ import (
 	"time"
 
 	brokerconfigmap "knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap/broker"
+	testpkg "knative.dev/eventing-kafka-broker/test/pkg"
+	"knative.dev/eventing-kafka-broker/test/pkg/tracing"
 
 	cetest "github.com/cloudevents/sdk-go/v2/test"
 	"github.com/openzipkin/zipkin-go/model"
+
 	tracinghelper "knative.dev/eventing/test/conformance/helpers/tracing"
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/trigger"
+
 	"knative.dev/pkg/system"
+
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
@@ -41,8 +46,6 @@ import (
 	"knative.dev/reconciler-test/resources/svc"
 
 	. "knative.dev/reconciler-test/pkg/eventshub/assert"
-
-	"knative.dev/eventing-kafka-broker/test/pkg/tracing"
 )
 
 func TestTracingHeaders(t *testing.T) {
@@ -77,7 +80,7 @@ func TracingHeadersUsingOrderedDeliveryWithTraceExported() *feature.Feature {
 
 	f.Setup("create broker config", brokerconfigmap.Install(
 		configName,
-		brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+		brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersPlaintext),
 		brokerconfigmap.WithNumPartitions(1),
 		brokerconfigmap.WithReplicationFactor(1),
 	))
@@ -210,7 +213,7 @@ func TracingHeadersUsingUnorderedDelivery() *feature.Feature {
 
 	f.Setup("create broker config", brokerconfigmap.Install(
 		configName,
-		brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+		brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersPlaintext),
 		brokerconfigmap.WithNumPartitions(1),
 		brokerconfigmap.WithReplicationFactor(1),
 	))
@@ -264,7 +267,7 @@ func TracingHeadersUsingUnorderedDeliveryWithMultipleTriggers() *feature.Feature
 
 	f.Setup("create broker config", brokerconfigmap.Install(
 		configName,
-		brokerconfigmap.WithBootstrapServer("my-cluster-kafka-bootstrap.kafka:9092"),
+		brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersPlaintext),
 		brokerconfigmap.WithNumPartitions(1),
 		brokerconfigmap.WithReplicationFactor(1),
 	))

--- a/test/pkg/broker/broker.go
+++ b/test/pkg/broker/broker.go
@@ -77,8 +77,7 @@ func CreatorWithOptions(client *eventingtestlib.Client, version string, brokerOp
 	switch version {
 	case "v1":
 		namespace := client.Namespace
-		// TODO: why the heck we have this name?
-		cmName := "kafka-broker-upgrade-config"
+		cmName := "kafka-broker-config"
 		// Create Broker's own ConfigMap to prevent using defaults.
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/reconciler-tests.sh
+++ b/test/reconciler-tests.sh
@@ -3,7 +3,7 @@
 source $(dirname $0)/e2e-common.sh
 
 if ! ${SKIP_INITIALIZE}; then
-  initialize $@ --skip-istio-addon
+  initialize $@ --skip-istio-addon --min-nodes=4 --max-nodes=4
   save_release_artifacts || fail_test "Failed to save release artifacts"
 fi
 

--- a/test/reconciler-tests.sh
+++ b/test/reconciler-tests.sh
@@ -28,7 +28,6 @@ if [ "${EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO:-""}" != "" ]; then
   success
 fi
 
-export BROKER_CLASS=Kafka
 if [[ -z "${BROKER_CLASS}" ]]; then
   fail_test "Broker class is not defined. Specify it with 'BROKER_CLASS' env var."
 else

--- a/test/reconciler-tests.sh
+++ b/test/reconciler-tests.sh
@@ -37,9 +37,8 @@ fi
 
 if [ "${BROKER_CLASS}" == "KafkaNamespaced" ]; then
   # if flag exists, only test tests that are relevant to namespaced KafkaBroker
-  #  echo "BROKER_CLASS is set to 'KafkaNamespaced'. Only running the relevant tests."
-  #  go_test_e2e -timeout=1h ./test/e2e_new/... || fail_test "E2E (new) suite failed"
-  echo "BROKER_CLASS is set to 'KafkaNamespaced'. Skipping tests."
+  echo "BROKER_CLASS is set to 'KafkaNamespaced'. Only running the relevant tests."
+  go_test_e2e -timeout=1h ./test/e2e_new/... || fail_test "E2E (new) suite failed"
   success
 fi
 


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Enable namespaced broker again
- Adjust tests for the new validation rules per webhook (no cross namespace spec.config)
- 
## **Blocked by:**
- [x] https://github.com/knative/eventing/pull/6510
- [x] https://github.com/knative/test-infra/pull/3514
- [x] https://github.com/knative-sandbox/eventing-kafka-broker/pull/2570 (not 100% sure)
- [x] Upgrading eventing dependency: https://github.com/knative-sandbox/eventing-kafka-broker/pull/2610
- [x] https://github.com/knative-sandbox/eventing-kafka-broker/pull/2610 requires https://github.com/knative-sandbox/eventing-kafka-broker/pull/2609


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
