### PR TITLE
Doing base 64 encoding of the data

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -295,7 +296,8 @@ public class RecordDispatcherImpl implements RecordDispatcher {
       if (data.length() > KN_ERROR_DATA_MAX_BYTES) {
         data = data.substring(0, KN_ERROR_DATA_MAX_BYTES);
       }
-      extensions.put(KN_ERROR_DATA_EXT_NAME, data);
+
+      extensions.put(KN_ERROR_DATA_EXT_NAME, Base64.getEncoder().encodeToString(data.getBytes()));
     }
 
     return addExtensions(recordContext, extensions);

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
@@ -34,6 +34,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.kafka.client.common.tracing.ConsumerTracer;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
@@ -291,12 +292,13 @@ public class RecordDispatcherImpl implements RecordDispatcher {
     extensions.put(KN_ERROR_DEST_EXT_NAME, destination);
     extensions.put(KN_ERROR_CODE_EXT_NAME, String.valueOf(response.statusCode()));
 
-    var data = response.bodyAsString();
+    // we extract the response as byte array as we do not need a string
+    // representation of it
+    var data = response.bodyAsBuffer();
     if (data != null) {
       if (data.length() > KN_ERROR_DATA_MAX_BYTES) {
-        data = data.substring(0, KN_ERROR_DATA_MAX_BYTES);
+        data = Buffer.buffer(data.getBytes(0, KN_ERROR_DATA_MAX_BYTES));
       }
-
       extensions.put(KN_ERROR_DATA_EXT_NAME, Base64.getEncoder().encodeToString(data.getBytes()));
     }
 

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
+import java.util.Base64;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -291,7 +292,7 @@ public class RecordDispatcherTest {
     assertEquals(record.value().getData(), failedRecord.value().getData());
     assertEquals("testdest", failedRecord.value().getExtension("knativeerrordest"));
     assertEquals(String.valueOf(errorCode), failedRecord.value().getExtension("knativeerrorcode"));
-    assertEquals(errorBody, failedRecord.value().getExtension("knativeerrordata"));
+    assertEquals(Base64.getEncoder().encodeToString(errorBody.getBytes()), failedRecord.value().getExtension("knativeerrordata"));
 
     assertEventDispatchLatency();
     assertEventProcessingLatency();
@@ -352,7 +353,7 @@ public class RecordDispatcherTest {
     assertEquals(record.value().getData(), failedRecord.value().getData());
     assertEquals("testdest", failedRecord.value().getExtension("knativeerrordest"));
     assertEquals(String.valueOf(errorCode), failedRecord.value().getExtension("knativeerrorcode"));
-    assertEquals(errorBody, failedRecord.value().getExtension("knativeerrordata"));
+    assertEquals(Base64.getEncoder().encodeToString(errorBody.getBytes()), failedRecord.value().getExtension("knativeerrordata"));
 
     assertEventDispatchLatency();
     assertEventProcessingLatency();

--- a/test/e2e_new/dls_extensions_test.go
+++ b/test/e2e_new/dls_extensions_test.go
@@ -57,6 +57,7 @@ func TestDeadLetterSinkExtensions(t *testing.T) {
 	env.Test(ctx, t, SubscriberReturnedErrorNoData())
 	env.Test(ctx, t, SubscriberReturnedErrorSmallData())
 	env.Test(ctx, t, SubscriberReturnedErrorLargeData())
+	env.Test(ctx, t, SubscriberReturnedHtmlWebpage())
 }
 
 func SubscriberUnreachable() *feature.Feature {
@@ -295,6 +296,72 @@ func SubscriberReturnedErrorLargeData() *feature.Feature {
 
 	return f
 }
+
+
+func SubscriberReturnedHtmlWebpage() *feature.Feature {
+	f := feature.NewFeature()
+
+	sourceName := feature.MakeRandomK8sName("source")
+	sinkName := feature.MakeRandomK8sName("sink")
+	deadLetterSinkName := feature.MakeRandomK8sName("dls")
+	triggerName := feature.MakeRandomK8sName("trigger")
+	brokerName := feature.MakeRandomK8sName("broker")
+
+	ev := cetest.FullEvent()
+
+	f.Setup("install one partition configuration", single_partition_config.Install)
+	f.Setup("install broker", broker.Install(
+		brokerName,
+		broker.WithBrokerClass(kafka.BrokerClass),
+		broker.WithConfig(single_partition_config.ConfigMapName),
+	))
+	f.Setup("broker is ready", broker.IsReady(brokerName))
+	f.Setup("broker is addressable", broker.IsAddressable(brokerName))
+
+	errorData := "<!doctype html>\n<html>\n<head>\n    <title>Error Page(tm)</title>\n</head>\n<body>\n<p>Quoth the server, 404!\n</body></html>"
+	f.Setup("install sink", eventshub.Install(
+		sinkName,
+		eventshub.StartReceiver,
+		eventshub.DropFirstN(1),
+		eventshub.DropEventsResponseCode(404),
+		eventshub.DropEventsResponseBody(errorData),
+	))
+	f.Setup("install dead letter sink", eventshub.Install(
+		deadLetterSinkName,
+		eventshub.StartReceiver,
+	))
+	f.Setup("install trigger", trigger.Install(
+		triggerName,
+		brokerName,
+		trigger.WithSubscriber(svc.AsKReference(sinkName), ""),
+		trigger.WithDeadLetterSink(svc.AsKReference(deadLetterSinkName), ""),
+	))
+	f.Setup("trigger is ready", trigger.IsReady(triggerName))
+
+	f.Requirement("install source", eventshub.Install(
+		sourceName,
+		eventshub.StartSenderToResource(broker.GVR(), brokerName),
+		eventshub.InputEvent(ev),
+	))
+
+	f.Assert("knativeerrordest, knativeerrorcode, knativeerrordata added", assertEnhancedWithKnativeErrorExtensions(
+		deadLetterSinkName,
+		func(ctx context.Context) cetest.EventMatcher {
+			sinkAddress, _ := svc.Address(ctx, sinkName)
+			return cetest.HasExtension("knativeerrordest", sinkAddress.String())
+		},
+		func(ctx context.Context) cetest.EventMatcher {
+			return cetest.HasExtension("knativeerrorcode", "404")
+		},
+		func(ctx context.Context) cetest.EventMatcher {
+			return cetest.HasExtension("knativeerrordata", base64.StdEncoding.EncodeToString([]byte(errorData)))
+		},
+	))
+
+	return f
+}
+
+
 
 func assertEnhancedWithKnativeErrorExtensions(sinkName string, matcherfns ...func(ctx context.Context) cetest.EventMatcher) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {

--- a/test/e2e_new/dls_extensions_test.go
+++ b/test/e2e_new/dls_extensions_test.go
@@ -22,6 +22,7 @@ package e2e_new
 import (
 	"context"
 	"encoding/base64"
+	"html"
 	"strings"
 	"testing"
 	"time"
@@ -297,7 +298,6 @@ func SubscriberReturnedErrorLargeData() *feature.Feature {
 	return f
 }
 
-
 func SubscriberReturnedHtmlWebpage() *feature.Feature {
 	f := feature.NewFeature()
 
@@ -354,14 +354,12 @@ func SubscriberReturnedHtmlWebpage() *feature.Feature {
 			return cetest.HasExtension("knativeerrorcode", "404")
 		},
 		func(ctx context.Context) cetest.EventMatcher {
-			return cetest.HasExtension("knativeerrordata", base64.StdEncoding.EncodeToString([]byte(errorData)))
+			return cetest.HasExtension("knativeerrordata", html.UnescapeString(base64.StdEncoding.EncodeToString([]byte(errorData))))
 		},
 	))
 
 	return f
 }
-
-
 
 func assertEnhancedWithKnativeErrorExtensions(sinkName string, matcherfns ...func(ctx context.Context) cetest.EventMatcher) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {

--- a/test/e2e_new/dls_extensions_test.go
+++ b/test/e2e_new/dls_extensions_test.go
@@ -21,6 +21,7 @@ package e2e_new
 
 import (
 	"context"
+	"encoding/base64"
 	"strings"
 	"testing"
 	"time"
@@ -224,7 +225,7 @@ func SubscriberReturnedErrorSmallData() *feature.Feature {
 			return cetest.HasExtension("knativeerrorcode", "422")
 		},
 		func(ctx context.Context) cetest.EventMatcher {
-			return cetest.HasExtension("knativeerrordata", errorData)
+			return cetest.HasExtension("knativeerrordata", base64.StdEncoding.EncodeToString([]byte(errorData)))
 		},
 	))
 
@@ -288,7 +289,7 @@ func SubscriberReturnedErrorLargeData() *feature.Feature {
 			return cetest.HasExtension("knativeerrorcode", "422")
 		},
 		func(ctx context.Context) cetest.EventMatcher {
-			return cetest.HasExtension("knativeerrordata", errorDataTruncated)
+			return cetest.HasExtension("knativeerrordata", base64.StdEncoding.EncodeToString([]byte(errorDataTruncated)))
 		},
 	))
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #2594 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Avoiding "invalid" HTTP header values for CE extension, we encode the actual data of the `knativeerrordata` extension.
- updated unit and reconciler tests to reflect the base64 encoding
- added a new case for the returning http error and webpage...

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
We are doing base64 encoding for the value of the `knativeerrordata`, to avoid issues with adding the data to the HTTP header, when the message is delivered to the deadlettersink. Consumers of the `knativeerrordata` must decode it in case they are interested in it. 
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
