### PR TITLE
Retry Only If the Status Code Is Retryable

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
@@ -133,6 +133,11 @@ public final class WebClientCloudEventSender implements CloudEventSender {
           if (isRetryableStatusCode(response.statusCode()) && retryCounter < consumerVerticleContext.getEgressConfig().getRetry()) {
             return retry(retryCounter, event);
           }
+          return Future.failedFuture(cause);
+        }
+
+        if (retryCounter < consumerVerticleContext.getEgressConfig().getRetry()) {
+          return retry(retryCounter, event);
         }
 
         return Future.failedFuture(cause);

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
@@ -135,10 +135,6 @@ public final class WebClientCloudEventSender implements CloudEventSender {
           }
         }
 
-        if (retryCounter < consumerVerticleContext.getEgressConfig().getRetry()) {
-          return retry(retryCounter, event);
-        }
-
         return Future.failedFuture(cause);
       }
     );


### PR DESCRIPTION
Signed-off-by: Vikram Vuppla naga.vicky@gmail.com

Fixes #

Why:
- Currently the retry is happening regardless of the response status code is retryable or not, remove the buggy retry logic

## Proposed Changes


- :bug: Fix bug
