### PR TITLE
Fix cluster role for post install job

### DIFF
--- a/control-plane/config/post-install/200-controller-cluster-role.yaml
+++ b/control-plane/config/post-install/200-controller-cluster-role.yaml
@@ -29,6 +29,14 @@ rules:
       - delete
       - deletecollection
 
+  - apiGroups:
+      - "apps"
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+
   # sources.knative.dev resources and finalizers we care about.
   - apiGroups:
       - sources.knative.dev


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

Fixes #2681 

```
ansuvarghese$ k get pods -n knative-eventing
NAME                                           READY   STATUS      RESTARTS       AGE
kafka-controller-post-install-wxz79            1/1     Running     9 (5m4s ago)   22m
```

```
ansuvarghese$ k logs kafka-controller-post-install-wxz79 -n knative-eventing
{"severity":"EMERGENCY","timestamp":"2022-09-27T22:24:31.085183047Z","logger":"kafka-broker-post-install","caller":"post-install/main.go:46","message":"source dispatcher deletion failed: failed while waiting for statefulset to come up: failed to get statefulset knative-eventing/kafka-source-dispatcher: statefulsets.apps \"kafka-source-dispatcher\" is forbidden: User \"system:serviceaccount:knative-eventing:knative-kafka-controller-post-install\" cannot get resource \"statefulsets\" in API group \"apps\" in the namespace \"knative-eventing\"","commit":"8cfb0de-dirty","stacktrace":"main.main\n\tknative.dev/eventing-kafka-broker/control-plane/cmd/post-install/main.go:46\nruntime.main\n\truntime/proc.go:250"}
```

Fixes above error.