### PR TITLE
Granting permissions to delete consumer groups metadata

### DIFF
--- a/test/kafka/user-sasl-scram-512.yaml
+++ b/test/kafka/user-sasl-scram-512.yaml
@@ -43,6 +43,11 @@ spec:
           patternType: literal
         operation: Read
         host: "*"
+      - resource:
+          type: group
+          name: "*"
+        operation: Delete
+        host: "*"
       # Example ACL rules for producing to topic knative-messaging-kafka
       - resource:
           type: topic

--- a/test/kafka/user-tls.yaml
+++ b/test/kafka/user-tls.yaml
@@ -43,6 +43,11 @@ spec:
           patternType: literal
         operation: Read
         host: "*"
+      - resource:
+          type: group
+          name: "*"
+        operation: Delete
+        host: "*"
       # Example ACL rules for producing to a topic.
       - resource:
           type: topic


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Granting permissions to delete consumer groups metadata which is (and actually already was) needed to delete consumer groups. (something we did downstream as well)

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
