### PR TITLE
Revert "[data-plane]: Bump ch.qos.logback.version from 1.2.11 to 1.4.1 in /data-plane"

### DIFF
--- a/data-plane/THIRD-PARTY.txt
+++ b/data-plane/THIRD-PARTY.txt
@@ -1,7 +1,7 @@
 
 Lists of 163 third-party dependencies.
-     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Classic Module (ch.qos.logback:logback-classic:1.4.1 - http://logback.qos.ch/logback-classic)
-     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Core Module (ch.qos.logback:logback-core:1.4.1 - http://logback.qos.ch/logback-core)
+     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Classic Module (ch.qos.logback:logback-classic:1.2.11 - http://logback.qos.ch/logback-classic)
+     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Core Module (ch.qos.logback:logback-core:1.2.11 - http://logback.qos.ch/logback-core)
      (The Apache Software License, Version 2.0) Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.13.3 - http://github.com/FasterXML/jackson)
      (The Apache Software License, Version 2.0) Jackson-core (com.fasterxml.jackson.core:jackson-core:2.13.3 - https://github.com/FasterXML/jackson-core)
      (The Apache Software License, Version 2.0) jackson-databind (com.fasterxml.jackson.core:jackson-databind:2.13.3 - http://github.com/FasterXML/jackson)

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -50,7 +50,7 @@
     <protobuf.version>3.20.3</protobuf.version>
     <bucket4j.version>7.4.0</bucket4j.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <ch.qos.logback.version>1.4.1</ch.qos.logback.version>
+    <ch.qos.logback.version>1.2.11</ch.qos.logback.version>
     <net.logstash.logback.encoder.version>7.2</net.logstash.logback.encoder.version>
     <assertj.version>3.22.0</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>


### PR DESCRIPTION
Reverts knative-sandbox/eventing-kafka-broker#2678

This breaks structured logging:
```
W0927 09:16:30.950136   34760 gcp.go:120] WARNING: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.25+; use gcloud instead.
To learn more, consult https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
Picked up JAVA_TOOL_OPTIONS: -XX:+CrashOnOutOfMemoryError
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```