### PR TITLE
Fix for "CONSUMER_CONTRACT_CONFIG_MAP_FORMAT missing value" in source-controller

### DIFF
--- a/control-plane/config/eventing-kafka-source/200-controller/500-controller.yaml
+++ b/control-plane/config/eventing-kafka-source/200-controller/500-controller.yaml
@@ -74,7 +74,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: CONSUMER_CONTRACT_CONFIG_FORMAT
+            - name: CONSUMER_CONTRACT_CONFIG_MAP_FORMAT
               value: json
 
             - name: SYSTEM_NAMESPACE


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

Error in source-controller reported:
```
kew\": 2}"},{"Name":"LowestOrdinalPriority","Weight":2,"Args":null},{"Name":"EvenPodSpread","Weight":2,"Args":"{\"MaxSkew\": 2}"}]}}
{"level":"info","ts":"2022-09-13T20:40:01.357Z","logger":"kafka-source-controller","caller":"consumergroup/controller.go:257","msg":"Schedulers policy registration","commit":"fecf5c3-dirty","knative.dev/pod":"kafka-source-controller-547955954b-g4445","configmap":"config-kafka-descheduler","policy":{"Predicates":[],"Priorities":[{"Name":"RemoveWithEvenPodSpreadPriority","Weight":10,"Args":"{\"MaxSkew\": 2}"},{"Name":"RemoveWithAvailabilityZonePriority","Weight":10,"Args":"{\"MaxSkew\": 2}"},{"Name":"RemoveWithHighestOrdinalPriority","Weight":2,"Args":null}]}}
panic: failed to process env variables for consumer controller, prefix CONSUMER: required key CONSUMER_CONTRACT_CONFIG_MAP_FORMAT missing value
```

Fixes incorrect environment variable in kafka-source-controller