### PR TITLE
Fix for using namespace of the broker instead of status annotation namespace

### DIFF
--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -194,13 +194,12 @@ func WithBootstrapServerStatusAnnotation(servers string) reconcilertesting.Broke
 	}
 }
 
-func WithSecretStatusAnnotation(name string, namespace string) reconcilertesting.BrokerOption {
+func WithSecretStatusAnnotation(name string) reconcilertesting.BrokerOption {
 	return func(broker *eventing.Broker) {
 		if broker.Status.Annotations == nil {
 			broker.Status.Annotations = make(map[string]string, 10)
 		}
 		broker.Status.Annotations[security.AuthSecretNameKey] = name
-		broker.Status.Annotations[security.AuthSecretNamespaceKey] = namespace
 	}
 }
 

--- a/control-plane/pkg/reconciler/trigger/v2/triggerv2.go
+++ b/control-plane/pkg/reconciler/trigger/v2/triggerv2.go
@@ -134,7 +134,12 @@ func (r Reconciler) reconcileConsumerGroup(ctx context.Context, broker *eventing
 		offset = sources.OffsetEarliest
 	}
 
-	secret, err := security.Secret(ctx, &security.AnnotationsSecretLocator{Annotations: broker.Status.Annotations}, security.DefaultSecretProviderFunc(r.SecretLister, r.KubeClient))
+	namespace := broker.GetNamespace()
+	if broker.Spec.Config.Namespace != "" {
+		namespace = broker.Spec.Config.Namespace
+	}
+
+	secret, err := security.Secret(ctx, &security.AnnotationsSecretLocator{Annotations: broker.Status.Annotations, Namespace: namespace}, security.DefaultSecretProviderFunc(r.SecretLister, r.KubeClient))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret: %w", err)
 	}

--- a/control-plane/pkg/reconciler/trigger/v2/triggerv2_test.go
+++ b/control-plane/pkg/reconciler/trigger/v2/triggerv2_test.go
@@ -496,7 +496,7 @@ func TestReconcileKind(t *testing.T) {
 					BrokerReady,
 					WithTopicStatusAnnotation(BrokerTopic()),
 					WithBootstrapServerStatusAnnotation(bootstrapServers),
-					WithSecretStatusAnnotation("secret-1", SystemNamespace),
+					WithSecretStatusAnnotation("secret-1"),
 				),
 				DataPlaneConfigMap(env.DataPlaneConfigMapNamespace, env.DataPlaneConfigConfigMapName, brokerreconciler.ConsumerConfigKey,
 					DataPlaneConfigInitialOffset(brokerreconciler.ConsumerConfigKey, sources.OffsetLatest),
@@ -520,13 +520,13 @@ func TestReconcileKind(t *testing.T) {
 							SecretSpec: &internalscg.SecretSpec{
 								Ref: &internalscg.SecretReference{
 									Name:      "secret-1",
-									Namespace: SystemNamespace,
+									Namespace: ConfigMapNamespace,
 								},
 							},
 						}),
 					)),
 				),
-				NewLegacySASLSecret(SystemNamespace, "secret-1"),
+				NewLegacySASLSecret(ConfigMapNamespace, "secret-1"),
 			},
 			Key: testKey,
 			WantUpdates: []clientgotesting.UpdateActionImpl{
@@ -550,7 +550,7 @@ func TestReconcileKind(t *testing.T) {
 								SecretSpec: &internalscg.SecretSpec{
 									Ref: &internalscg.SecretReference{
 										Name:      "secret-1",
-										Namespace: SystemNamespace,
+										Namespace: ConfigMapNamespace,
 									},
 								},
 							}),

--- a/control-plane/pkg/security/config.go
+++ b/control-plane/pkg/security/config.go
@@ -140,12 +140,5 @@ func (a *AnnotationsSecretLocator) SecretName() (string, bool) {
 
 func (a *AnnotationsSecretLocator) SecretNamespace() (string, bool) {
 	name, ok := a.SecretName()
-	if a.Namespace != "" {
-		return a.Namespace, len(a.Namespace) > 0 && ok && len(name) > 0
-	}
-	namespace, ok := a.Annotations[AuthSecretNamespaceKey]
-	if ok && namespace != "" {
-		return namespace, ok
-	}
-	return "", false
+	return a.Namespace, len(a.Namespace) > 0 && ok && len(name) > 0
 }


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

