### PR TITLE
Avoid removing AuthSpec for compatibility

### DIFF
--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_types.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_types.go
@@ -27,6 +27,7 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
+	eventingv1alpha1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/apis/internals/kafka/eventing"
 )
 
@@ -124,7 +125,9 @@ type DestinationReply struct {
 }
 
 type Auth struct {
-	NetSpec    *bindings.KafkaNetSpec
+	NetSpec *bindings.KafkaNetSpec
+	// Deprecated, use secret spec
+	AuthSpec   *eventingv1alpha1.Auth `json:"AuthSpec,omitempty"`
 	SecretSpec *SecretSpec
 }
 

--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/zz_generated.deepcopy.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha1
 
 import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	eventingv1alpha1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
 	v1beta1 "knative.dev/eventing-kafka/pkg/apis/bindings/v1beta1"
 	duckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
@@ -36,6 +37,11 @@ func (in *Auth) DeepCopyInto(out *Auth) {
 	if in.NetSpec != nil {
 		in, out := &in.NetSpec, &out.NetSpec
 		*out = new(v1beta1.KafkaNetSpec)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.AuthSpec != nil {
+		in, out := &in.AuthSpec, &out.AuthSpec
+		*out = new(eventingv1alpha1.Auth)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.SecretSpec != nil {


### PR DESCRIPTION
This breaks upgrades:

```
{"level":"error","ts":"2022-11-18T16:55:44.956Z","logger":"kafka-broker-controller","caller":"controller/controller.go:566","msg":"Reconcile error","commit":"3d507f2","knative.dev/pod":"kafka-controller-5f99c8bc78-cjgll","knative.dev/controller":"knative.dev.eventing-kafka-broker.control-plane.pkg.reconciler.consumergroup.Reconciler","knative.dev/kind":"internal.kafka.eventing.knative.dev.ConsumerGroup","knative.dev/traceid":"b26cd645-27fe-467f-bdfe-4ab856e7a1fb","knative.dev/key":"dev/894c28fc-6800-4f75-bf10-f99ca1e19f30","duration":0.136223835,"error":"admission webhook \"validation.webhook.kafka.eventing.knative.dev\" denied the request: decoding request failed: cannot decode incoming new object: json: unknown field \"AuthSpec\"","stacktrace":"knative.dev/pkg/controller.(*Impl).handleErr\n\tknative.dev/pkg@v0.0.0-20221107171117-0243d641354d/controller/controller.go:566\nknative.dev/pkg/controller.(*Impl).processNextWorkItem\n\tknative.dev/pkg@v0.0.0-20221107171117-0243d641354d/controller/controller.go:543\nknative.dev/pkg/controller.(*Impl).RunContext.func3\n\tknative.dev/pkg@v0.0.0-20221107171117-0243d641354d/controller/controller.go:491"}
```

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

