### PR TITLE
Remove empty match expression to avoid operator loops

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-pod-defaulting.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-pod-defaulting.yaml
@@ -32,7 +32,6 @@ webhooks:
     reinvocationPolicy: IfNeeded
     matchPolicy: Equivalent
     namespaceSelector:
-      matchExpressions: [ ]
       matchLabels:
         app.kubernetes.io/name: knative-eventing
     objectSelector:


### PR DESCRIPTION
knative/pkg modifies this field and our operator starts
to loop due to these updates but since the field is empty
is pointless to keep it.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>