### PR TITLE
Restrict wildcard rbac apiGroups

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
@@ -22,13 +22,13 @@ metadata:
     kafka.eventing.knative.dev/release: devel
 rules:
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - configmaps
     verbs:
       - delete
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - configmaps
       - services
@@ -40,7 +40,7 @@ rules:
       - create
       - delete
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - pods
     verbs:
@@ -49,7 +49,7 @@ rules:
       - get
       - watch
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - pods/finalizers
     verbs:
@@ -59,7 +59,7 @@ rules:
       - update
       - delete
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - events
     verbs:
@@ -79,7 +79,7 @@ rules:
       - watch
 
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - secrets
     verbs:
@@ -111,7 +111,7 @@ rules:
       - list
       - watch
   - apiGroups:
-    - "*"
+    - ""
     resources:
       - serviceaccounts
     verbs:
@@ -135,7 +135,7 @@ rules:
 
   # Scheduler permissions
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - nodes
     verbs:

--- a/control-plane/config/post-install/200-controller-cluster-role.yaml
+++ b/control-plane/config/post-install/200-controller-cluster-role.yaml
@@ -69,7 +69,7 @@ rules:
       - delete
 
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - services
     resourceNames:
@@ -82,7 +82,7 @@ rules:
 
   # to be able to list channel services and patch them
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - services
     verbs:
@@ -142,7 +142,7 @@ rules:
       - delete
 
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - serviceaccounts
     resourceNames:
@@ -154,7 +154,7 @@ rules:
       - delete
 
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - secrets
     resourceNames:
@@ -164,7 +164,7 @@ rules:
       - delete
 
   - apiGroups:
-      - "*"
+      - "autoscaling"
     resources:
       - horizontalpodautoscalers
     resourceNames:
@@ -173,7 +173,7 @@ rules:
       - delete
 
   - apiGroups:
-      - "*"
+      - "policy"
     resources:
       - poddisruptionbudgets
     resourceNames:
@@ -182,7 +182,7 @@ rules:
       - delete
 
   - apiGroups:
-    - "*"
+    - "coordination.k8s.io"
     resources:
       - leases
     resourceNames:
@@ -193,7 +193,7 @@ rules:
   # to be able to read the old configmap and migrate
   # and then delete them
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - configmaps
     resourceNames:
@@ -205,7 +205,7 @@ rules:
 
   # to be able update config in the new configmap
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - configmaps
     resourceNames:

--- a/data-plane/config/broker/200-broker-data-plane-cluster-role.yaml
+++ b/data-plane/config/broker/200-broker-data-plane-cluster-role.yaml
@@ -22,7 +22,7 @@ metadata:
     kafka.eventing.knative.dev/release: devel
 rules:
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - secrets
     verbs:

--- a/data-plane/config/channel/200-channel-data-plane-cluster-role.yaml
+++ b/data-plane/config/channel/200-channel-data-plane-cluster-role.yaml
@@ -22,7 +22,7 @@ metadata:
     kafka.eventing.knative.dev/release: devel
 rules:
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - secrets
     verbs:

--- a/data-plane/config/sink/200-sink-data-plane-cluster-role.yaml
+++ b/data-plane/config/sink/200-sink-data-plane-cluster-role.yaml
@@ -22,7 +22,7 @@ metadata:
     kafka.eventing.knative.dev/release: devel
 rules:
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - secrets
     verbs:

--- a/data-plane/config/source/200-source-data-plane-cluster-role.yaml
+++ b/data-plane/config/source/200-source-data-plane-cluster-role.yaml
@@ -22,7 +22,7 @@ metadata:
     kafka.eventing.knative.dev/release: devel
 rules:
   - apiGroups:
-      - "*"
+      - ""
     resources:
       - secrets
     verbs:


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/SRVKS-896

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use specific apiGroups in rbac rules instead of wildcards. According to http://static.open-scap.org/ssg-guides/ssg-ocp4-guide-cis.html#xccdf_org.ssgproject.content_rule_rbac_wildcard_use

