### PR TITLE
Configurable default values for autoscaler

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-autoscaler.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-autoscaler.yaml
@@ -1,0 +1,29 @@
+# Copyright 2022 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-kafka-autoscaler
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
+data:
+    class: "keda.autoscaling.knative.dev"
+    min-scale: "0"
+    max-scale: "50"
+    polling-interval: "10"
+    cooldown-period: "300"
+    lag-threshold: "100"
+    activation-lag-threshold: "1"

--- a/control-plane/config/eventing-kafka-broker/200-controller/500-controller.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/500-controller.yaml
@@ -147,6 +147,9 @@ spec:
             - name: DESCHEDULER_CONFIG
               value: 'config-kafka-descheduler'
 
+            - name: AUTOSCALER_CONFIG
+              value: 'config-kafka-autoscaler'
+
             - name: CONFIG_LEADERELECTION_NAME
               value: config-kafka-leader-election
             - name: CONFIG_LOGGING_NAME

--- a/control-plane/config/eventing-kafka-source/200-controller/100-config-kafka-autoscaler.yaml
+++ b/control-plane/config/eventing-kafka-source/200-controller/100-config-kafka-autoscaler.yaml
@@ -1,0 +1,1 @@
+../../eventing-kafka-broker/200-controller/100-config-kafka-autoscaler.yaml

--- a/control-plane/config/eventing-kafka-source/200-controller/500-controller.yaml
+++ b/control-plane/config/eventing-kafka-source/200-controller/500-controller.yaml
@@ -82,6 +82,9 @@ spec:
             - name: DESCHEDULER_CONFIG
               value: 'config-kafka-descheduler'
 
+            - name: AUTOSCALER_CONFIG
+              value: 'config-kafka-autoscaler'
+
             - name: CONFIG_LEADERELECTION_NAME
               value: config-kafka-leader-election
             - name: CONFIG_LOGGING_NAME

--- a/control-plane/pkg/autoscaler/config.go
+++ b/control-plane/pkg/autoscaler/config.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package autoscaler
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// AutoscalerConfig contains the defaults defined in the autoscaler ConfigMap.
+type AutoscalerConfig struct {
+	AutoscalerClass    map[string]string
+	AutoscalerDefaults map[string]int32
+}
+
+func defaultConfig() *AutoscalerConfig {
+	return &AutoscalerConfig{
+		AutoscalerClass: map[string]string{
+			AutoscalingClassAnnotation: AutoscalingClassDisabledAnnotationValue,
+		},
+		AutoscalerDefaults: map[string]int32{
+			AutoscalingMinScaleAnnotation:        DefaultMinReplicaCount,
+			AutoscalingMaxScaleAnnotation:        DefaultMaxReplicaCount,
+			AutoscalingPollingIntervalAnnotation: DefaultPollingInterval,
+			AutoscalingCooldownPeriodAnnotation:  DefaultCooldownPeriod,
+			AutoscalingLagThreshold:              DefaultLagThreshold,
+			AutoscalingActivationLagThreshold:    DefaultActivationLagThreshold,
+		},
+	}
+}
+
+// NewConfigFromMap creates a AutoscalerConfig from the supplied map
+func NewConfigFromMap(data map[string]string) (*AutoscalerConfig, error) {
+	ac := defaultConfig()
+
+	if class, ok := data["class"]; ok && class == AutoscalingClassDisabledAnnotationValue { //autoscaler disabled - ignore new defaults
+		return ac, nil
+	}
+
+	for key, val := range data {
+		key = convertConfigKeyToAutoscalingAnnotation(key)
+
+		if key == AutoscalingClassAnnotation {
+			ac.AutoscalerClass[AutoscalingClassAnnotation] = val
+		} else {
+			i, err := strconv.ParseInt(val, 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("Expected value for autoscaling annotation: "+key+" should be integer but got "+val, err)
+			}
+			ac.AutoscalerDefaults[key] = int32(i)
+		}
+	}
+
+	return ac, nil
+}
+
+func convertConfigKeyToAutoscalingAnnotation(configkey string) (autoscalingannotation string) {
+	return Autoscaling + "/" + configkey
+}

--- a/control-plane/pkg/autoscaler/keda/keda.go
+++ b/control-plane/pkg/autoscaler/keda/keda.go
@@ -47,17 +47,17 @@ func GenerateScaleTarget(cg *kafkainternals.ConsumerGroup) *kedav1alpha1.ScaleTa
 	}
 }
 
