### PR TITLE
Run hack/update-codegen.sh with Go 1.19

### DIFF
--- a/control-plane/pkg/client/clientset/versioned/fake/register.go
+++ b/control-plane/pkg/client/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/control-plane/pkg/client/clientset/versioned/scheme/register.go
+++ b/control-plane/pkg/client/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/control-plane/pkg/client/internals/kafka/clientset/versioned/fake/register.go
+++ b/control-plane/pkg/client/internals/kafka/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/control-plane/pkg/client/internals/kafka/clientset/versioned/scheme/register.go
+++ b/control-plane/pkg/client/internals/kafka/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/control-plane/pkg/contract/subscriptionsapi.go
+++ b/control-plane/pkg/contract/subscriptionsapi.go
@@ -132,7 +132,7 @@ func newNotFilter(f v1.SubscriptionsAPIFilter) *DialectedFilter {
 // newCESQLFilter converts the SubscriptionsAPIFilter into the sql dialect of the
 // DialectedFilter as defined in CloudEvents Subscriptions API.
 //
-// CESOL filter is a Cloud Events SQL Expression
+// # CESOL filter is a Cloud Events SQL Expression
 //
 // See "CNCF CloudEvents Subscriptions API" > "3.2.4.1 Filters Dialects"
 // https://github.com/cloudevents/spec/blob/main/subscriptions/sql.md#any-filter-dialect

--- a/control-plane/pkg/kafka/consumer_group_lag_test.go
+++ b/control-plane/pkg/kafka/consumer_group_lag_test.go
@@ -18,7 +18,6 @@ package kafka
 
 import (
 	"io"
-	"io/ioutil"
 	"math"
 	"net"
 	"testing"
@@ -524,7 +523,7 @@ func fakeKafkaBrokerListener(t *testing.T, addr string) (*sarama.Broker, func())
 		if err != nil {
 			return
 		}
-		_, _ = io.Copy(ioutil.Discard, conn)
+		_, _ = io.Copy(io.Discard, conn)
 	}()
 
 	broker := sarama.NewBroker(addr)

--- a/control-plane/pkg/reconciler/testing/objects_common.go
+++ b/control-plane/pkg/reconciler/testing/objects_common.go
@@ -18,7 +18,7 @@ package testing
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/magiconair/properties"
@@ -333,17 +333,17 @@ func NewKedaSecret(ns, name string) *corev1.Secret {
 }
 
 func loadCerts() (ca, userKey, userCert []byte) {
-	ca, err := ioutil.ReadFile("testdata/ca.crt")
+	ca, err := os.ReadFile("testdata/ca.crt")
 	if err != nil {
 		panic(err)
 	}
 
-	userKey, err = ioutil.ReadFile("testdata/user.key")
+	userKey, err = os.ReadFile("testdata/user.key")
 	if err != nil {
 		panic(err)
 	}
 
-	userCert, err = ioutil.ReadFile("testdata/user.crt")
+	userCert, err = os.ReadFile("testdata/user.crt")
 	if err != nil {
 		panic(err)
 	}

--- a/control-plane/pkg/security/secret_test.go
+++ b/control-plane/pkg/security/secret_test.go
@@ -17,7 +17,7 @@
 package security
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/Shopify/sarama"
@@ -192,7 +192,6 @@ func TestSSL(t *testing.T) {
 	assert.True(t, config.Net.TLS.Enable)
 	assert.Greater(t, len(config.Net.TLS.Config.Certificates), 0)
 	assert.NotNil(t, config.Net.TLS.Config.RootCAs)
-	assert.Greater(t, len(config.Net.TLS.Config.RootCAs.Subjects()), 0)
 }
 
 func TestSSLNoUserKey(t *testing.T) {
@@ -256,7 +255,6 @@ func TestSSLNoClientAuth(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, config.Net.TLS.Enable)
 	assert.NotNil(t, config.Net.TLS.Config.RootCAs)
-	assert.Greater(t, len(config.Net.TLS.Config.RootCAs.Subjects()), 0)
 }
 
 func TestSSLNoClientAuthInvalidFlag(t *testing.T) {
@@ -294,7 +292,6 @@ func TestSASLPLainSSL(t *testing.T) {
 	assert.True(t, config.Net.TLS.Enable)
 	assert.Equal(t, len(config.Net.TLS.Config.Certificates), 0)
 	assert.NotNil(t, config.Net.TLS.Config.RootCAs)
-	assert.Greater(t, len(config.Net.TLS.Config.RootCAs.Subjects()), 0)
 	assert.True(t, config.Net.SASL.Enable)
 	assert.True(t, config.Net.SASL.Handshake)
 	assert.Equal(t, sarama.SASLMechanism(sarama.SASLTypePlaintext), config.Net.SASL.Mechanism)
@@ -322,7 +319,6 @@ func TestSASLSCRAM256SSL(t *testing.T) {
 	assert.True(t, config.Net.TLS.Enable)
 	assert.Equal(t, len(config.Net.TLS.Config.Certificates), 0)
 	assert.NotNil(t, config.Net.TLS.Config.RootCAs)
-	assert.Greater(t, len(config.Net.TLS.Config.RootCAs.Subjects()), 0)
 	assert.True(t, config.Net.SASL.Enable)
 	assert.True(t, config.Net.SASL.Handshake)
 	assert.Equal(t, sarama.SASLMechanism(sarama.SASLTypeSCRAMSHA256), config.Net.SASL.Mechanism)
@@ -350,7 +346,6 @@ func TestSASLSCRAM512SSL(t *testing.T) {
 	assert.True(t, config.Net.TLS.Enable)
 	assert.Equal(t, len(config.Net.TLS.Config.Certificates), 0)
 	assert.NotNil(t, config.Net.TLS.Config.RootCAs)
-	assert.Greater(t, len(config.Net.TLS.Config.RootCAs.Subjects()), 0)
 	assert.True(t, config.Net.SASL.Enable)
 	assert.True(t, config.Net.SASL.Handshake)
 	assert.Equal(t, sarama.SASLMechanism(sarama.SASLTypeSCRAMSHA512), config.Net.SASL.Mechanism)
@@ -378,13 +373,13 @@ func TestSASLSCRAM512SSLInvalidCaCert(t *testing.T) {
 }
 
 func loadCerts(t *testing.T) (ca, userKey, userCert []byte) {
-	ca, err := ioutil.ReadFile("testdata/ca.crt")
+	ca, err := os.ReadFile("testdata/ca.crt")
 	assert.Nil(t, err)
 
-	userKey, err = ioutil.ReadFile("testdata/user.key")
+	userKey, err = os.ReadFile("testdata/user.key")
 	assert.Nil(t, err)
 
-	userCert, err = ioutil.ReadFile("testdata/user.crt")
+	userCert, err = os.ReadFile("testdata/user.crt")
 	assert.Nil(t, err)
 
 	return ca, userKey, userCert

--- a/test/e2e_broker/broker_trigger_sink_test.go
+++ b/test/e2e_broker/broker_trigger_sink_test.go
@@ -44,10 +44,11 @@ import (
 +---------+     +--------+     +---------+   +---------------------------+
 |  Broker +---->+ Trigger+---->+KafkaSink+-->+kafka consumer (test image)|
 +----+----+     +--------+     +----+----+   +---------------------------+
-     |                              ^
-     |          +--------+          |
-     +--------->+ Trigger+----------+
-                +--------+
+
+	|                              ^
+	|          +--------+          |
+	+--------->+ Trigger+----------+
+	           +--------+
 */
 func TestBrokerV1TriggersV1SinkV1Alpha1(t *testing.T) {
 	testingpkg.RunMultipleN(t, 10, func(t *testing.T) {

--- a/test/e2e_new_channel/kafka_channel_upstream_test.go
+++ b/test/e2e_new_channel/kafka_channel_upstream_test.go
@@ -162,7 +162,6 @@ EventSource ---> (Channel ---> Subscription) x 10 ---> Sink
 It uses Subscription's spec.reply as spec.subscriber.
 
 This test should fail with https://github.com/knative/eventing/issues/5756 done.
-
 */
 func TestChannelChainByUsingReplyAsSubscriber(t *testing.T) {
 	// This test fails with our KafkaChannel here since the test assumes it is ok to leave Subscription's `spec.subscriber` empty.
@@ -191,7 +190,6 @@ func TestChannelChainByUsingReplyAsSubscriber(t *testing.T) {
 TestChannelChain tests the following scenario:
 
 EventSource ---> (Channel ---> Subscription) x 10 ---> Sink
-
 */
 func TestChannelChain(t *testing.T) {
 	t.Parallel()
@@ -267,13 +265,15 @@ func TestChannelDeadLetterSinkByUsingReplyAsSubscriber(t *testing.T) {
 /*
 TestEventTransformationForSubscription tests the following scenario:
 
-             1            2                 5            6                  7
+	1            2                 5            6                  7
+
 EventSource ---> Channel ---> Subscription ---> Channel ---> Subscription ----> Service(Logger)
-                                   |  ^
-                                 3 |  | 4
-                                   |  |
-                                   |  ---------
-                                   -----------> Service(Transformation)
+
+	  |  ^
+	3 |  | 4
+	  |  |
+	  |  ---------
+	  -----------> Service(Transformation)
 */
 func TestEventTransformationForSubscriptionV1(t *testing.T) {
 	t.Parallel()
@@ -293,7 +293,6 @@ func TestEventTransformationForSubscriptionV1(t *testing.T) {
 TestBinaryEventForChannel tests the following scenario:
 
 EventSource (binary-encoded messages) ---> Channel ---> Subscription ---> Service(Logger)
-
 */
 func TestBinaryEventForChannel(t *testing.T) {
 	t.Parallel()
@@ -313,7 +312,6 @@ func TestBinaryEventForChannel(t *testing.T) {
 TestStructuredEventForChannel tests the following scenario:
 
 EventSource (structured-encoded messages) ---> Channel ---> Subscription ---> Service(Logger)
-
 */
 func TestStructuredEventForChannel(t *testing.T) {
 	t.Parallel()

--- a/third_party/pkg/client/clientset/versioned/fake/register.go
+++ b/third_party/pkg/client/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/third_party/pkg/client/clientset/versioned/scheme/register.go
+++ b/third_party/pkg/client/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.


### PR DESCRIPTION
As per title.

Go 1.19 is now required to generate and verify generated code.