### PR TITLE
Using Red Hat OpenJDK with ubi8

### DIFF
--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -397,7 +397,7 @@
             <!--  KinD e2e tests registry uses HTTP -->
             <allowInsecureRegistries>true</allowInsecureRegistries>
             <from>
-              <image>gcr.io/distroless/java17-debian11:nonroot</image>
+              <image>registry.access.redhat.com/ubi8/openjdk-17</image>
               <platforms>
                 <platform>
                   <architecture>amd64</architecture>


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes

- Going with Red Hat UBI8 as the OpenJDK base

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
