### PR TITLE
Refactor ConsumerVerticleFactory and enhance dispatcher logging

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/ConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/ConsumerVerticle.java
@@ -18,7 +18,7 @@ package dev.knative.eventing.kafka.broker.dispatcher.impl.consumer;
 import dev.knative.eventing.kafka.broker.core.AsyncCloseable;
 import dev.knative.eventing.kafka.broker.dispatcher.RecordDispatcher;
 import dev.knative.eventing.kafka.broker.dispatcher.main.ConsumerVerticleContext;
-import dev.knative.eventing.kafka.broker.dispatcher.main.LoggingConsumerVerticleContext;
+import dev.knative.eventing.kafka.broker.dispatcher.main.ConsumerVerticleLoggingContext;
 import io.cloudevents.CloudEvent;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
@@ -45,7 +45,7 @@ public abstract class ConsumerVerticle extends AbstractVerticle {
   private final Initializer initializer;
 
   private final ConsumerVerticleContext consumerVerticleContext;
-  private final LoggingConsumerVerticleContext loggingContext;
+  private final ConsumerVerticleLoggingContext loggingContext;
 
   KafkaConsumer<Object, CloudEvent> consumer;
   RecordDispatcher recordDispatcher;
@@ -56,7 +56,7 @@ public abstract class ConsumerVerticle extends AbstractVerticle {
     Objects.requireNonNull(consumerVerticleContext);
 
     this.consumerVerticleContext = consumerVerticleContext;
-    this.loggingContext = new LoggingConsumerVerticleContext(consumerVerticleContext);
+    this.loggingContext = new ConsumerVerticleLoggingContext(consumerVerticleContext);
 
     this.initializer = initializer;
   }
@@ -111,7 +111,7 @@ public abstract class ConsumerVerticle extends AbstractVerticle {
     return consumerVerticleContext;
   }
 
-  protected LoggingConsumerVerticleContext getLoggingContext() {
+  protected ConsumerVerticleLoggingContext getLoggingContext() {
     return loggingContext;
   }
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -95,7 +96,7 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
   @Override
   void startConsumer(Promise<Void> startPromise) {
     // We need to sub first, then we can start the polling loop
-    this.consumer.subscribe(new HashSet<>(getConsumerVerticleContext().getResource().getTopicsList()))
+    this.consumer.subscribe(Set.copyOf(getConsumerVerticleContext().getResource().getTopicsList()))
       .onFailure(startPromise::fail)
       .onSuccess(v -> {
         if (this.pollTimer.compareAndSet(-1, 0)) {

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
@@ -82,7 +82,7 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
         final var executor = recordDispatcherExecutors.remove(partition);
         if (executor != null) {
           logger.info("Stopping executor {} {}",
-            keyValue("context", context.getLoggingContext()),
+            getConsumerVerticleContext().getLoggingKeyValue(),
             keyValue("topicPartition", partition)
           );
           executor.stop();
@@ -108,7 +108,7 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
 
   private void poll() {
     if (this.closed.get() || this.isPollInFlight.get()) {
-      logger.debug("Consumer closed or poll is in-flight {}", keyValue("context", getLoggingContext()));
+      logger.debug("Consumer closed or poll is in-flight {}", getConsumerVerticleContext().getLoggingKeyValue());
       return;
     }
 
@@ -117,7 +117,7 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
     if (bucket != null && bucket.getAvailableTokens() <= 0) {
       logger.info("Rate limiter, tokens unavailable {} {}",
         keyValue("wait.ms", POLLING_MS),
-        keyValue("context", getLoggingContext())
+        getConsumerVerticleContext().getLoggingKeyValue()
       );
       return;
     }
@@ -125,12 +125,12 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
     // Only poll new records when at-least one internal per-partition queue
     // needs more records.
     if (areAllExecutorsBusy()) {
-      logger.debug("all executors are busy {}", keyValue("context", getLoggingContext()));
+      logger.debug("all executors are busy {}", getConsumerVerticleContext().getLoggingKeyValue());
       return;
     }
 
     if (this.isPollInFlight.compareAndSet(false, true)) {
-      logger.debug("Polling for records {}", getLoggingContext());
+      logger.debug("Polling for records {}", getConsumerVerticleContext().getLoggingKeyValue());
 
       this.consumer.poll(POLLING_TIMEOUT)
         .onSuccess(this::recordsHandler)
@@ -185,7 +185,7 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
 
   private Future<Void> dispatch(final KafkaConsumerRecord<Object, CloudEvent> record) {
     if (this.closed.get()) {
-      return Future.failedFuture("Consumer verticle closed " + getLoggingContext());
+      return Future.failedFuture("Consumer verticle closed " + getConsumerVerticleContext());
     }
 
     return this.recordDispatcher.dispatch(record);

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -88,7 +87,7 @@ public final class UnorderedConsumerVerticle extends ConsumerVerticle {
           " waiting for response from subscriber before polling for new records {} {} {}",
         keyValue(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, getConsumerVerticleContext().getMaxPollRecords()),
         keyValue("records", inFlightRecords),
-        keyValue("context", getLoggingContext())
+        getConsumerVerticleContext().getLoggingKeyValue()
       );
       return;
     }
@@ -98,7 +97,7 @@ public final class UnorderedConsumerVerticle extends ConsumerVerticle {
         .onSuccess(this::handleRecords)
         .onFailure(cause -> {
           isPollInFlight.set(false);
-          logger.error("Failed to poll messages {}", keyValue("context", getLoggingContext()), cause);
+          logger.error("Failed to poll messages {}", getConsumerVerticleContext().getLoggingKeyValue(), cause);
           // Wait before retrying.
           vertx.setTimer(BACKOFF_DELAY_MS, t -> poll());
         });

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
@@ -16,6 +16,7 @@
 package dev.knative.eventing.kafka.broker.dispatcher.impl.consumer;
 
 import dev.knative.eventing.kafka.broker.dispatcher.DeliveryOrder;
+import dev.knative.eventing.kafka.broker.dispatcher.main.ConsumerVerticleContext;
 import io.cloudevents.CloudEvent;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -25,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -34,7 +36,7 @@ import static dev.knative.eventing.kafka.broker.core.utils.Logging.keyValue;
 /**
  * This {@link io.vertx.core.Verticle} implements an unordered consumer logic, as described in {@link DeliveryOrder#UNORDERED}.
  */
-public final class UnorderedConsumerVerticle extends BaseConsumerVerticle {
+public final class UnorderedConsumerVerticle extends ConsumerVerticle {
 
   private static final Logger logger = LoggerFactory.getLogger(UnorderedConsumerVerticle.class);
 
@@ -43,30 +45,22 @@ public final class UnorderedConsumerVerticle extends BaseConsumerVerticle {
   // to block a verticle thread.
   private static final Duration POLL_TIMEOUT = Duration.ofMillis(500);
 
-  private final int maxPollRecords;
-
   private final AtomicBoolean closed;
   private final AtomicInteger inFlightRecords;
   private final AtomicBoolean isPollInFlight;
 
-  public UnorderedConsumerVerticle(final Initializer initializer,
-                                   final Set<String> topics,
-                                   final int maxPollRecords) {
-    super(initializer, topics);
-    if (maxPollRecords <= 0) {
-      this.maxPollRecords = 500;
-    } else {
-      this.maxPollRecords = maxPollRecords;
-    }
+  public UnorderedConsumerVerticle(final ConsumerVerticleContext context,
+                                   final Initializer initializer) {
+    super(context, initializer);
     this.inFlightRecords = new AtomicInteger(0);
     this.closed = new AtomicBoolean(false);
     this.isPollInFlight = new AtomicBoolean(false);
   }
 
   @Override
-  void startConsumer(Promise<Void> startPromise) {
-    this.consumer.subscribe(this.topics, startPromise);
-
+  void startConsumer(final Promise<Void> startPromise) {
+    final var topics = new HashSet<>(getConsumerVerticleContext().getResource().getTopicsList());
+    this.consumer.subscribe(topics, startPromise);
     startPromise.future()
       .onSuccess(v -> poll());
   }
@@ -88,13 +82,13 @@ public final class UnorderedConsumerVerticle extends BaseConsumerVerticle {
     if (closed.get() || isPollInFlight.get()) {
       return;
     }
-    if (inFlightRecords.get() >= maxPollRecords) {
+    if (inFlightRecords.get() >= getConsumerVerticleContext().getMaxPollRecords()) {
       logger.info(
         "In flight records exceeds " + ConsumerConfig.MAX_POLL_RECORDS_CONFIG +
           " waiting for response from subscriber before polling for new records {} {} {}",
-        keyValue(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords),
+        keyValue(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, getConsumerVerticleContext().getMaxPollRecords()),
         keyValue("records", inFlightRecords),
-        keyValue("topics", topics)
+        keyValue("context", getLoggingContext())
       );
       return;
     }
@@ -104,7 +98,7 @@ public final class UnorderedConsumerVerticle extends BaseConsumerVerticle {
         .onSuccess(this::handleRecords)
         .onFailure(cause -> {
           isPollInFlight.set(false);
-          logger.error("Failed to poll messages {}", keyValue("topics", topics), cause);
+          logger.error("Failed to poll messages {}", keyValue("context", getLoggingContext()), cause);
           // Wait before retrying.
           vertx.setTimer(BACKOFF_DELAY_MS, t -> poll());
         });

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -58,8 +58,7 @@ public final class UnorderedConsumerVerticle extends ConsumerVerticle {
 
   @Override
   void startConsumer(final Promise<Void> startPromise) {
-    final var topics = new HashSet<>(getConsumerVerticleContext().getResource().getTopicsList());
-    this.consumer.subscribe(topics, startPromise);
+    this.consumer.subscribe(Set.copyOf(getConsumerVerticleContext().getResource().getTopicsList()), startPromise);
     startPromise.future()
       .onSuccess(v -> poll());
   }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerFactory.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.dispatcher.main;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.kafka.client.common.KafkaClientOptions;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+
+import java.util.Map;
+
+@FunctionalInterface
+public interface ConsumerFactory<K, V> {
+
+  KafkaConsumer<K, V> create(final Vertx vertx, final Map<String, Object> consumerConfigs);
+
+  static <K, V> ConsumerFactory<K, V> defaultFactory() {
+    return new ConsumerFactory<>() {
+
+      private KafkaConsumer<K, V> consumer;
+
+      @Override
+      public KafkaConsumer<K, V> create(Vertx vertx, Map<String, Object> consumerConfigs) {
+        if (consumer == null) {
+          consumer = KafkaConsumer.create(vertx, new KafkaClientOptions().setConfig(consumerConfigs)
+            // Disable tracing provided by vertx-kafka-client, because it doesn't work well with our dispatch logic.
+            // RecordDispatcher, when receiving a new record, takes care of adding the proper receive record span.
+            .setTracingPolicy(TracingPolicy.IGNORE));
+        }
+        return consumer;
+      }
+    };
+  }
+}
+
+

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
@@ -164,6 +164,10 @@ public class ConsumerVerticleBuilder {
         try {
           future.toCompletionStage().toCompletableFuture().get(1, TimeUnit.SECONDS);
         } catch (final Exception ignored) {
+          ConsumerVerticleContext.logger.warn("Partition revoked handler failed {} {}",
+            consumerVerticleContext.getLoggingKeyValue(),
+            keyValue("partitions", partitions)
+          );
         }
       }
     };

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.dispatcher.main;
+
+import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
+import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
+import dev.knative.eventing.kafka.broker.core.security.Credentials;
+import dev.knative.eventing.kafka.broker.core.security.KafkaClientsAuth;
+import dev.knative.eventing.kafka.broker.dispatcher.CloudEventSender;
+import dev.knative.eventing.kafka.broker.dispatcher.DeliveryOrder;
+import dev.knative.eventing.kafka.broker.dispatcher.Filter;
+import dev.knative.eventing.kafka.broker.dispatcher.ResponseHandler;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.NoopResponseHandler;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.RecordDispatcherImpl;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.RecordDispatcherMutatorChain;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.ResourceContext;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.ResponseToHttpEndpointHandler;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.ResponseToKafkaTopicHandler;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.CloudEventOverridesMutator;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.ConsumerVerticle;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.OffsetManager;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.OrderedConsumerVerticle;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.PartitionRevokedHandler;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.UnorderedConsumerVerticle;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.filter.subscriptionsapi.AllFilter;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.filter.subscriptionsapi.AnyFilter;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.filter.subscriptionsapi.CeSqlFilter;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.filter.subscriptionsapi.ExactFilter;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.filter.subscriptionsapi.NotFilter;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.filter.subscriptionsapi.PrefixFilter;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.filter.subscriptionsapi.SuffixFilter;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.http.WebClientCloudEventSender;
+import io.cloudevents.CloudEvent;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.kafka.client.common.KafkaClientOptions;
+import io.vertx.kafka.client.common.TopicPartition;
+import io.vertx.kafka.client.common.tracing.ConsumerTracer;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static dev.knative.eventing.kafka.broker.core.utils.Logging.keyValue;
+
+public class ConsumerVerticleBuilder {
+
+  private final static CloudEventSender NO_DEAD_LETTER_SINK_SENDER = CloudEventSender.noop("No dead letter sink set");
+
+  private final ConsumerVerticleContext consumerVerticleContext;
+
+  public ConsumerVerticleBuilder(final ConsumerVerticleContext consumerVerticleContext) {
+    this.consumerVerticleContext = consumerVerticleContext;
+  }
+
+  public ConsumerVerticle build() {
+    return createConsumerVerticle(getInitializer());
+  }
+
+  private ConsumerVerticle.Initializer getInitializer() {
+    return (vertx, consumerVerticle) -> consumerVerticleContext.getAuthProvider()
+      .getCredentials(consumerVerticleContext.getResource())
+      .onSuccess(credentials -> build(vertx, consumerVerticle, credentials))
+      .mapEmpty();
+  }
+
+  private void build(final Vertx vertx, final ConsumerVerticle consumerVerticle, final Credentials credentials) {
+    KafkaClientsAuth.attachCredentials(consumerVerticleContext.getConsumerConfigs(), credentials);
+    KafkaClientsAuth.attachCredentials(consumerVerticleContext.getProducerConfigs(), credentials);
+
+    final KafkaConsumer<Object, CloudEvent> consumer = this.consumerVerticleContext
+      .getConsumerFactory()
+      .create(vertx, consumerVerticleContext.getConsumerConfigs());
+    consumerVerticle.setConsumer(consumer);
+
+    final var metricsCloser = Metrics.register(consumer.unwrap());
+    consumerVerticle.setCloser(metricsCloser);
+
+    final var egressSubscriberSender = createConsumerRecordSender(vertx);
+    final var egressDeadLetterSender = createDeadLetterSinkRecordSender(vertx);
+    final var responseHandler = createResponseHandler(vertx);
+
+    final var offsetManager = new OffsetManager(
+      vertx,
+      consumer,
+      (v) -> {
+      },
+      getCommitIntervalMs()
+    );
+
+    final var recordDispatcher = new RecordDispatcherMutatorChain(
+      new RecordDispatcherImpl(
+        new ResourceContext(consumerVerticleContext.getResource(), consumerVerticleContext.getEgress()),
+        getFilter(),
+        egressSubscriberSender,
+        egressDeadLetterSender,
+        responseHandler,
+        offsetManager,
+        ConsumerTracer.create(((VertxInternal) vertx).tracer(),
+          new KafkaClientOptions().setConfig(consumerVerticleContext.getConsumerConfigs())
+            // Make sure the policy is propagate for the manually instantiated consumer tracer
+            .setTracingPolicy(TracingPolicy.PROPAGATE)), Metrics.getRegistry()),
+
+      new CloudEventOverridesMutator(consumerVerticleContext.getResource().getCloudEventOverrides())
+    );
+    consumerVerticle.setRecordDispatcher(recordDispatcher);
+
+    final var partitionRevokedHandlers = List.of(
+      consumerVerticle.getPartitionsRevokedHandler(),
+      offsetManager.getPartitionRevokedHandler()
+    );
+    consumer.partitionsRevokedHandler(handlePartitionsRevoked(partitionRevokedHandlers));
+  }
+
+  private ConsumerVerticle createConsumerVerticle(final ConsumerVerticle.Initializer initializer) {
+    return switch (DeliveryOrder.fromContract(consumerVerticleContext.getEgress().getDeliveryOrder())) {
+      case ORDERED -> new OrderedConsumerVerticle(consumerVerticleContext, initializer);
+      case UNORDERED -> new UnorderedConsumerVerticle(consumerVerticleContext, initializer);
+    };
+  }
+
+  /**
+   * For each handler call partitionRevoked and wait for the future to complete.
+   *
+   * @param partitionRevokedHandlers partition revoked handlers
+   * @return a single handler that dispatches the partition revoked event to the given handlers.
+   */
+  private Handler<Set<TopicPartition>> handlePartitionsRevoked(final List<PartitionRevokedHandler> partitionRevokedHandlers) {
+    return partitions -> {
+
+      ConsumerVerticleContext.logger.info("Received revoke partitions for consumer {} {}",
+        consumerVerticleContext.getLoggingContext(),
+        keyValue("partitions", partitions)
+      );
+
+      final var futures = new ArrayList<Future<Void>>(partitionRevokedHandlers.size());
+      for (PartitionRevokedHandler partitionRevokedHandler : partitionRevokedHandlers) {
+        futures.add(partitionRevokedHandler.partitionRevoked(partitions));
+      }
+
+      for (final var future : futures) {
+        try {
+          future.toCompletionStage().toCompletableFuture().get(1, TimeUnit.SECONDS);
+        } catch (final Exception ignored) {
+        }
+      }
+    };
+  }
+
+  private Filter getFilter() {
+    // Dialected filters should override the attributes filter
+    if (consumerVerticleContext.getEgress().getDialectedFilterCount() > 0) {
+      return getFilter(consumerVerticleContext.getEgress().getDialectedFilterList());
+    } else if (consumerVerticleContext.getEgress().hasFilter()) {
+      return new ExactFilter(consumerVerticleContext.getEgress().getFilter().getAttributesMap());
+    }
+    return Filter.noop();
+  }
+
+  private static Filter getFilter(List<DataPlaneContract.DialectedFilter> filters) {
+    return new AllFilter(filters.stream().map(ConsumerVerticleBuilder::getFilter).collect(Collectors.toSet()));
+  }
+
+  private static Filter getFilter(DataPlaneContract.DialectedFilter filter) {
+    return switch (filter.getFilterCase()) {
+      case EXACT -> new ExactFilter(filter.getExact().getAttributesMap());
+      case PREFIX -> new PrefixFilter(filter.getPrefix().getAttributesMap());
+      case SUFFIX -> new SuffixFilter(filter.getSuffix().getAttributesMap());
+      case NOT -> new NotFilter(getFilter(filter.getNot().getFilter()));
+      case ANY -> new AnyFilter(filter.getAny().getFiltersList().stream().map(ConsumerVerticleBuilder::getFilter).collect(Collectors.toSet()));
+      case ALL -> new AllFilter(filter.getAll().getFiltersList().stream().map(ConsumerVerticleBuilder::getFilter).collect(Collectors.toSet()));
+      case CESQL -> new CeSqlFilter(filter.getCesql().getExpression());
+      default -> Filter.noop();
+    };
+  }
+
+  private ResponseHandler createResponseHandler(final Vertx vertx) {
+    if (consumerVerticleContext.getEgress().hasReplyUrl()) {
+      return new ResponseToHttpEndpointHandler(new WebClientCloudEventSender(
+        vertx,
+        WebClient.create(vertx, consumerVerticleContext.getWebClientOptions()),
+        consumerVerticleContext.getEgress().getReplyUrl(),
+        consumerVerticleContext.getEgressConfig()
+      ));
+    }
+
+    if (consumerVerticleContext.getEgress().hasReplyToOriginalTopic()) {
+      final KafkaProducer<String, CloudEvent> producer = this.consumerVerticleContext
+        .getProducerFactory()
+        .create(vertx, consumerVerticleContext.getProducerConfigs());
+      return new ResponseToKafkaTopicHandler(producer, consumerVerticleContext.getResource().getTopics(0));
+    }
+
+    return new NoopResponseHandler();
+  }
+
+  private CloudEventSender createConsumerRecordSender(final Vertx vertx) {
+    return new WebClientCloudEventSender(
+      vertx,
+      WebClient.create(vertx, consumerVerticleContext.getWebClientOptions()),
+      consumerVerticleContext.getEgress().getDestination(),
+      consumerVerticleContext.getEgressConfig()
+    );
+  }
+
+  private CloudEventSender createDeadLetterSinkRecordSender(final Vertx vertx) {
+    if (hasDeadLetterSink(consumerVerticleContext.getEgressConfig())) {
+      var webClientOptions = consumerVerticleContext.getWebClientOptions();
+      // TODO use numPartitions for ordered delivery or max.poll.records for unordered delivery
+      // if (egress.getVReplicas() > 0) {
+      //   webClientOptions = new WebClientOptions(this.webClientOptions);
+      //   webClientOptions.setMaxPoolSize(egress.getVReplicas());
+      // }
+      return new WebClientCloudEventSender(
+        vertx,
+        WebClient.create(vertx, webClientOptions),
+        consumerVerticleContext.getEgressConfig().getDeadLetter(),
+        consumerVerticleContext.getEgressConfig()
+      );
+    }
+
+    return NO_DEAD_LETTER_SINK_SENDER;
+  }
+
+  private int getCommitIntervalMs() {
+    final var commitInterval = consumerVerticleContext.getConsumerConfigs().get(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG);
+    if (commitInterval == null) {
+      return 5000;
+    }
+    return Integer.parseInt(String.valueOf(commitInterval));
+  }
+
+  private static boolean hasDeadLetterSink(final DataPlaneContract.EgressConfig egressConfig) {
+    return !(egressConfig == null || egressConfig.getDeadLetter().isEmpty());
+  }
+}

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
@@ -206,14 +206,14 @@ public class ConsumerVerticleBuilder {
       ));
     }
 
-    if (consumerVerticleContext.getEgress().hasReplyToOriginalTopic()) {
-      final KafkaProducer<String, CloudEvent> producer = this.consumerVerticleContext
-        .getProducerFactory()
-        .create(vertx, consumerVerticleContext.getProducerConfigs());
-      return new ResponseToKafkaTopicHandler(producer, consumerVerticleContext.getResource().getTopics(0));
+    if (consumerVerticleContext.getEgress().hasDiscardReply()) {
+      return new NoopResponseHandler();
     }
 
-    return new NoopResponseHandler();
+    final KafkaProducer<String, CloudEvent> producer = this.consumerVerticleContext
+      .getProducerFactory()
+      .create(vertx, consumerVerticleContext.getProducerConfigs());
+    return new ResponseToKafkaTopicHandler(producer, consumerVerticleContext.getResource().getTopics(0));
   }
 
   private CloudEventSender createConsumerRecordSender(final Vertx vertx) {

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
@@ -151,7 +151,7 @@ public class ConsumerVerticleBuilder {
     return partitions -> {
 
       ConsumerVerticleContext.logger.info("Received revoke partitions for consumer {} {}",
-        consumerVerticleContext.getLoggingContext(),
+        consumerVerticleContext.getLoggingKeyValue(),
         keyValue("partitions", partitions)
       );
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleContext.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleContext.java
@@ -53,7 +53,7 @@ public class ConsumerVerticleContext {
 
   private Integer maxPoolRecords;
 
-  private LoggingConsumerVerticleContext loggingContext;
+  private ConsumerVerticleLoggingContext loggingContext;
 
   public ConsumerVerticleContext withConsumerConfigs(final Map<String, Object> consumerConfigs) {
     this.consumerConfigs = new HashMap<>(consumerConfigs);
@@ -172,9 +172,9 @@ public class ConsumerVerticleContext {
     return webClientOptions;
   }
 
-  public LoggingConsumerVerticleContext getLoggingContext() {
+  public ConsumerVerticleLoggingContext getLoggingContext() {
     if (loggingContext == null) {
-      loggingContext = new LoggingConsumerVerticleContext(this);
+      loggingContext = new ConsumerVerticleLoggingContext(this);
     }
     return loggingContext;
   }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleContext.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleContext.java
@@ -32,6 +32,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static dev.knative.eventing.kafka.broker.core.utils.Logging.keyValue;
+
 public class ConsumerVerticleContext {
 
   public final static Logger logger = LoggerFactory.getLogger(ConsumerVerticleContext.class);
@@ -172,11 +174,15 @@ public class ConsumerVerticleContext {
     return webClientOptions;
   }
 
-  public ConsumerVerticleLoggingContext getLoggingContext() {
+  private synchronized ConsumerVerticleLoggingContext getLoggingContext() {
     if (loggingContext == null) {
       loggingContext = new ConsumerVerticleLoggingContext(this);
     }
     return loggingContext;
+  }
+
+  public Object getLoggingKeyValue() {
+    return keyValue("context", getLoggingContext());
   }
 
   public ConsumerFactory<Object, CloudEvent> getConsumerFactory() {
@@ -218,4 +224,8 @@ public class ConsumerVerticleContext {
     return resource != null && !resource.getNamespace().isBlank() && !resource.getName().isBlank();
   }
 
+  @Override
+  public String toString() {
+    return "ConsumerVerticleContext{" + getLoggingContext() + "}";
+  }
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleContext.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleContext.java
@@ -53,7 +53,8 @@ public class ConsumerVerticleContext {
   private ConsumerFactory<Object, CloudEvent> consumerFactory;
   private ProducerFactory<String, CloudEvent> producerFactory;
 
-  private Integer maxPoolRecords;
+  private Integer maxPollRecords;
+  private static final int DEFAULT_MAX_POLL_RECORDS = 50;
 
   private ConsumerVerticleLoggingContext loggingContext;
 
@@ -141,13 +142,15 @@ public class ConsumerVerticleContext {
   }
 
   public int getMaxPollRecords() {
-    if (maxPoolRecords == null) {
+    if (this.maxPollRecords == null) {
       final var mpr = getConsumerConfigs().get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG);
       if (mpr == null) {
-        maxPoolRecords = 500;
+        this.maxPollRecords = DEFAULT_MAX_POLL_RECORDS;
+      } else {
+        this.maxPollRecords = Integer.parseInt(mpr.toString());
       }
     }
-    return maxPoolRecords;
+    return this.maxPollRecords;
   }
 
   public DataPlaneContract.EgressConfig getEgressConfig() {

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleContext.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleContext.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.dispatcher.main;
+
+import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
+import dev.knative.eventing.kafka.broker.core.security.AuthProvider;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.InvalidCloudEventInterceptor;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.KeyDeserializer;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.http.WebClientCloudEventSender;
+import io.cloudevents.CloudEvent;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.vertx.ext.web.client.WebClientOptions;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class ConsumerVerticleContext {
+
+  public final static Logger logger = LoggerFactory.getLogger(ConsumerVerticleContext.class);
+
+  private DataPlaneContract.Resource resource;
+
+  private DataPlaneContract.Egress egress;
+  private DataPlaneContract.EgressConfig egressConfig;
+
+  private AuthProvider authProvider;
+  private MeterRegistry metricsRegistry;
+
+  private Map<String, Object> consumerConfigs;
+  private Map<String, Object> producerConfigs;
+  private WebClientOptions webClientOptions;
+
+  private ConsumerFactory<Object, CloudEvent> consumerFactory;
+  private ProducerFactory<String, CloudEvent> producerFactory;
+
+  private Integer maxPoolRecords;
+
+  private LoggingConsumerVerticleContext loggingContext;
+
+  public ConsumerVerticleContext withConsumerConfigs(final Map<String, Object> consumerConfigs) {
+    this.consumerConfigs = new HashMap<>(consumerConfigs);
+    return this;
+  }
+
+  public ConsumerVerticleContext withProducerConfigs(final Map<String, Object> producerConfigs) {
+    this.producerConfigs = new HashMap<>(producerConfigs);
+    return this;
+  }
+
+  public ConsumerVerticleContext withResource(final DataPlaneContract.Resource resource, final DataPlaneContract.Egress egress) {
+    Objects.requireNonNull(resource);
+    Objects.requireNonNull(consumerConfigs);
+    Objects.requireNonNull(producerConfigs);
+
+    // Copy resource and remove egresses to avoid keeping references to all egresses.
+    this.resource = DataPlaneContract.Resource.newBuilder(resource).clearEgresses().build();
+    withEgress(egress);
+
+    consumerConfigs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, resource.getBootstrapServers());
+    producerConfigs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, resource.getBootstrapServers());
+
+    consumerConfigs.put(ConsumerConfig.GROUP_ID_CONFIG, egress.getConsumerGroup());
+    consumerConfigs.put(KeyDeserializer.KEY_TYPE, egress.getKeyType());
+    if (isResourceReferenceDefined(resource.getReference())) {
+      // Set the resource reference so that when the interceptor gets a record that is not a CloudEvent, it can set
+      // CloudEvents context attributes accordingly (see InvalidCloudEventInterceptor for more information).
+      consumerConfigs.put(InvalidCloudEventInterceptor.SOURCE_NAME_CONFIG, resource.getReference().getName());
+      consumerConfigs.put(InvalidCloudEventInterceptor.SOURCE_NAMESPACE_CONFIG, resource.getReference().getNamespace());
+    }
+    return this;
+  }
+
+  private void withEgress(final DataPlaneContract.Egress egress) {
+    Objects.requireNonNull(egress);
+    Objects.requireNonNull(resource);
+    Objects.requireNonNull(consumerConfigs);
+
+    this.egress = egress;
+
+    if (egress.hasEgressConfig()) {
+      this.egressConfig = egress.getEgressConfig();
+    } else {
+      this.egressConfig = resource.getEgressConfig();
+    }
+
+    final var maxProcessingTime = maxProcessingTimeMs(consumerConfigs, egressConfig);
+    consumerConfigs.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxProcessingTime);
+  }
+
+  public ConsumerVerticleContext withAuthProvider(final AuthProvider authProvider) {
+    this.authProvider = authProvider;
+    return this;
+  }
+
+  public ConsumerVerticleContext withMeterRegistry(MeterRegistry metricsRegistry) {
+    this.metricsRegistry = metricsRegistry;
+    return this;
+  }
+
+  public ConsumerVerticleContext withWebClientOptions(final WebClientOptions webClientOptions) {
+    this.webClientOptions = new WebClientOptions(webClientOptions);
+    return this;
+  }
+
+  public ConsumerVerticleContext withConsumerFactory(final ConsumerFactory<Object, CloudEvent> consumerFactory) {
+    this.consumerFactory = consumerFactory;
+    return this;
+  }
+
+  public ConsumerVerticleContext withProducerFactory(final ProducerFactory<String, CloudEvent> producerFactory) {
+    this.producerFactory = producerFactory;
+    return this;
+  }
+
+  public DataPlaneContract.Resource getResource() {
+    return resource;
+  }
+
+  public DataPlaneContract.Egress getEgress() {
+    return egress;
+  }
+
+  public int getMaxPollRecords() {
+    if (maxPoolRecords == null) {
+      final var mpr = getConsumerConfigs().get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG);
+      if (mpr == null) {
+        maxPoolRecords = 500;
+      }
+    }
+    return maxPoolRecords;
+  }
+
+  public DataPlaneContract.EgressConfig getEgressConfig() {
+    return egressConfig;
+  }
+
+  public AuthProvider getAuthProvider() {
+    return authProvider;
+  }
+
+  public MeterRegistry getMetricsRegistry() {
+    return metricsRegistry;
+  }
+
+  public Map<String, Object> getConsumerConfigs() {
+    return consumerConfigs;
+  }
+
+  public Map<String, Object> getProducerConfigs() {
+    return producerConfigs;
+  }
+
+  public WebClientOptions getWebClientOptions() {
+    return webClientOptions;
+  }
+
+  public LoggingConsumerVerticleContext getLoggingContext() {
+    if (loggingContext == null) {
+      loggingContext = new LoggingConsumerVerticleContext(this);
+    }
+    return loggingContext;
+  }
+
+  public ConsumerFactory<Object, CloudEvent> getConsumerFactory() {
+    return this.consumerFactory;
+  }
+
+  public ProducerFactory<String, CloudEvent> getProducerFactory() {
+    return this.producerFactory;
+  }
+
+  private static int maxProcessingTimeMs(final Map<String, Object> consumerConfigs, final DataPlaneContract.EgressConfig egressConfig) {
+    final var mpr = consumerConfigs.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG);
+    final long maxPollRecords = mpr == null ? /* default max.poll.records */ 500L : Long.parseLong(mpr.toString());
+    final var retryPolicy = WebClientCloudEventSender.computeRetryPolicy(egressConfig);
+    final var retry = egressConfig.getRetry();
+    final var timeout = egressConfig.getTimeout() > 0 ? egressConfig.getTimeout() : WebClientCloudEventSender.DEFAULT_TIMEOUT_MS;
+
+    long maxProcessingTimeForSingleRecord = timeout;
+    for (int i = 1; i <= retry; i++) {
+      maxProcessingTimeForSingleRecord += timeout + retryPolicy.apply(i);
+    }
+    // In addition, we add some seconds as overhead for each retry.
+    final long overhead = 1000L * retry;
+    maxProcessingTimeForSingleRecord += overhead;
+    // So far, the max processing time calculated is for one single record,
+    // however, we poll records in batches based on the `max.poll.records`
+    // configuration, so the total max processing time is:
+    //
+    // Times 2 for dead letter sink retries.
+    final var total = 2 * maxPollRecords * maxProcessingTimeForSingleRecord;
+
+    if (total >= Integer.MAX_VALUE) {
+      return Integer.MAX_VALUE;
+    }
+    return (int) total;
+  }
+
+  private static boolean isResourceReferenceDefined(DataPlaneContract.Reference resource) {
+    return resource != null && !resource.getNamespace().isBlank() && !resource.getName().isBlank();
+  }
+
+}

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
@@ -16,84 +16,26 @@
 package dev.knative.eventing.kafka.broker.dispatcher.main;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
-import dev.knative.eventing.kafka.broker.contract.DataPlaneContract.EgressConfig;
-import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
 import dev.knative.eventing.kafka.broker.core.security.AuthProvider;
-import dev.knative.eventing.kafka.broker.core.security.KafkaClientsAuth;
-import dev.knative.eventing.kafka.broker.dispatcher.CloudEventSender;
 import dev.knative.eventing.kafka.broker.dispatcher.ConsumerVerticleFactory;
-import dev.knative.eventing.kafka.broker.dispatcher.DeliveryOrder;
-import dev.knative.eventing.kafka.broker.dispatcher.Filter;
-import dev.knative.eventing.kafka.broker.dispatcher.ResponseHandler;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.NoopResponseHandler;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.RecordDispatcherImpl;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.RecordDispatcherMutatorChain;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.ResourceContext;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.ResponseToHttpEndpointHandler;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.ResponseToKafkaTopicHandler;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.BaseConsumerVerticle;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.CloudEventOverridesMutator;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.InvalidCloudEventInterceptor;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.KeyDeserializer;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.OffsetManager;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.OrderedConsumerVerticle;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.PartitionRevokedHandler;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.UnorderedConsumerVerticle;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.filter.subscriptionsapi.AllFilter;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.filter.subscriptionsapi.AnyFilter;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.filter.subscriptionsapi.CeSqlFilter;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.filter.subscriptionsapi.ExactFilter;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.filter.subscriptionsapi.NotFilter;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.filter.subscriptionsapi.PrefixFilter;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.filter.subscriptionsapi.SuffixFilter;
-import dev.knative.eventing.kafka.broker.dispatcher.impl.http.WebClientCloudEventSender;
-import io.cloudevents.CloudEvent;
+import dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.ConsumerVerticle;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.tracing.TracingPolicy;
-import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
-import io.vertx.kafka.client.common.KafkaClientOptions;
-import io.vertx.kafka.client.common.TopicPartition;
-import io.vertx.kafka.client.common.tracing.ConsumerTracer;
-import io.vertx.kafka.client.consumer.KafkaConsumer;
-import io.vertx.kafka.client.producer.KafkaProducer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static dev.knative.eventing.kafka.broker.core.utils.Logging.keyValue;
-
 public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
-
-  private static final Logger logger = LoggerFactory.getLogger(ConsumerVerticleFactoryImpl.class);
-
-  private final static CloudEventSender NO_DEAD_LETTER_SINK_SENDER = CloudEventSender.noop("No dead letter sink set");
 
   private final Map<String, Object> consumerConfigs;
   private final WebClientOptions webClientOptions;
   private final Map<String, Object> producerConfigs;
   private final AuthProvider authProvider;
+  private final MeterRegistry metricsRegistry;
 
   /**
    * All args constructor.
@@ -123,276 +65,31 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
       .stream()
       .map(e -> new SimpleImmutableEntry<>(e.getKey().toString(), e.getValue().toString()))
       .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
     this.webClientOptions = webClientOptions;
     this.authProvider = authProvider;
+    this.metricsRegistry = metricsRegistry;
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public AbstractVerticle get(final DataPlaneContract.Resource resource, final DataPlaneContract.Egress egress) {
+  public ConsumerVerticle get(final DataPlaneContract.Resource resource, final DataPlaneContract.Egress egress) {
     Objects.requireNonNull(resource, "provide resource");
     Objects.requireNonNull(egress, "provide egress");
 
-    // Consumer and producer configs are shared objects and they act as a prototype for each instance.
-    final var consumerConfigs = new HashMap<>(this.consumerConfigs);
-    consumerConfigs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, resource.getBootstrapServers());
-    consumerConfigs.put(ConsumerConfig.GROUP_ID_CONFIG, egress.getConsumerGroup());
-    consumerConfigs.put(KeyDeserializer.KEY_TYPE, egress.getKeyType());
-    if (isResourceReferenceDefined(resource.getReference())) {
-      // Set the resource reference so that when the interceptor gets a record that is not a CloudEvent, it can set
-      // CloudEvents context attributes accordingly (see InvalidCloudEventInterceptor for more information).
-      consumerConfigs.put(InvalidCloudEventInterceptor.SOURCE_NAME_CONFIG, resource.getReference().getName());
-      consumerConfigs.put(InvalidCloudEventInterceptor.SOURCE_NAMESPACE_CONFIG, resource.getReference().getNamespace());
-    }
-
-    final var egressConfig =
-      egress.hasEgressConfig() ?
-        egress.getEgressConfig() :
-        resource.getEgressConfig();
-
-    final var maxProcessingTime = maxProcessingTimeMs(consumerConfigs, egressConfig);
-    consumerConfigs.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxProcessingTime);
-
-    final var producerConfigs = new HashMap<>(this.producerConfigs);
-    producerConfigs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, resource.getBootstrapServers());
-
-    final DeliveryOrder deliveryOrder = DeliveryOrder.fromContract(egress.getDeliveryOrder());
-
-    final BaseConsumerVerticle.Initializer initializer = (vertx, consumerVerticle) ->
-      authProvider.getCredentials(resource).onSuccess(credentials -> {
-       KafkaClientsAuth.attachCredentials(consumerConfigs, credentials);
-       KafkaClientsAuth.attachCredentials(producerConfigs, credentials);
-
-       final KafkaConsumer<Object, CloudEvent> consumer = createConsumer(vertx, consumerConfigs);
-       final var metricsCloser = Metrics.register(consumer.unwrap());
-
-       final var egressSubscriberSender = createConsumerRecordSender(
-         vertx,
-         egress.getDestination(),
-         egressConfig,
-         egress
-       );
-
-       final var egressDeadLetterSender = hasDeadLetterSink(egressConfig)
-         ? createConsumerRecordSender(vertx, egressConfig.getDeadLetter(), egressConfig, egress)
-         : NO_DEAD_LETTER_SINK_SENDER;
-
-       final var filter = getFilter(egress);
-
-       final var responseHandler = getResponseHandler(egress,
-         () -> getResponseToKafkaTopicHandler(vertx, producerConfigs, resource),
-         () -> new ResponseToHttpEndpointHandler(createConsumerRecordSender(vertx, egress.getReplyUrl(), egressConfig, egress)));
-       final var commitIntervalMs = Integer.parseInt(String.valueOf(consumerConfigs.get(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG)));
-
-       final var offsetManager = new OffsetManager(vertx, consumer, (v) -> {}, commitIntervalMs);
-       final var recordDispatcherImpl = new RecordDispatcherImpl(
-         new ResourceContext(resource, egress),
-         filter,
-         egressSubscriberSender,
-         egressDeadLetterSender,
-         responseHandler,
-         offsetManager,
-         ConsumerTracer.create(
-           ((VertxInternal) vertx).tracer(),
-           new KafkaClientOptions()
-             .setConfig(consumerConfigs)
-             // Make sure the policy is propagate for the manually instantiated consumer tracer
-             .setTracingPolicy(TracingPolicy.PROPAGATE)
-         ),
-         Metrics.getRegistry()
-       );
-
-       final var recordDispatcher = new RecordDispatcherMutatorChain(
-         recordDispatcherImpl,
-         new CloudEventOverridesMutator(resource.getCloudEventOverrides())
-       );
-
-       final var partitionRevokedHandlers = List.of(
-         consumerVerticle.getPartitionsRevokedHandler(),
-         offsetManager.getPartitionRevokedHandler()
-       );
-       consumer.partitionsRevokedHandler(handlePartitionsRevoked(egress.getConsumerGroup(), partitionRevokedHandlers));
-
-       // Set all the built objects in the consumer verticle
-       consumerVerticle.setRecordDispatcher(recordDispatcher);
-       consumerVerticle.setConsumer(consumer);
-       consumerVerticle.setCloser(metricsCloser);
-     })
-       .mapEmpty();
-
-    return getConsumerVerticle(
-      egress,
-      deliveryOrder,
-      initializer,
-      new HashSet<>(resource.getTopicsList()),
-      consumerConfigs.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG),
-      Metrics.getRegistry()
-    );
-  }
-
-  /**
-   * For each handler call partitionRevoked and wait for the future to complete.
-   *
-   * @param consumerGroup            consumer group id
-   * @param partitionRevokedHandlers partition revoked handlers
-   * @return a single handler that dispatches the partition revoked event to the given handlers.
-   */
-  private Handler<Set<TopicPartition>> handlePartitionsRevoked(final String consumerGroup,
-                                                               final List<PartitionRevokedHandler> partitionRevokedHandlers) {
-    return partitions -> {
-
-      logger.info("Received revoke partitions for consumer group {} {}",
-        keyValue("group.id", consumerGroup),
-        keyValue("topicPartitions", partitions)
-      );
-
-      final var futures = new ArrayList<Future<Void>>(partitionRevokedHandlers.size());
-      for (PartitionRevokedHandler partitionRevokedHandler : partitionRevokedHandlers) {
-        futures.add(partitionRevokedHandler.partitionRevoked(partitions));
-      }
-
-      for (final var future : futures) {
-        try {
-          future
-            .toCompletionStage()
-            .toCompletableFuture()
-            .get(1, TimeUnit.SECONDS);
-        } catch (final Exception ignored) {
-        }
-      }
-    };
-  }
-
-  private Filter getFilter(DataPlaneContract.Egress egress) {
-    // Dialected filters should override the attributes filter
-    if (egress.getDialectedFilterCount() > 0) {
-      logger.debug("Egress contains dialected-filters. Dialected-filters will be used for event filtering. Egress {}", egress.getReference());
-      return getFilter(egress.getDialectedFilterList());
-    } else if (egress.hasFilter()) {
-      return new ExactFilter(egress.getFilter().getAttributesMap());
-    }
-    return Filter.noop();
-  }
-
-  private static Filter getFilter(DataPlaneContract.DialectedFilter filter) {
-    return switch (filter.getFilterCase()) {
-      case EXACT -> new ExactFilter(filter.getExact().getAttributesMap());
-      case PREFIX -> new PrefixFilter(filter.getPrefix().getAttributesMap());
-      case SUFFIX -> new SuffixFilter(filter.getSuffix().getAttributesMap());
-      case NOT -> new NotFilter(getFilter(filter.getNot().getFilter()));
-      case ANY -> new AnyFilter(filter.getAny().getFiltersList().stream().
-        map(ConsumerVerticleFactoryImpl::getFilter).collect(Collectors.toSet()));
-      case ALL -> new AllFilter(filter.getAll().getFiltersList().stream().
-        map(ConsumerVerticleFactoryImpl::getFilter).collect(Collectors.toSet()));
-      case CESQL -> new CeSqlFilter(filter.getCesql().getExpression());
-      default -> Filter.noop();
-    };
-  }
-
-  private static Filter getFilter(List<DataPlaneContract.DialectedFilter> filters) {
-    return new AllFilter(filters.stream().map(ConsumerVerticleFactoryImpl::getFilter).collect(Collectors.toSet()));
-  }
-
-  static ResponseHandler getResponseHandler(final DataPlaneContract.Egress egress,
-                                            final Supplier<ResponseHandler> kafkaSupplier,
-                                            final Supplier<ResponseHandler> httpSupplier) {
-    if (egress.hasReplyUrl()) {
-      return httpSupplier.get();
-    } else if (egress.hasReplyToOriginalTopic()) {
-      return kafkaSupplier.get();
-    } else if (egress.hasDiscardReply()) {
-      return new NoopResponseHandler();
-    }
-    //TODO: log
-    return kafkaSupplier.get();
-  }
-
-  private ResponseToKafkaTopicHandler getResponseToKafkaTopicHandler(final Vertx vertx,
-                                                                     final Map<String, Object> producerConfigs,
-                                                                     final DataPlaneContract.Resource resource) {
-    final KafkaProducer<String, CloudEvent> producer = createProducer(vertx, producerConfigs);
-    return new ResponseToKafkaTopicHandler(producer, resource.getTopics(0));
-  }
-
-  protected KafkaProducer<String, CloudEvent> createProducer(final Vertx vertx,
-                                                             final Map<String, Object> producerConfigs) {
-    Properties producerProperties = new Properties();
-    producerProperties.putAll(producerConfigs);
-    return KafkaProducer.create(vertx, producerProperties);
-  }
-
-  protected KafkaConsumer<Object, CloudEvent> createConsumer(final Vertx vertx,
-                                                             final Map<String, Object> consumerConfigs) {
-    return KafkaConsumer.create(
-      vertx,
-      new KafkaClientOptions()
-        .setConfig(consumerConfigs)
-        // Disable tracing provided by vertx-kafka-client, because it doesn't work well with our dispatch logic.
-        // RecordDispatcher, when receiving a new record, takes care of adding the proper receive record span.
-        .setTracingPolicy(TracingPolicy.IGNORE)
-    );
-  }
-
-  private CloudEventSender createConsumerRecordSender(final Vertx vertx,
-                                                      final String target,
-                                                      final EgressConfig egressConfig,
-                                                      final DataPlaneContract.Egress egress) {
-    var webClientOptions = this.webClientOptions;
-    // TODO use numPartitions for ordered delivery or max.poll.records for unordered delivery
-    // if (egress.getVReplicas() > 0) {
-    //   webClientOptions = new WebClientOptions(this.webClientOptions);
-    //   webClientOptions.setMaxPoolSize(egress.getVReplicas());
-    // }
-    return new WebClientCloudEventSender(vertx, WebClient.create(vertx, webClientOptions), target, egressConfig);
-  }
-
-  private static boolean hasDeadLetterSink(final EgressConfig egressConfig) {
-    return !(egressConfig == null || egressConfig.getDeadLetter().isEmpty());
-  }
-
-  private static AbstractVerticle getConsumerVerticle(final DataPlaneContract.Egress egress,
-                                                      final DeliveryOrder type,
-                                                      final BaseConsumerVerticle.Initializer initializer,
-                                                      final Set<String> topics,
-                                                      final Object maxPollRecords,
-                                                      final MeterRegistry meterRegistry) {
-    final var maxRecords = maxPollRecords == null ? 0 : Integer.parseInt(maxPollRecords.toString());
-    return switch (type) {
-      case ORDERED -> new OrderedConsumerVerticle(egress, initializer, topics, maxRecords, meterRegistry);
-      case UNORDERED -> new UnorderedConsumerVerticle(initializer, topics, maxRecords);
-    };
-  }
-
-  private static boolean isResourceReferenceDefined(DataPlaneContract.Reference resource) {
-    return resource != null && !resource.getNamespace().isBlank() && !resource.getName().isBlank();
-  }
-
-  private static int maxProcessingTimeMs(final HashMap<String, Object> consumerConfigs, final EgressConfig egressConfig) {
-    final var mpr = consumerConfigs.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG);
-    final long maxPollRecords = mpr == null ? /* default max.poll.records */ 500L : Long.parseLong(mpr.toString());
-    final var retryPolicy = WebClientCloudEventSender.computeRetryPolicy(egressConfig);
-    final var retry = egressConfig.getRetry();
-    final var timeout = egressConfig.getTimeout() > 0 ? egressConfig.getTimeout() : WebClientCloudEventSender.DEFAULT_TIMEOUT_MS;
-
-    long maxProcessingTimeForSingleRecord = timeout;
-    for (int i = 1; i <= retry; i++) {
-      maxProcessingTimeForSingleRecord += timeout + retryPolicy.apply(i);
-    }
-    // In addition, we add some seconds as overhead for each retry.
-    final long overhead = 1000L * retry;
-    maxProcessingTimeForSingleRecord += overhead;
-    // So far, the max processing time calculated is for one single record,
-    // however, we poll records in batches based on the `max.poll.records`
-    // configuration, so the total max processing time is:
-    //
-    // Times 2 for dead letter sink retries.
-    final var total = 2 * maxPollRecords * maxProcessingTimeForSingleRecord;
-
-    if (total >= Integer.MAX_VALUE) {
-      return Integer.MAX_VALUE;
-    }
-    return (int) total;
+    return new ConsumerVerticleBuilder(
+      new ConsumerVerticleContext()
+        .withConsumerConfigs(consumerConfigs)
+        .withProducerConfigs(producerConfigs)
+        .withWebClientOptions(webClientOptions)
+        .withAuthProvider(authProvider)
+        .withMeterRegistry(metricsRegistry)
+        .withResource(resource, egress)
+        .withConsumerFactory(ConsumerFactory.defaultFactory())
+        .withProducerFactory(ProducerFactory.defaultFactory())
+    )
+      .build();
   }
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleLoggingContext.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleLoggingContext.java
@@ -27,10 +27,12 @@ public final class ConsumerVerticleLoggingContext {
   private final List<String> topics;
   private final String consumerGroup;
   private final DataPlaneContract.Reference reference;
+  private final String destination;
 
   public ConsumerVerticleLoggingContext(final ConsumerVerticleContext context) {
     this.topics = context.getResource().getTopicsList();
     this.consumerGroup = context.getEgress().getConsumerGroup();
+    this.destination = context.getEgress().getDestination();
     this.reference = context.getEgress().getReference();
   }
 
@@ -39,6 +41,7 @@ public final class ConsumerVerticleLoggingContext {
     return "{" +
       "topics=" + topics +
       ", consumerGroup='" + consumerGroup + '\'' +
+      ", destination ='" + destination + '\'' +
       ", reference=" + reference +
       '}';
   }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleLoggingContext.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleLoggingContext.java
@@ -22,13 +22,13 @@ import java.util.List;
 /**
  * This class holds logging information for a given consumer verticle.
  */
-public class LoggingConsumerVerticleContext {
+public final class ConsumerVerticleLoggingContext {
 
-  public final List<String> topics;
-  public final String consumerGroup;
-  public final DataPlaneContract.Reference reference;
+  private final List<String> topics;
+  private final String consumerGroup;
+  private final DataPlaneContract.Reference reference;
 
-  public LoggingConsumerVerticleContext(final ConsumerVerticleContext context) {
+  public ConsumerVerticleLoggingContext(final ConsumerVerticleContext context) {
     this.topics = context.getResource().getTopicsList();
     this.consumerGroup = context.getEgress().getConsumerGroup();
     this.reference = context.getEgress().getReference();

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/LoggingConsumerVerticleContext.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/LoggingConsumerVerticleContext.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.dispatcher.main;
+
+import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
+
+import java.util.List;
+
+/**
+ * This class holds logging information for a given consumer verticle.
+ */
+public class LoggingConsumerVerticleContext {
+
+  public final List<String> topics;
+  public final String consumerGroup;
+  public final DataPlaneContract.Reference reference;
+
+  public LoggingConsumerVerticleContext(final ConsumerVerticleContext context) {
+    this.topics = context.getResource().getTopicsList();
+    this.consumerGroup = context.getEgress().getConsumerGroup();
+    this.reference = context.getEgress().getReference();
+  }
+
+  @Override
+  public String toString() {
+    return "{" +
+      "topics=" + topics +
+      ", consumerGroup='" + consumerGroup + '\'' +
+      ", reference=" + reference +
+      '}';
+  }
+}

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ProducerFactory.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ProducerFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.dispatcher.main;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.kafka.client.common.KafkaClientOptions;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.producer.KafkaProducer;
+
+import java.util.Map;
+import java.util.Properties;
+
+@FunctionalInterface
+public interface ProducerFactory<K, V> {
+
+  KafkaProducer<K, V> create(final Vertx vertx, final Map<String, Object> configs);
+
+  static <K, V> ProducerFactory<K, V> defaultFactory() {
+    return new ProducerFactory<>() {
+
+      private KafkaProducer<K, V> producer;
+
+      @Override
+      public KafkaProducer<K, V> create(Vertx vertx, Map<String, Object> configs) {
+        if (producer == null) {
+          Properties producerProperties = new Properties();
+          producerProperties.putAll(configs);
+          producer = KafkaProducer.create(vertx, producerProperties);
+        }
+        return producer;
+      }
+    };
+  }
+}

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticleTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticleTest.java
@@ -15,13 +15,15 @@
  */
 package dev.knative.eventing.kafka.broker.dispatcher.impl.consumer;
 
+import dev.knative.eventing.kafka.broker.dispatcher.main.ConsumerVerticleContext;
+
 import java.util.Set;
 
 public class UnorderedConsumerVerticleTest extends AbstractConsumerVerticleTest {
 
   @Override
-  BaseConsumerVerticle createConsumerVerticle(
-    BaseConsumerVerticle.Initializer initializer, Set<String> topics) {
-    return new UnorderedConsumerVerticle(initializer, topics, 5);
+  ConsumerVerticle createConsumerVerticle(final ConsumerVerticleContext context,
+                                          final ConsumerVerticle.Initializer initializer) {
+    return new UnorderedConsumerVerticle(context, initializer);
   }
 }

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/integration/UnorderedConsumerTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/integration/UnorderedConsumerTest.java
@@ -32,18 +32,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.backends.BackendRegistries;
-import java.net.URI;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.StickyAssignor;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
@@ -51,6 +40,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static dev.knative.eventing.kafka.broker.core.file.FileWatcherTest.write;
 import static dev.knative.eventing.kafka.broker.core.testing.CoreObjects.contract;
@@ -73,15 +70,7 @@ public class UnorderedConsumerTest {
   public void testUnorderedConsumer(final Vertx vertx) throws Exception {
     ContractMessageCodec.register(vertx.eventBus());
 
-    final var producerConfigs = new Properties();
-    final var consumerConfigs = new Properties();
-    consumerConfigs.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 100L);
-    consumerConfigs.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, StickyAssignor.class.getName());
-
-    final var consumerVerticleFactoryMock = new ConsumerVerticleFactoryImplMock(
-      consumerConfigs,
-      producerConfigs
-    );
+    final var consumerVerticleFactoryMock = new ConsumerVerticleFactoryImplMock();
 
     final var event = new CloudEventBuilder()
       .withType("dev.knative")

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/main/FakeConsumerVerticleContext.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/main/FakeConsumerVerticleContext.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.dispatcher.main;
+
+import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
+import dev.knative.eventing.kafka.broker.core.security.AuthProvider;
+import dev.knative.eventing.kafka.broker.core.testing.CoreObjects;
+import io.vertx.ext.web.client.WebClientOptions;
+
+import java.util.HashMap;
+
+public class FakeConsumerVerticleContext {
+
+  public static ConsumerVerticleContext get() {
+    return new ConsumerVerticleContext()
+      .withProducerConfigs(new HashMap<>())
+      .withConsumerConfigs(new HashMap<>())
+      .withResource(CoreObjects.resource1(), CoreObjects.egress1());
+  }
+
+  public static ConsumerVerticleContext get(final DataPlaneContract.Resource resource, final DataPlaneContract.Egress egress) {
+    return new ConsumerVerticleContext()
+      .withProducerConfigs(new HashMap<>())
+      .withConsumerConfigs(new HashMap<>())
+      .withAuthProvider(AuthProvider.noAuth())
+      .withWebClientOptions(new WebClientOptions())
+      .withResource(resource, egress);
+  }
+}

--- a/hack/data-plane.sh
+++ b/hack/data-plane.sh
@@ -54,7 +54,7 @@ function receiver_build_push() {
   local receiver="${KNATIVE_KAFKA_BROKER_RECEIVER:-${KO_DOCKER_REPO}/knative-kafka-broker-receiver}"
   export KNATIVE_KAFKA_RECEIVER_IMAGE="${receiver}:${TAG}"
 
-  ./mvnw package jib:build -pl ${RECEIVER_DIRECTORY} -DskipTests || return $?
+  ./mvnw clean package jib:build -pl ${RECEIVER_DIRECTORY} -DskipTests || return $?
 }
 
 function dispatcher_build_push() {
@@ -63,7 +63,7 @@ function dispatcher_build_push() {
   local dispatcher="${KNATIVE_KAFKA_BROKER_DISPATCHER:-${KO_DOCKER_REPO}/knative-kafka-broker-dispatcher}"
   export KNATIVE_KAFKA_DISPATCHER_IMAGE="${dispatcher}:${TAG}"
 
-  ./mvnw package jib:build -pl "${DISPATCHER_DIRECTORY}" -DskipTests || return $?
+  ./mvnw clean package jib:build -pl "${DISPATCHER_DIRECTORY}" -DskipTests || return $?
 }
 
 function data_plane_build_push() {


### PR DESCRIPTION
As highlighted in [1], our logging statements don't contain enough info to contextualize a specific log statement.

In this PR, I'm restructuring the way we create Consumer verticles, so that we can inject arbitrary context to our log statements based on the specific resource / egress they are acting for.

The large refactoring is also meant to simplify the CosumerVerticleFactoryImpl which was doing to much and it has been a cause of a recent misconfiguration [2].

Previously, we had a single CosumerVerticleFactoryImpl that was doing everything to build a Consumer verticle, now, I'm braking down the logic into multiple single purpose classes.

[1] https://github.com/knative-sandbox/eventing-kafka-broker/pull/1999
[2] https://github.com/knative-sandbox/eventing-kafka-broker/commit/1865320ffedf9e02b608bcd6cd8c89d8b6c9ba43

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>