### PR TITLE
Templating support in namespaced broker additional resources

### DIFF
--- a/control-plane/pkg/propagator/resource_propagator.go
+++ b/control-plane/pkg/propagator/resource_propagator.go
@@ -17,7 +17,9 @@
 package propagator
 
 import (
+	"bytes"
 	"fmt"
+	"text/template"
 
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
@@ -32,7 +34,42 @@ type Resources struct {
 	Resources []unstructured.Unstructured
 }
 
-func Unmarshal(cm *corev1.ConfigMap) (Resources, error) {
+type TemplateData struct {
+	Namespace string
+}
+
+func Unmarshal(cm *corev1.ConfigMap, templateData TemplateData) (Resources, error) {
+	templateString, ok := cm.Data[configMapKey]
+	if !ok {
+		return Resources{}, nil
+	}
+
+	tmpl, err := template.New(fmt.Sprintf("%s/%s", cm.Namespace, cm.Name)).Parse(templateString)
+	if err != nil {
+		return Resources{}, fmt.Errorf("failed to unmarshal resources to propagate from ConfigMap %s/%s: %w", cm.GetNamespace(), cm.GetName(), err)
+	}
+
+	buf := bytes.Buffer{}
+	if err := tmpl.Execute(&buf, templateData); err != nil {
+		return Resources{}, fmt.Errorf("failed to unmarshal resources to propagate from ConfigMap %s/%s: %w", cm.GetNamespace(), cm.GetName(), err)
+	}
+	data := buf.String()
+
+	resources := make([]map[string]interface{}, 0, 2)
+
+	if err := yaml.Unmarshal([]byte(data), &resources); err != nil {
+		return Resources{}, fmt.Errorf("failed to unmarshal resources to propagate from ConfigMap %s/%s: %w", cm.GetNamespace(), cm.GetName(), err)
+	}
+
+	ret := Resources{}
+	for _, r := range resources {
+		ret.Resources = append(ret.Resources, unstructured.Unstructured{Object: r})
+	}
+
+	return ret, nil
+}
+
+func UnmarshalTemplate(cm *corev1.ConfigMap) (Resources, error) {
 	data, ok := cm.Data[configMapKey]
 	if !ok {
 		return Resources{}, nil

--- a/control-plane/pkg/propagator/resource_propagator.go
+++ b/control-plane/pkg/propagator/resource_propagator.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"text/template"
 
-	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/control-plane/pkg/reconciler/broker/namespaced_broker.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_broker.go
@@ -181,7 +181,7 @@ func (r *NamespacedReconciler) getManifest(ctx context.Context, broker *eventing
 	}
 	resources = append(resources, additionalRoleBindings...)
 
-	additionalResources, err := r.resourcesFromConfigMap(NamespacedBrokerAdditionalResourcesConfigMapName)
+	additionalResources, err := r.resourcesFromConfigMap(NamespacedBrokerAdditionalResourcesConfigMapName, broker.Namespace)
 	if err != nil {
 		return mf.Manifest{}, err
 	}
@@ -408,7 +408,7 @@ func (r *NamespacedReconciler) createManifestFromClusterRoleBinding(broker *even
 	return unstructuredFromObject(cm)
 }
 
-func (r *NamespacedReconciler) resourcesFromConfigMap(name string) ([]unstructured.Unstructured, error) {
+func (r *NamespacedReconciler) resourcesFromConfigMap(name string, renderNamespace string) ([]unstructured.Unstructured, error) {
 	cm, err := r.ConfigMapLister.ConfigMaps(r.SystemNamespace).Get(name)
 	if apierrors.IsNotFound(err) {
 		return nil, nil
@@ -417,7 +417,7 @@ func (r *NamespacedReconciler) resourcesFromConfigMap(name string) ([]unstructur
 		return nil, fmt.Errorf("failed to get ConfigMap %s/%s: %w", r.SystemNamespace, name, err)
 	}
 
-	resources, err := propagator.Unmarshal(cm)
+	resources, err := propagator.Unmarshal(cm, propagator.TemplateData{Namespace: renderNamespace})
 	if err != nil {
 		return nil, err
 	}

--- a/control-plane/pkg/reconciler/broker/namespaced_broker.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_broker.go
@@ -434,6 +434,10 @@ func unstructuredFromObject(obj runtime.Object) (unstructured.Unstructured, erro
 
 func appendNewOwnerRefsToPersisted(client mf.Client, broker *eventing.Broker) mf.Transformer {
 	return func(resource *unstructured.Unstructured) error {
+		if resource.GetKind() == "Namespace" {
+			return nil
+		}
+
 		existingRefs, err := getPersistedOwnerRefs(client, resource)
 		if err != nil {
 			return err
@@ -504,7 +508,7 @@ func setLabel(u *unstructured.Unstructured) error {
 func filterMetadataMap(metadata map[string]string) map[string]string {
 	r := make(map[string]string, len(metadata))
 	for k, v := range metadata {
-		if strings.Contains(k, "knative") || strings.Contains(k, "cert") || k == "app" || k == "name" {
+		if strings.Contains(k, "knative") || strings.Contains(k, "cert") || strings.Contains(k, "monitoring") || k == "app" || k == "name" {
 			r[k] = v
 		}
 	}

--- a/control-plane/pkg/reconciler/broker/namespaced_broker.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_broker.go
@@ -504,7 +504,7 @@ func setLabel(u *unstructured.Unstructured) error {
 func filterMetadataMap(metadata map[string]string) map[string]string {
 	r := make(map[string]string, len(metadata))
 	for k, v := range metadata {
-		if strings.Contains(k, "knative") || k == "app" {
+		if strings.Contains(k, "knative") || strings.Contains(k, "cert") || k == "app" || k == "name" {
 			r[k] = v
 		}
 	}

--- a/control-plane/pkg/reconciler/broker/namespaced_broker.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_broker.go
@@ -202,12 +202,12 @@ func (r *NamespacedReconciler) getManifest(ctx context.Context, broker *eventing
 		return mf.Manifest{}, fmt.Errorf("unable to append owner ref: %w", err)
 	}
 
-	manifest, err = manifest.Transform(filterMetadata())
+	manifest, err = manifest.Transform(filterMetadata)
 	if err != nil {
 		return mf.Manifest{}, fmt.Errorf("unable to filter metadata: %w", err)
 	}
 
-	manifest, err = manifest.Transform(setLabel())
+	manifest, err = manifest.Transform(setLabel)
 	if err != nil {
 		return mf.Manifest{}, fmt.Errorf("unable to set label: %w", err)
 	}
@@ -488,21 +488,17 @@ func appendOwnerRef(refs []metav1.OwnerReference, broker *eventing.Broker) ([]me
 	return append(refs, newRef), true
 }
 
-func filterMetadata() mf.Transformer {
-	return func(u *unstructured.Unstructured) error {
-		u.SetLabels(filterMetadataMap(u.GetLabels()))
-		u.SetAnnotations(filterMetadataMap(u.GetAnnotations()))
-		return nil
-	}
+func filterMetadata(u *unstructured.Unstructured) error {
+	u.SetLabels(filterMetadataMap(u.GetLabels()))
+	u.SetAnnotations(filterMetadataMap(u.GetAnnotations()))
+	return nil
 }
 
-func setLabel() mf.Transformer {
-	return func(u *unstructured.Unstructured) error {
-		labels := u.GetLabels()
-		labels[kafka.NamespacedBrokerDataplaneLabelKey] = kafka.NamespacedBrokerDataplaneLabelValue
-		u.SetLabels(labels)
-		return nil
-	}
+func setLabel(u *unstructured.Unstructured) error {
+	labels := u.GetLabels()
+	labels[kafka.NamespacedBrokerDataplaneLabelKey] = kafka.NamespacedBrokerDataplaneLabelValue
+	u.SetLabels(labels)
+	return nil
 }
 
 func filterMetadataMap(metadata map[string]string) map[string]string {

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 
 require (
 	github.com/kedacore/keda/v2 v2.8.1
-	gopkg.in/yaml.v3 v3.0.1
 	knative.dev/eventing v0.35.1-0.20221222072558-1c40365a6c0a
 	knative.dev/eventing-kafka v0.35.1-0.20221219133153-20e1b33541bc
 	knative.dev/hack v0.0.0-20221209013717-b9801b4f5a4d
@@ -153,6 +152,7 @@ require (
 	google.golang.org/grpc v1.49.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/code-generator v0.25.4 // indirect
 	k8s.io/gengo v0.0.0-20221011193443-fad74ee6edd9 // indirect
 	k8s.io/klog/v2 v2.80.2-0.20221028030830-9ae4992afb54 // indirect

--- a/test/e2e_new/features/featuressteps/broker.go
+++ b/test/e2e_new/features/featuressteps/broker.go
@@ -164,7 +164,7 @@ func AddAdditionalResourcesToPropagationConfigMap(cmName string, additionalResou
 			t.Errorf("Failed to get ConfigMap %s/%s: %w", system.Namespace(), cmName, err)
 		}
 
-		resources, err := propagator.Unmarshal(cm)
+		resources, err := propagator.UnmarshalTemplate(cm)
 		if err != nil {
 			t.Fatal("Failed to unmarshal resources from ConfigMap %s/%s: %w\n%s", system.Namespace(), cmName, err, cm.Data["resources"])
 		}

--- a/test/e2e_new/features/namespaced_broker.go
+++ b/test/e2e_new/features/namespaced_broker.go
@@ -46,7 +46,8 @@ func NamespacedBrokerResourcesPropagation() *feature.Feature {
 				"namespace": system.Namespace(),
 			},
 			"data": map[string]string{
-				"config": "x-unknown-config",
+				"config":           "x-unknown-config",
+				"dataFromTemplate": "{{.Namespace}}",
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Templating support in namespaced broker additional resources
- We need to *inject* the namespace into the spec of the resources created

Sample resource to put in additional resources CM is following. The `{{.Namespace}}` variable will be changed to the broker namespace.
```
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
...
spec:
  endpoints:
    - tlsConfig:
        ca: {}
        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
        cert: {}
        serverName: "kafka-broker-receiver-sm-service.{{.Namespace}}.svc"
  namespaceSelector:
    matchNames:
      - "{{.Namespace}}"
...
```

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Added templating support in namespaced broker additional resources, which allows injecting information to those resources.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