-func GenerateScaleTriggers(cg *kafkainternals.ConsumerGroup, triggerAuthentication *kedav1alpha1.TriggerAuthentication) ([]kedav1alpha1.ScaleTriggers, error) {
+func GenerateScaleTriggers(cg *kafkainternals.ConsumerGroup, triggerAuthentication *kedav1alpha1.TriggerAuthentication, aconfig autoscaler.AutoscalerConfig) ([]kedav1alpha1.ScaleTriggers, error) {
 	triggers := make([]kedav1alpha1.ScaleTriggers, 0, len(cg.Spec.Template.Spec.Topics))
 	bootstrapServers := cg.Spec.Template.Spec.Configs.Configs[kafka.BootstrapServersConfigMapKey]
 	consumerGroup := cg.Spec.Template.Spec.Configs.Configs[kafka.GroupIDConfigMapKey]
 
-	lagThreshold, err := GetInt32ValueFromMap(cg.Annotations, autoscaler.AutoscalingLagThreshold, autoscaler.DefaultLagThreshold)
+	lagThreshold, err := GetInt32ValueFromMap(cg.Annotations, autoscaler.AutoscalingLagThreshold, aconfig.AutoscalerDefaults[autoscaler.AutoscalingLagThreshold])
 	if err != nil {
 		return nil, err
 	}
 
-	activationLagThreshold, err := GetInt32ValueFromMap(cg.Annotations, autoscaler.AutoscalingActivationLagThreshold, autoscaler.DefaultActivationLagThreshold)
+	activationLagThreshold, err := GetInt32ValueFromMap(cg.Annotations, autoscaler.AutoscalingActivationLagThreshold, aconfig.AutoscalerDefaults[autoscaler.AutoscalingActivationLagThreshold])
 	if err != nil {
 		return nil, err
 	}

--- a/control-plane/pkg/autoscaler/keda/resources.go
+++ b/control-plane/pkg/autoscaler/keda/resources.go
@@ -31,21 +31,21 @@ var (
 	KedaSchemeGroupVersion = schema.GroupVersion{Group: "keda.sh", Version: "v1alpha1"}
 )
 
-func GenerateScaledObject(obj metav1.Object, gvk schema.GroupVersionKind, scaleTarget *kedav1alpha1.ScaleTarget, triggers []kedav1alpha1.ScaleTriggers) (*kedav1alpha1.ScaledObject, error) {
+func GenerateScaledObject(obj metav1.Object, gvk schema.GroupVersionKind, scaleTarget *kedav1alpha1.ScaleTarget, triggers []kedav1alpha1.ScaleTriggers, aconfig autoscaler.AutoscalerConfig) (*kedav1alpha1.ScaledObject, error) {
 
-	cooldownPeriod, err := GetInt32ValueFromMap(obj.GetAnnotations(), autoscaler.AutoscalingCooldownPeriodAnnotation, autoscaler.DefaultCooldownPeriod)
+	cooldownPeriod, err := GetInt32ValueFromMap(obj.GetAnnotations(), autoscaler.AutoscalingCooldownPeriodAnnotation, aconfig.AutoscalerDefaults[autoscaler.AutoscalingCooldownPeriodAnnotation])
 	if err != nil {
 		return nil, err
 	}
-	pollingInterval, err := GetInt32ValueFromMap(obj.GetAnnotations(), autoscaler.AutoscalingPollingIntervalAnnotation, autoscaler.DefaultPollingInterval)
+	pollingInterval, err := GetInt32ValueFromMap(obj.GetAnnotations(), autoscaler.AutoscalingPollingIntervalAnnotation, aconfig.AutoscalerDefaults[autoscaler.AutoscalingPollingIntervalAnnotation])
 	if err != nil {
 		return nil, err
 	}
-	minReplicaCount, err := GetInt32ValueFromMap(obj.GetAnnotations(), autoscaler.AutoscalingMinScaleAnnotation, autoscaler.DefaultMinReplicaCount)
+	minReplicaCount, err := GetInt32ValueFromMap(obj.GetAnnotations(), autoscaler.AutoscalingMinScaleAnnotation, aconfig.AutoscalerDefaults[autoscaler.AutoscalingMinScaleAnnotation])
 	if err != nil {
 		return nil, err
 	}
-	maxReplicaCount, err := GetInt32ValueFromMap(obj.GetAnnotations(), autoscaler.AutoscalingMaxScaleAnnotation, autoscaler.DefaultMaxReplicaCount)
+	maxReplicaCount, err := GetInt32ValueFromMap(obj.GetAnnotations(), autoscaler.AutoscalingMaxScaleAnnotation, aconfig.AutoscalerDefaults[autoscaler.AutoscalingMaxScaleAnnotation])
 	if err != nil {
 		return nil, err
 	}

--- a/control-plane/pkg/reconciler/consumergroup/autoscaler_config.go
+++ b/control-plane/pkg/reconciler/consumergroup/autoscaler_config.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package consumergroup
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/autoscaler"
+)
+
+func (r Reconciler) autoscalerDefaultsFromConfigMap(ctx context.Context, configMapName string) (*autoscaler.AutoscalerConfig, error) {
+	cm, err := r.KubeClient.CoreV1().ConfigMaps(r.SystemNamespace).Get(ctx, configMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error while retrieving the %s config map in namespace %s: %+v", configMapName, r.SystemNamespace, err)
+	}
+
+	config, err := autoscaler.NewConfigFromMap(cm.Data)
+	if err != nil {
+		return nil, fmt.Errorf("error while parsing the %s config map in namespace %s: %+v", configMapName, r.SystemNamespace, err)
+	}
+
+	return config, nil
+}

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
@@ -1671,7 +1671,8 @@ func TestReconcileKind(t *testing.T) {
 			InitOffsetsFunc: func(ctx context.Context, kafkaClient sarama.Client, kafkaAdminClient sarama.ClusterAdmin, topics []string, consumerGroup string) (int32, error) {
 				return 1, nil
 			},
-			SystemNamespace: systemNamespace,
+			SystemNamespace:  systemNamespace,
+			AutoscalerConfig: "",
 		}
 
 		r.KafkaFeatureFlags = configapis.FromContext(store.ToContext(ctx))

--- a/control-plane/pkg/reconciler/consumergroup/controller.go
+++ b/control-plane/pkg/reconciler/consumergroup/controller.go
@@ -75,6 +75,7 @@ type envConfig struct {
 	PodCapacity                int32  `envconfig:"POD_CAPACITY" required:"true"`
 	SchedulerPolicyConfigMap   string `envconfig:"SCHEDULER_CONFIG" required:"true"`
 	DeSchedulerPolicyConfigMap string `envconfig:"DESCHEDULER_CONFIG" required:"true"`
+	AutoscalerConfigMap        string `envconfig:"AUTOSCALER_CONFIG" required:"true"`
 }
 
 type SchedulerConfig struct {
@@ -121,6 +122,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher) *controller.I
 		NewKafkaClusterAdminClient: sarama.NewClusterAdmin,
 		KafkaFeatureFlags:          config.DefaultFeaturesConfig(),
 		KedaClient:                 kedaclient.Get(ctx),
+		AutoscalerConfig:           env.AutoscalerConfigMap,
 	}
 
 	consumerInformer := consumer.Get(ctx)

--- a/control-plane/pkg/reconciler/consumergroup/controller_test.go
+++ b/control-plane/pkg/reconciler/consumergroup/controller_test.go
@@ -48,6 +48,8 @@ const (
 	ConfigKafkaSchedulerName = "config-kafka-scheduler"
 	// ConfigKafkaDeSchedulerName is the name of the ConfigMap to configure the descheduler.
 	ConfigKafkaDeSchedulerName = "config-kafka-descheduler"
+	// ConfigKafkaAutoscalerName is the name of the ConfigMap to configure the autoscaler.
+	ConfigKafkaAutoscalerName = "config-kafka-autoscaler"
 )
 
 func TestNewController(t *testing.T) {
@@ -97,6 +99,7 @@ func TestNewController(t *testing.T) {
 	t.Setenv("POD_CAPACITY", PodCapacity)
 	t.Setenv("SCHEDULER_CONFIG", ConfigKafkaSchedulerName)
 	t.Setenv("DESCHEDULER_CONFIG", ConfigKafkaDeSchedulerName)
+	t.Setenv("AUTOSCALER_CONFIG", ConfigKafkaAutoscalerName)
 	controller := NewController(ctx, configmap.NewStaticWatcher(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "config-kafka-features",


### PR DESCRIPTION
Fixes #2804

Signed-off-by: aavarghese <avarghese@us.ibm.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- New configmap for specifying [default values](https://github.com/knative-sandbox/eventing-kafka-broker/blob/main/control-plane/pkg/autoscaler/autoscaler_api.go#L52-L63) for Autoscaling Kafka resources

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
