### PR TITLE
Do not block finalization if secret for external topic is gone

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -401,7 +401,6 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 
 	// External topics are not managed by the broker,
 	// therefore we do not delete them
-	//	_, externalTopic := isExternalTopic(broker)
 	if !externalTopic {
 
 		// I do not like the use of `_`

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -387,14 +387,21 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 		return err
 	}
 
+	_, externalTopic := isExternalTopic(broker)
 	secret, err := security.Secret(ctx, &security.MTConfigMapSecretLocator{ConfigMap: brokerConfig, UseNamespaceInConfigmap: false}, r.SecretProviderFunc())
 	if err != nil {
-		return fmt.Errorf("failed to get secret: %w", err)
+
+		if externalTopic {
+			// we don't care
+			return nil
+		} else {
+			return fmt.Errorf("failed to get secret: %w", err)
+		}
 	}
 
 	// External topics are not managed by the broker,
 	// therefore we do not delete them
-	_, externalTopic := isExternalTopic(broker)
+	//	_, externalTopic := isExternalTopic(broker)
 	if !externalTopic {
 
 		// I do not like the use of `_`

--- a/test/e2e_new/broker_test.go
+++ b/test/e2e_new/broker_test.go
@@ -84,6 +84,22 @@ func TestBrokerConfigMapDoesNotExist(t *testing.T) {
 	env.Test(ctx, t, features.BrokerConfigMapDoesNotExist())
 }
 
+func TestBrokerAuthSecretDoesNotExist(t *testing.T) {
+	// this test is observed to flake more when it is parallel
+	// t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.WithPollTimings(PollInterval, PollTimeout),
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, features.BrokerAuthSecretDoesNotExist())
+}
+
 func TestTriggerLatestOffset(t *testing.T) {
 	// this test is observed to flake more when it is parallel
 	// t.Parallel()

--- a/test/e2e_new/features/broker_deleted_recreated.go
+++ b/test/e2e_new/features/broker_deleted_recreated.go
@@ -121,7 +121,7 @@ func BrokerAuthSecretDoesNotExist() *feature.Feature {
 			broker.WithConfig(configName),
 			broker.WithAnnotations(
 				map[string]interface{}{
-					kafkabroker.ExternalTopicAnnotation : "my-topic",
+					kafkabroker.ExternalTopicAnnotation: "my-topic",
 				}))...))
 
 	f.Assert("delete broker", featuressteps.DeleteBroker(brokerName))

--- a/test/e2e_new/features/broker_deleted_recreated.go
+++ b/test/e2e_new/features/broker_deleted_recreated.go
@@ -27,6 +27,8 @@ import (
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/resources/svc"
 
+	kafkabroker "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/broker"
+
 	"knative.dev/eventing-kafka-broker/test/e2e_new/features/featuressteps"
 	"knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap"
 	brokerconfigmap "knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap/broker"
@@ -112,10 +114,17 @@ func BrokerAuthSecretDoesNotExist() *feature.Feature {
 		brokerconfigmap.WithAuthSecret("does-not-exist"),
 	))
 
-	f.Setup("install broker", broker.Install(brokerName, append(broker.WithEnvConfig(), broker.WithConfig(configName))...))
+	f.Setup("install broker", broker.Install(
+		brokerName,
+		append(
+			broker.WithEnvConfig(),
+			broker.WithConfig(configName),
+			broker.WithAnnotations(
+				map[string]interface{}{
+					kafkabroker.ExternalTopicAnnotation : "my-topic",
+				}))...))
 
 	f.Assert("delete broker", featuressteps.DeleteBroker(brokerName))
-
 
 	return f
 }

--- a/test/e2e_new/resources/configmap/broker/broker_config.go
+++ b/test/e2e_new/resources/configmap/broker/broker_config.go
@@ -61,3 +61,9 @@ func WithBootstrapServer(bootstrapServer string) manifest.CfgFn {
 		cfg["bootstrapServer"] = bootstrapServer
 	}
 }
+
+func WithAuthSecret(authSecret string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["authSecret"] = authSecret
+	}
+}

--- a/test/e2e_new/resources/configmap/broker/broker_config.yaml
+++ b/test/e2e_new/resources/configmap/broker/broker_config.yaml
@@ -27,3 +27,6 @@ data:
   {{ if .replicationFactor }}
   default.topic.replication.factor: "{{ .replicationFactor }}"
   {{ end }}
+  {{ if .authSecret }}
+  auth.secret.ref.name: "{{ .authSecret }}"
+  {{ end }}


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #2828

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- If secret for external managed topic is gone / not present, we do not block the finalization. The broker does anyways not need to perform any sorts of clean-ups on these externally managed topics

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
