### PR TITLE
NIT: Reflect that the ContentMode for KafkaSink is binary

### DIFF
--- a/control-plane/pkg/apis/eventing/v1alpha1/kafka_sink_types.go
+++ b/control-plane/pkg/apis/eventing/v1alpha1/kafka_sink_types.go
@@ -85,11 +85,11 @@ type KafkaSinkSpec struct {
 	// - structured
 	// - binary
 	//
-	// - default: structured.
+	// - default: binary.
 	//
 	// - https://github.com/cloudevents/spec/blob/v1.0/spec.md#message
-	//	 - https://github.com/cloudevents/spec/blob/v1.0/kafka-protocol-binding.md#33-structured-content-mode
 	//	 - https://github.com/cloudevents/spec/blob/v1.0/kafka-protocol-binding.md#32-binary-content-mode'
+	//	 - https://github.com/cloudevents/spec/blob/v1.0/kafka-protocol-binding.md#33-structured-content-mode
 	//
 	// +optional
 	ContentMode *string `json:"contentMode,omitempty"`


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- In #2391 we changed the default of the `ContentMode` for the `KafkaSink` CRD, but we did not change the doc on the actual `types` file

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
