### PR TITLE
Return "nil" saslType if not present for Auth

### DIFF
--- a/control-plane/pkg/autoscaler/keda/keda.go
+++ b/control-plane/pkg/autoscaler/keda/keda.go
@@ -216,8 +216,7 @@ func retrieveSaslTypeIfPresent(cg *kafkainternals.ConsumerGroup, secret corev1.S
 
 	if cg.Spec.Template.Spec.Auth.SecretSpec != nil && cg.Spec.Template.Spec.Auth.SecretSpec.Ref != nil {
 		if saslTypeValue, ok := secret.Data[security.SaslType]; ok {
-			saslType := string(saslTypeValue)
-			return pointer.String(saslType)
+			return pointer.String(string(saslTypeValue))
 		}
 	}
 	return nil

--- a/control-plane/pkg/autoscaler/keda/keda.go
+++ b/control-plane/pkg/autoscaler/keda/keda.go
@@ -206,21 +206,21 @@ func GenerateTriggerAuthentication(cg *kafkainternals.ConsumerGroup, secretData 
 }
 
 func retrieveSaslTypeIfPresent(cg *kafkainternals.ConsumerGroup, secret corev1.Secret) *string {
-	var saslType string
-
 	if cg.Spec.Template.Spec.Auth.NetSpec != nil && cg.Spec.Template.Spec.Auth.NetSpec.SASL.Enable && cg.Spec.Template.Spec.Auth.NetSpec.SASL.Type.SecretKeyRef != nil {
 		secretKeyRefKey := cg.Spec.Template.Spec.Auth.NetSpec.SASL.Type.SecretKeyRef.Key
 		if saslTypeValue, ok := secret.Data[secretKeyRefKey]; ok {
-			saslType = string(saslTypeValue)
+			saslType := string(saslTypeValue)
+			return &saslType
 		}
 	}
 
 	if cg.Spec.Template.Spec.Auth.SecretSpec != nil && cg.Spec.Template.Spec.Auth.SecretSpec.Ref != nil {
 		if saslTypeValue, ok := secret.Data[security.SaslType]; ok {
-			saslType = string(saslTypeValue)
+			saslType := string(saslTypeValue)
+			return &saslType
 		}
 	}
-	return &saslType
+	return nil
 }
 
 func addAuthSecretTargetRef(parameter string, secretKeyRef v1beta1.SecretValueFromSource, secretTargetRefs []kedav1alpha1.AuthSecretTargetRef) []kedav1alpha1.AuthSecretTargetRef {

--- a/control-plane/pkg/autoscaler/keda/keda.go
+++ b/control-plane/pkg/autoscaler/keda/keda.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	"knative.dev/eventing-kafka/pkg/apis/bindings/v1beta1"
 	"knative.dev/pkg/kmeta"
 
@@ -210,14 +211,14 @@ func retrieveSaslTypeIfPresent(cg *kafkainternals.ConsumerGroup, secret corev1.S
 		secretKeyRefKey := cg.Spec.Template.Spec.Auth.NetSpec.SASL.Type.SecretKeyRef.Key
 		if saslTypeValue, ok := secret.Data[secretKeyRefKey]; ok {
 			saslType := string(saslTypeValue)
-			return &saslType
+			return pointer.String(saslType)
 		}
 	}
 
 	if cg.Spec.Template.Spec.Auth.SecretSpec != nil && cg.Spec.Template.Spec.Auth.SecretSpec.Ref != nil {
 		if saslTypeValue, ok := secret.Data[security.SaslType]; ok {
 			saslType := string(saslTypeValue)
-			return &saslType
+			return pointer.String(saslType)
 		}
 	}
 	return nil

--- a/control-plane/pkg/autoscaler/keda/keda.go
+++ b/control-plane/pkg/autoscaler/keda/keda.go
@@ -210,8 +210,7 @@ func retrieveSaslTypeIfPresent(cg *kafkainternals.ConsumerGroup, secret corev1.S
 	if cg.Spec.Template.Spec.Auth.NetSpec != nil && cg.Spec.Template.Spec.Auth.NetSpec.SASL.Enable && cg.Spec.Template.Spec.Auth.NetSpec.SASL.Type.SecretKeyRef != nil {
 		secretKeyRefKey := cg.Spec.Template.Spec.Auth.NetSpec.SASL.Type.SecretKeyRef.Key
 		if saslTypeValue, ok := secret.Data[secretKeyRefKey]; ok {
-			saslType := string(saslTypeValue)
-			return pointer.String(saslType)
+			return pointer.String(string(saslTypeValue))
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

/cc @pierDipi 

Fixes below error:
```
{
                "lastTransitionTime": "2022-11-22T16:30:29Z",
                "message": "failed to set up autoscaler: SASL type value \"\" is not supported",
                "reason": "AutoscalerFailed",
                "status": "False",
                "type": "ConsumerGroup"
              },
```