### PR TITLE
Increased wait timeout, fail test if scaling times out

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -253,7 +253,7 @@ function scale_controlplane() {
     # Scale up components for HA tests
     kubectl -n knative-eventing scale deployment "$deployment" --replicas="${REPLICAS}" || fail_test "Failed to scale up to ${REPLICAS} ${deployment}"
     # Wait for the deployment to be available
-    kubectl -n knative-eventing wait deployment "$deployment" --for condition=Available=True --timeout=180s
+    kubectl -n knative-eventing wait deployment "$deployment" --for condition=Available=True --timeout=600s || fail_test "Failed to scale up to ${REPLICAS} ${deployment}"
   done
 }
 


### PR DESCRIPTION
Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>

# Fixes

This PR is a follow-up to issue #2729 
While the initial PR for that issue did address the knative deployment scaling hiccups on the s390x platform to ,say, 95% there is still the occasional test run that fails due to the knative webhook deployment not being available at the time when sacura is to be deployed (see: https://prow.knative.dev/view/gs/knative-prow/logs/s390x-e2e-tests-sasl-plain_eventing-kafka-broker_release-1.8_periodic/1584595827215568896)

## Proposed Changes

The change in this PR attempts to fix the issue fully by
a) increasing the wait timeout for the knative deployment scaling to 10 minutes
b) failing the test run deliberately in case the deployment scaling timeout is reached
