### PR TITLE
Fix for scaling issue

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -252,6 +252,8 @@ function scale_controlplane() {
     sleep 5
     # Scale up components for HA tests
     kubectl -n knative-eventing scale deployment "$deployment" --replicas="${REPLICAS}" || fail_test "Failed to scale up to ${REPLICAS} ${deployment}"
+    # Wait for the deployment to be available
+    kubectl -n knative-eventing wait deployment "$deployment" --for condition=Available=True --timeout=180s
   done
 }
 


### PR DESCRIPTION
Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>

Fixes #2729

## Proposed Changes

This PR addresses the issue reported in #2729 by adding a waiting period of 180s max to the scaling operation of various deployments prior to the deployment of sacura.

Note that this affects the e2e test code only, no changes to the actual product / component code.