### PR TITLE
Source HA cleanup minor changes

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/500-controller.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/500-controller.yaml
@@ -75,8 +75,6 @@ spec:
               value: kafka-channel-channels-subscriptions
             - name: SINK_CONTRACT_CONFIG_MAP_NAME
               value: kafka-sink-sinks
-            - name: SOURCE_CONTRACT_CONFIG_MAP_NAME
-              value: kafka-source-sources
 
             - name: BROKER_DATA_PLANE_CONFIG_CONFIG_MAP_NAME
               value: config-kafka-broker-data-plane

--- a/control-plane/config/eventing-kafka-source/200-controller/500-controller.yaml
+++ b/control-plane/config/eventing-kafka-source/200-controller/500-controller.yaml
@@ -62,8 +62,6 @@ spec:
           env:
             - name: SOURCE_DATA_PLANE_CONFIG_MAP_NAMESPACE
               value: knative-eventing
-            - name: SOURCE_CONTRACT_CONFIG_MAP_NAME
-              value: kafka-source-sources
             - name: SOURCE_CONTRACT_CONFIG_MAP_FORMAT
               value: json
             - name: SOURCE_INGRESS_NAME

--- a/data-plane/config/source/500-dispatcher.yaml
+++ b/data-plane/config/source/500-dispatcher.yaml
@@ -23,6 +23,7 @@ metadata:
     app: kafka-source-dispatcher
     kafka.eventing.knative.dev/release: devel
 spec:
+  replicas: 0
   serviceName: kafka-source-dispatcher
   podManagementPolicy: "Parallel"
   selector:


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

Dispatches replicas setting initially to 0 so statefulset can autoscale up as needed by scheduler and do the eventual necessary pod binding plus config map creation, etc...

Removing old contract config map env var...

/cc @pierDipi 