### PR TITLE
Remove meters of deleted resources

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/IngressReconcilerListener.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/IngressReconcilerListener.java
@@ -16,7 +16,12 @@
 package dev.knative.eventing.kafka.broker.core.reconciler;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public interface IngressReconcilerListener {
 
@@ -26,4 +31,44 @@ public interface IngressReconcilerListener {
 
   Future<Void> onDeleteIngress(DataPlaneContract.Resource resource, DataPlaneContract.Ingress ingress);
 
+  static IngressReconcilerListener all(final IngressReconcilerListener... listeners) {
+    return new CompositeIngressReconcilerLister(listeners);
+  }
+}
+
+class CompositeIngressReconcilerLister implements IngressReconcilerListener {
+
+  private IngressReconcilerListener[] listeners;
+
+  public CompositeIngressReconcilerLister(final IngressReconcilerListener... listeners) {
+    Objects.requireNonNull(listeners);
+    this.listeners = listeners;
+  }
+
+  @Override
+  public Future<Void> onNewIngress(DataPlaneContract.Resource resource, DataPlaneContract.Ingress ingress) {
+    return CompositeFuture.all(
+      Arrays.stream(listeners)
+        .map(l -> l.onNewIngress(resource, ingress))
+        .collect(Collectors.toList())
+    ).mapEmpty();
+  }
+
+  @Override
+  public Future<Void> onUpdateIngress(DataPlaneContract.Resource resource, DataPlaneContract.Ingress ingress) {
+    return CompositeFuture.all(
+      Arrays.stream(listeners)
+        .map(l -> l.onUpdateIngress(resource, ingress))
+        .collect(Collectors.toList())
+    ).mapEmpty();
+  }
+
+  @Override
+  public Future<Void> onDeleteIngress(DataPlaneContract.Resource resource, DataPlaneContract.Ingress ingress) {
+    return CompositeFuture.all(
+      Arrays.stream(listeners)
+        .map(l -> l.onDeleteIngress(resource, ingress))
+        .collect(Collectors.toList())
+    ).mapEmpty();
+  }
 }

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/metrics/MetricsTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/metrics/MetricsTest.java
@@ -17,7 +17,10 @@ package dev.knative.eventing.kafka.broker.core.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import dev.knative.eventing.kafka.broker.core.utils.BaseEnv;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -26,8 +29,12 @@ import io.vertx.micrometer.backends.BackendRegistries;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.MockProducer;
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.stream.Collectors;
 
 @ExtendWith(VertxExtension.class)
 public class MetricsTest {
@@ -54,5 +61,81 @@ public class MetricsTest {
     throws Exception {
     final var meterBinder = Metrics.register(new MockConsumer<>(OffsetResetStrategy.LATEST));
     meterBinder.close();
+  }
+
+  @Test
+  public void searchShouldReturnMetersWithAdditionalTags() {
+
+    final var registry = Metrics.getRegistry();
+
+    Metrics.eventCount(Tags.of(
+        Tag.of(Metrics.Tags.EVENT_TYPE, "type"),
+        Tag.of(Metrics.Tags.RESOURCE_NAME, "name"),
+        Tag.of(Metrics.Tags.RESOURCE_NAMESPACE, "namespace")
+      ))
+      .register(registry)
+      .increment();
+
+    Metrics.eventDispatchLatency(Tags.of(
+        Tag.of(Metrics.Tags.EVENT_TYPE, "type"),
+        Tag.of(Metrics.Tags.RESOURCE_NAME, "name"),
+        Tag.of(Metrics.Tags.CONSUMER_NAME, "cname"),
+        Tag.of(Metrics.Tags.RESOURCE_NAMESPACE, "namespace")
+      ))
+      .register(registry)
+      .record(10);
+
+    Metrics.eventProcessingLatency(Tags.of(
+        Tag.of(Metrics.Tags.EVENT_TYPE, "type"),
+        Tag.of(Metrics.Tags.RESOURCE_NAME, "name"),
+        Tag.of(Metrics.Tags.CONSUMER_NAME, "cname"),
+        Tag.of(Metrics.Tags.RESOURCE_NAMESPACE, "namespace")
+      ))
+      .register(registry)
+      .record(10);
+
+    Metrics.eventDispatchLatency(Tags.of(
+        Tag.of(Metrics.Tags.EVENT_TYPE, "type"),
+        Tag.of(Metrics.Tags.RESOURCE_NAME, "name"),
+        Tag.of(Metrics.Tags.CONSUMER_NAME, "cname"),
+        Tag.of(Metrics.Tags.RESOURCE_NAMESPACE, "other-namespace")
+      ))
+      .register(registry)
+      .record(10);
+
+    final var expectedResourceMetersCount = 3;
+    final var expectedEgressMetersCount = 2;
+
+    final var resourceMeters = Metrics.searchResourceMeters(registry, DataPlaneContract.Reference.newBuilder()
+      .setName("name")
+      .setNamespace("namespace")
+      .build()
+    );
+
+    final var egressMeters = Metrics.searchEgressMeters(registry, DataPlaneContract.Reference.newBuilder()
+      .setName("cname")
+      .setNamespace("namespace")
+      .build()
+    );
+
+    Assertions.assertThat(resourceMeters).hasSize(expectedResourceMetersCount);
+    Assertions.assertThat(egressMeters).hasSize(expectedEgressMetersCount);
+
+    Assertions.assertThat(
+      resourceMeters.stream().filter(m -> m.getId().getName().equals(Metrics.EVENTS_COUNT)).collect(Collectors.toList())
+    ).hasSize(1);
+    Assertions.assertThat(
+      resourceMeters.stream().filter(m -> m.getId().getName().equals(Metrics.EVENT_DISPATCH_LATENCY)).collect(Collectors.toList())
+    ).hasSize(1);
+    Assertions.assertThat(
+      resourceMeters.stream().filter(m -> m.getId().getName().equals(Metrics.EVENT_PROCESSING_LATENCY)).collect(Collectors.toList())
+    ).hasSize(1);
+
+    Assertions.assertThat(
+      egressMeters.stream().filter(m -> m.getId().getName().equals(Metrics.EVENT_DISPATCH_LATENCY)).collect(Collectors.toList())
+    ).hasSize(1);
+    Assertions.assertThat(
+      egressMeters.stream().filter(m -> m.getId().getName().equals(Metrics.EVENT_PROCESSING_LATENCY)).collect(Collectors.toList())
+    ).hasSize(1);
   }
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
@@ -504,6 +504,10 @@ public class RecordDispatcherImpl implements RecordDispatcher {
   public Future<Void> close() {
     this.closed.set(true);
 
+    Metrics
+      .searchEgressMeters(meterRegistry, resourceContext.getEgress().getReference())
+      .forEach(meterRegistry::remove);
+
     if (inFlightEvents.get() == 0) {
       closePromise.tryComplete();
     }

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/IngressRequestHandler.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/IngressRequestHandler.java
@@ -15,10 +15,12 @@
  */
 package dev.knative.eventing.kafka.broker.receiver;
 
+import dev.knative.eventing.kafka.broker.core.reconciler.IngressReconcilerListener;
+
 /**
  * This class handles incoming ingress requests.
  */
-public interface IngressRequestHandler {
+public interface IngressRequestHandler extends IngressReconcilerListener {
 
   void handle(RequestContext request, IngressProducer producer);
 

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticle.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticle.java
@@ -15,6 +15,7 @@
  */
 package dev.knative.eventing.kafka.broker.receiver.impl;
 
+import dev.knative.eventing.kafka.broker.core.reconciler.IngressReconcilerListener;
 import dev.knative.eventing.kafka.broker.core.reconciler.ResourcesReconciler;
 import dev.knative.eventing.kafka.broker.receiver.IngressProducer;
 import dev.knative.eventing.kafka.broker.receiver.IngressRequestHandler;
@@ -87,7 +88,7 @@ public class ReceiverVerticle extends AbstractVerticle implements Handler<HttpSe
     this.ingressProducerStore = this.ingressProducerStoreFactory.apply(vertx);
     this.messageConsumer = ResourcesReconciler
       .builder()
-      .watchIngress(this.ingressProducerStore)
+      .watchIngress(IngressReconcilerListener.all(this.ingressProducerStore, this.ingressRequestHandler))
       .buildAndListen(vertx);
 
     this.server = vertx.createHttpServer(httpServerOptions);


### PR DESCRIPTION
Keeping meters for deleted resources around causes the
metrics endpoint to take a long time to respond with metrics
and it is also a waste of memory.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove meters of deleted resources

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Remove metrics associated with deleted resources from data plane pods.
```
