### PR TITLE
Fix finalization problem when broker has incorrect topic config

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -360,7 +360,15 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 	if !externalTopic {
 		topicConfig, err := r.topicConfig(logger, broker, brokerConfig)
 		if err != nil {
-			return fmt.Errorf("failed to resolve broker config: %w", err)
+
+			// On finalize, we fail to get a valid config, we can safely ignore and return nil
+			// no further actions are needed since we are also not putting the finalizer on given secret
+			// if we are not having a valid topic config
+			if strings.Contains(err.Error(), "validating topic config") {
+				return nil
+			} else {
+				return fmt.Errorf("failed to resolve broker config: %w", err)
+			}
 		}
 
 		// get security option for Sarama with secret info in it

--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -243,6 +243,19 @@ func BrokerConfig(bootstrapServers string, numPartitions, replicationFactor int,
 	return cm
 }
 
+func BogusBrokerConfig() *corev1.ConfigMap {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ConfigMapNamespace,
+			Name:      ConfigMapName,
+		},
+		Data: map[string]string{
+			"foo": "bar",
+		},
+	}
+	return cm
+}
+
 func BrokerAuthConfig(name string) CMOption {
 	return func(cm *corev1.ConfigMap) {
 		if cm.Data == nil {

--- a/test/e2e_new/bogus_config/bogus_config.yaml
+++ b/test/e2e_new/bogus_config/bogus_config.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+data:
+  channel-template-spec: |
+    apiVersion: messaging.knative.dev/v1
+    kind: InMemoryChannel
+  auth.secret.ref.name: strimzi-sasl-secret

--- a/test/e2e_new/bogus_config/install.go
+++ b/test/e2e_new/bogus_config/install.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bogus_config
+
+import (
+	"context"
+	"embed"
+
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/manifest"
+)
+
+const ConfigMapName = "broken-kafka-broker-config"
+
+//go:embed *.yaml
+var yamls embed.FS
+
+func Install(ctx context.Context, t feature.T) {
+	if _, err := manifest.InstallYamlFS(ctx, yamls, map[string]interface{}{
+		"name": ConfigMapName,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/e2e_new/broker_test.go
+++ b/test/e2e_new/broker_test.go
@@ -165,6 +165,22 @@ func TestTriggerLatestOffset(t *testing.T) {
 	env.Test(ctx, t, features.TriggerLatestOffset())
 }
 
+func TestBrokerWithBogusConfig(t *testing.T) {
+	// this test is observed to flake more when it is parallel
+	// t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.WithPollTimings(PollInterval, PollTimeout),
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, features.BrokerWithBogusConfig())
+}
+
 func TestBrokerCannotReachKafkaCluster(t *testing.T) {
 	// this test is observed to flake more when it is parallel
 	// t.Parallel()


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #2815

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- If an invalid topic config is present for a broker we do not block finalization

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
If an invalid topic config is present for a broker we do not block finalization
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
