### PR TITLE
Updates to use secret data (sasl and tls) from `auth.secret.ref.namespace` for Triggerv2 and Channelv2

### DIFF
--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -194,12 +194,13 @@ func WithBootstrapServerStatusAnnotation(servers string) reconcilertesting.Broke
 	}
 }
 
-func WithSecretStatusAnnotation(name string) reconcilertesting.BrokerOption {
+func WithSecretStatusAnnotation(name string, namespace string) reconcilertesting.BrokerOption {
 	return func(broker *eventing.Broker) {
 		if broker.Status.Annotations == nil {
 			broker.Status.Annotations = make(map[string]string, 10)
 		}
 		broker.Status.Annotations[security.AuthSecretNameKey] = name
+		broker.Status.Annotations[security.AuthSecretNamespaceKey] = namespace
 	}
 }
 

--- a/control-plane/pkg/reconciler/trigger/v2/triggerv2.go
+++ b/control-plane/pkg/reconciler/trigger/v2/triggerv2.go
@@ -134,12 +134,7 @@ func (r Reconciler) reconcileConsumerGroup(ctx context.Context, broker *eventing
 		offset = sources.OffsetEarliest
 	}
 
-	namespace := broker.GetNamespace()
-	if broker.Spec.Config.Namespace != "" {
-		namespace = broker.Spec.Config.Namespace
-	}
-
-	secret, err := security.Secret(ctx, &security.AnnotationsSecretLocator{Annotations: broker.Status.Annotations, Namespace: namespace}, security.DefaultSecretProviderFunc(r.SecretLister, r.KubeClient))
+	secret, err := security.Secret(ctx, &security.AnnotationsSecretLocator{Annotations: broker.Status.Annotations}, security.DefaultSecretProviderFunc(r.SecretLister, r.KubeClient))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret: %w", err)
 	}

--- a/control-plane/pkg/reconciler/trigger/v2/triggerv2_test.go
+++ b/control-plane/pkg/reconciler/trigger/v2/triggerv2_test.go
@@ -496,7 +496,7 @@ func TestReconcileKind(t *testing.T) {
 					BrokerReady,
 					WithTopicStatusAnnotation(BrokerTopic()),
 					WithBootstrapServerStatusAnnotation(bootstrapServers),
-					WithSecretStatusAnnotation("secret-1"),
+					WithSecretStatusAnnotation("secret-1", SystemNamespace),
 				),
 				DataPlaneConfigMap(env.DataPlaneConfigMapNamespace, env.DataPlaneConfigConfigMapName, brokerreconciler.ConsumerConfigKey,
 					DataPlaneConfigInitialOffset(brokerreconciler.ConsumerConfigKey, sources.OffsetLatest),
@@ -520,13 +520,13 @@ func TestReconcileKind(t *testing.T) {
 							SecretSpec: &internalscg.SecretSpec{
 								Ref: &internalscg.SecretReference{
 									Name:      "secret-1",
-									Namespace: ConfigMapNamespace,
+									Namespace: SystemNamespace,
 								},
 							},
 						}),
 					)),
 				),
-				NewLegacySASLSecret(ConfigMapNamespace, "secret-1"),
+				NewLegacySASLSecret(SystemNamespace, "secret-1"),
 			},
 			Key: testKey,
 			WantUpdates: []clientgotesting.UpdateActionImpl{
@@ -550,7 +550,7 @@ func TestReconcileKind(t *testing.T) {
 								SecretSpec: &internalscg.SecretSpec{
 									Ref: &internalscg.SecretReference{
 										Name:      "secret-1",
-										Namespace: ConfigMapNamespace,
+										Namespace: SystemNamespace,
 									},
 								},
 							}),

--- a/control-plane/pkg/security/config.go
+++ b/control-plane/pkg/security/config.go
@@ -131,14 +131,21 @@ type AnnotationsSecretLocator struct {
 }
 
 func (a *AnnotationsSecretLocator) SecretName() (string, bool) {
-	v, ok := a.Annotations[AuthSecretNameKey]
-	if ok && v != "" {
-		return v, ok
+	name, ok := a.Annotations[AuthSecretNameKey]
+	if ok && name != "" {
+		return name, ok
 	}
 	return "", false
 }
 
 func (a *AnnotationsSecretLocator) SecretNamespace() (string, bool) {
 	name, ok := a.SecretName()
-	return a.Namespace, len(a.Namespace) > 0 && ok && len(name) > 0
+	if a.Namespace != "" {
+		return a.Namespace, len(a.Namespace) > 0 && ok && len(name) > 0
+	}
+	namespace, ok := a.Annotations[AuthSecretNamespaceKey]
+	if ok && namespace != "" {
+		return namespace, ok
+	}
+	return "", false
 }


### PR DESCRIPTION
Should "UseNamespaceInConfigmap" for both brokers and channels specified by `auth.secret.ref.namespace` instead of using namespace of config map itself or namespace of reference object for v2....

This means parameters needed by KEDA will need to be referenced before creating KEDA CRs...

Signed-off-by: aavarghese <avarghese@us.ibm.com>

/cc @pierDipi @matzew 