### PR TITLE
[WIP] Adding new Kafka `activationLagThreshold` annotation for KEDA scaling

### DIFF
--- a/control-plane/pkg/keda/keda.go
+++ b/control-plane/pkg/keda/keda.go
@@ -33,7 +33,8 @@ import (
 )
 
 const (
-	defaultKafkaLagThreshold = 10
+	defaultKafkaLagThreshold           = 10
+	defaultKafkaActivationLagThreshold = 0
 )
 
 func GenerateScaleTarget(cg *kafkainternals.ConsumerGroup) *kedav1alpha1.ScaleTarget {
@@ -54,6 +55,11 @@ func GenerateScaleTriggers(cg *kafkainternals.ConsumerGroup, triggerAuthenticati
 		return nil, err
 	}
 
+	activationLagThreshold, err := keda.GetInt32ValueFromMap(cg.Annotations, keda.KedaAutoscalingKafkaActivationLagThreshold, defaultKafkaActivationLagThreshold)
+	if err != nil {
+		return nil, err
+	}
+
 	allowIdleConsumers := "false"
 	if cg.Status.Placements != nil {
 		allowIdleConsumers = "true"
@@ -61,11 +67,12 @@ func GenerateScaleTriggers(cg *kafkainternals.ConsumerGroup, triggerAuthenticati
 
 	for _, topic := range cg.Spec.Template.Spec.Topics {
 		triggerMetadata := map[string]string{
-			"bootstrapServers":   bootstrapServers,
-			"consumerGroup":      consumerGroup,
-			"topic":              topic,
-			"lagThreshold":       strconv.Itoa(int(*lagThreshold)),
-			"allowIdleConsumers": allowIdleConsumers,
+			"bootstrapServers":       bootstrapServers,
+			"consumerGroup":          consumerGroup,
+			"topic":                  topic,
+			"lagThreshold":           strconv.Itoa(int(*lagThreshold)),
+			"activationLagThreshold": strconv.Itoa(int(*activationLagThreshold)),
+			"allowIdleConsumers":     allowIdleConsumers,
 		}
 
 		trigger := kedav1alpha1.ScaleTriggers{
@@ -214,6 +221,7 @@ func SetAutoscalingAnnotations(objannotations map[string]string) map[string]stri
 		setAnnotation(objannotations, keda.KedaAutoscalingPollingIntervalAnnotation, cgannotations)
 		setAnnotation(objannotations, keda.KedaAutoscalingCooldownPeriodAnnotation, cgannotations)
 		setAnnotation(objannotations, keda.KedaAutoscalingKafkaLagThreshold, cgannotations)
+		setAnnotation(objannotations, keda.KedaAutoscalingKafkaActivationLagThreshold, cgannotations)
 		return cgannotations
 	}
 	return nil

--- a/control-plane/pkg/reconciler/testing/objects_consumergroup.go
+++ b/control-plane/pkg/reconciler/testing/objects_consumergroup.go
@@ -70,12 +70,13 @@ var (
 	}
 
 	ConsumerGroupAnnotations = map[string]string{
-		keda.AutoscalingClassAnnotation:               keda.KEDA,
-		keda.AutoscalingMinScaleAnnotation:            "0",
-		keda.AutoscalingMaxScaleAnnotation:            "5",
-		keda.KedaAutoscalingPollingIntervalAnnotation: "30",
-		keda.KedaAutoscalingCooldownPeriodAnnotation:  "300",
-		keda.KedaAutoscalingKafkaLagThreshold:         "10",
+		keda.AutoscalingClassAnnotation:                 keda.KEDA,
+		keda.AutoscalingMinScaleAnnotation:              "0",
+		keda.AutoscalingMaxScaleAnnotation:              "5",
+		keda.KedaAutoscalingPollingIntervalAnnotation:   "30",
+		keda.KedaAutoscalingCooldownPeriodAnnotation:    "300",
+		keda.KedaAutoscalingKafkaLagThreshold:           "10",
+		keda.KedaAutoscalingKafkaActivationLagThreshold: "0",
 	}
 )
 

--- a/vendor/knative.dev/eventing-autoscaler-keda/pkg/reconciler/keda/annotations.go
+++ b/vendor/knative.dev/eventing-autoscaler-keda/pkg/reconciler/keda/annotations.go
@@ -39,8 +39,11 @@ const (
 	// scales a Deployment down.
 	KedaAutoscalingCooldownPeriodAnnotation = KEDA + "/cooldownPeriod"
 
-	// KedaAutoscalingKafkaLagThreshold is the annotation that refers to the stream is lagging on the current consumer group
+	// KedaAutoscalingKafkaLagThreshold is the annotation that refers to the lag on the current consumer group that's used for scaling (1<->N)
 	KedaAutoscalingKafkaLagThreshold = KEDA + "/kafkaLagThreshold"
+
+	// KedaAutoscalingKafkaActivationLagThreshold is the annotation that refers to the lag on the current consumer group that's used for activation (0<->1)
+	KedaAutoscalingKafkaActivationLagThreshold = KEDA + "/kafkaActivationLagThreshold"
 
 	// KedaAutoscalingRabbitMQQueueLength is the annotation that refers to the target value for number of messages in a RabbitMQ brokers
 	// trigger queue.


### PR DESCRIPTION

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Added new Kafka `activationLagThreshold` annotation for KEDA scaling

Dependent on https://github.com/knative-sandbox/eventing-autoscaler-keda/pull/329 open PR.

Don't merge yet.