### PR TITLE
KEDA as scaling library minor fix in TriggerAuth gen

### DIFF
--- a/control-plane/pkg/keda/keda.go
+++ b/control-plane/pkg/keda/keda.go
@@ -192,7 +192,7 @@ func ScaleObjectFailed(namespace, name string, err error) reconciler.Event {
 
 func addAuthSecretTargetRef(parameter string, secretKeyRef v1beta1.SecretValueFromSource, secretTargetRefs []kedav1alpha1.AuthSecretTargetRef) []kedav1alpha1.AuthSecretTargetRef {
 	if secretKeyRef.SecretKeyRef == nil || secretKeyRef.SecretKeyRef.Name == "" || secretKeyRef.SecretKeyRef.Key == "" {
-		return nil
+		return secretTargetRefs
 	}
 
 	ref := kedav1alpha1.AuthSecretTargetRef{


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

Fix for new code in #2607 

/cc @pierDipi 