### PR TITLE
Improve ConsumerGroup finalization when missing resources

### DIFF
--- a/control-plane/pkg/counter/counter.go
+++ b/control-plane/pkg/counter/counter.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package counter
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
+)
+
+type Counter struct {
+	counterLock sync.RWMutex
+	counterMap  map[string]int
+
+	cache prober.Cache
+}
+
+func NewExpiringCounter(ctx context.Context) *Counter {
+	cache := prober.NewLocalExpiringCache(ctx, 10*time.Minute)
+	return &Counter{
+		cache: cache,
+	}
+}
+
+func (c *Counter) Inc(uuid string) int {
+	value := int(c.cache.GetStatus(uuid))
+	c.cache.UpsertStatus(uuid, prober.Status(value+1), nil, func(key string, arg interface{}) {})
+	return value
+}
+
+func (c *Counter) Del(uuid string) {
+	c.cache.Expire(uuid)
+}

--- a/control-plane/pkg/counter/counter.go
+++ b/control-plane/pkg/counter/counter.go
@@ -18,16 +18,12 @@ package counter
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
 )
 
 type Counter struct {
-	counterLock sync.RWMutex
-	counterMap  map[string]int
-
 	cache prober.Cache
 }
 

--- a/control-plane/pkg/counter/counter_test.go
+++ b/control-plane/pkg/counter/counter_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package counter_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/counter"
+)
+
+func TestCounter(t *testing.T) {
+	ctx := context.Background()
+	c := counter.NewExpiringCounter(ctx)
+
+	key := "a"
+
+	v1 := c.Inc(key)
+	v2 := c.Inc(key)
+
+	assert.Equal(t, 1, v1)
+	assert.Equal(t, 2, v2)
+
+	c.Del(key)
+	v3 := c.Inc(key)
+	assert.Equal(t, 1, v3)
+}

--- a/control-plane/pkg/reconciler/broker/controller.go
+++ b/control-plane/pkg/reconciler/broker/controller.go
@@ -40,6 +40,7 @@ import (
 	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/counter"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
@@ -71,7 +72,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher, env *config.E
 		NewKafkaClusterAdminClient: sarama.NewClusterAdmin,
 		ConfigMapLister:            configmapInformer.Lister(),
 		Env:                        env,
-		Counter:                    NewCounter(),
+		Counter:                    counter.NewExpiringCounter(ctx),
 	}
 
 	logger := logging.FromContext(ctx)

--- a/control-plane/pkg/reconciler/broker/namespaced_broker.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_broker.go
@@ -44,6 +44,7 @@ import (
 	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/counter"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/propagator"
@@ -73,7 +74,7 @@ type NamespacedReconciler struct {
 	BootstrapServers string
 
 	Prober  prober.Prober
-	Counter *Counter
+	Counter *counter.Counter
 
 	IPsLister          prober.IPListerWithMapping
 	ManifestivalClient mf.Client

--- a/control-plane/pkg/reconciler/broker/namespaced_controller.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_controller.go
@@ -37,6 +37,7 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/counter"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
 
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -95,7 +96,7 @@ func NewNamespacedController(ctx context.Context, watcher configmap.Watcher, env
 		ClusterRoleBindingLister:   clusterrolebindinginformer.Get(ctx).Lister(),
 		DeploymentLister:           deploymentinformer.Get(ctx).Lister(),
 		Env:                        env,
-		Counter:                    NewCounter(),
+		Counter:                    counter.NewExpiringCounter(ctx),
 		ManifestivalClient:         mfc,
 	}
 

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup.go
@@ -49,6 +49,7 @@ import (
 	internalv1alpha1 "knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/clientset/versioned/typed/eventing/v1alpha1"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/injection/reconciler/eventing/v1alpha1/consumergroup"
 	kafkainternalslisters "knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/listers/eventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/counter"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
 	kedav1alpha1 "knative.dev/eventing-kafka-broker/third_party/pkg/apis/keda/v1alpha1"
@@ -95,6 +96,10 @@ type Reconciler struct {
 	KafkaFeatureFlags *config.KafkaFeatureFlags
 	KedaClient        kedaclientset.Interface
 	AutoscalerConfig  string
+
+	// DeleteConsumerGroupMetadataCounter is an in-memory counter to count how many times we have
+	// tried to delete consumer group metadata from Kafka.
+	DeleteConsumerGroupMetadataCounter *counter.Counter
 }
 
 func (r Reconciler) ReconcileKind(ctx context.Context, cg *kafkainternals.ConsumerGroup) reconciler.Event {
@@ -168,6 +173,18 @@ func (r Reconciler) FinalizeKind(ctx context.Context, cg *kafkainternals.Consume
 		}
 	}
 
+	if err := r.deleteConsumerGroupMetadata(ctx, cg); err != nil {
+		// We retry a few times to delete Consumer group metadata from Kafka before giving up.
+		if v := r.DeleteConsumerGroupMetadataCounter.Inc(string(cg.GetUID())); v <= 5 {
+			return err
+		}
+		r.DeleteConsumerGroupMetadataCounter.Del(string(cg.GetUID()))
+	}
+
+	return nil
+}
+
+func (r Reconciler) deleteConsumerGroupMetadata(ctx context.Context, cg *kafkainternals.ConsumerGroup) error {
 	saramaSecurityOption, err := r.newAuthConfigOption(ctx, cg)
 	if err != nil {
 		return fmt.Errorf("failed to create config options for Kafka cluster auth: %w", err)

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
@@ -45,6 +45,7 @@ import (
 	kafkainternals "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1"
 	fakekafkainternalsclient "knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/injection/client/fake"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/injection/reconciler/eventing/v1alpha1/consumergroup"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/counter"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	kafkatesting "knative.dev/eventing-kafka-broker/control-plane/pkg/kafka/testing"
@@ -1671,8 +1672,9 @@ func TestReconcileKind(t *testing.T) {
 			InitOffsetsFunc: func(ctx context.Context, kafkaClient sarama.Client, kafkaAdminClient sarama.ClusterAdmin, topics []string, consumerGroup string) (int32, error) {
 				return 1, nil
 			},
-			SystemNamespace:  systemNamespace,
-			AutoscalerConfig: "",
+			SystemNamespace:                    systemNamespace,
+			AutoscalerConfig:                   "",
+			DeleteConsumerGroupMetadataCounter: counter.NewExpiringCounter(ctx),
 		}
 
 		r.KafkaFeatureFlags = configapis.FromContext(store.ToContext(ctx))
@@ -1810,7 +1812,8 @@ func TestReconcileKindNoAutoscaler(t *testing.T) {
 			InitOffsetsFunc: func(ctx context.Context, kafkaClient sarama.Client, kafkaAdminClient sarama.ClusterAdmin, topics []string, consumerGroup string) (int32, error) {
 				return 1, nil
 			},
-			SystemNamespace: systemNamespace,
+			SystemNamespace:                    systemNamespace,
+			DeleteConsumerGroupMetadataCounter: counter.NewExpiringCounter(ctx),
 		}
 
 		r.KafkaFeatureFlags = configapis.DefaultFeaturesConfig()
@@ -2193,7 +2196,8 @@ func TestFinalizeKind(t *testing.T) {
 					ErrorOnDeleteConsumerGroup: ErrorAssertOrNil(errorOnDeleteKafkaCG),
 				}, nil
 			},
-			KafkaFeatureFlags: configapis.DefaultFeaturesConfig(),
+			KafkaFeatureFlags:                  configapis.DefaultFeaturesConfig(),
+			DeleteConsumerGroupMetadataCounter: counter.NewExpiringCounter(ctx),
 		}
 
 		return consumergroup.NewReconciler(

--- a/control-plane/pkg/reconciler/consumergroup/controller.go
+++ b/control-plane/pkg/reconciler/consumergroup/controller.go
@@ -54,6 +54,7 @@ import (
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/injection/informers/eventing/v1alpha1/consumer"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/injection/informers/eventing/v1alpha1/consumergroup"
 	cgreconciler "knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/injection/reconciler/eventing/v1alpha1/consumergroup"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/counter"
 
 	kedaclient "knative.dev/eventing-kafka-broker/third_party/pkg/client/injection/client"
 )
@@ -108,21 +109,22 @@ func NewController(ctx context.Context, watcher configmap.Watcher) *controller.I
 	}
 
 	r := &Reconciler{
-		SchedulerFunc:              func(s string) Scheduler { return schedulers[strings.ToLower(s)] },
-		ConsumerLister:             consumer.Get(ctx).Lister(),
-		InternalsClient:            internalsclient.Get(ctx).InternalV1alpha1(),
-		SecretLister:               secretinformer.Get(ctx).Lister(),
-		ConfigMapLister:            configmapinformer.Get(ctx).Lister(),
-		PodLister:                  podinformer.Get(ctx).Lister(),
-		KubeClient:                 kubeclient.Get(ctx),
-		NameGenerator:              names.SimpleNameGenerator,
-		NewKafkaClient:             sarama.NewClient,
-		InitOffsetsFunc:            offset.InitOffsets,
-		SystemNamespace:            system.Namespace(),
-		NewKafkaClusterAdminClient: sarama.NewClusterAdmin,
-		KafkaFeatureFlags:          config.DefaultFeaturesConfig(),
-		KedaClient:                 kedaclient.Get(ctx),
-		AutoscalerConfig:           env.AutoscalerConfigMap,
+		SchedulerFunc:                      func(s string) Scheduler { return schedulers[strings.ToLower(s)] },
+		ConsumerLister:                     consumer.Get(ctx).Lister(),
+		InternalsClient:                    internalsclient.Get(ctx).InternalV1alpha1(),
+		SecretLister:                       secretinformer.Get(ctx).Lister(),
+		ConfigMapLister:                    configmapinformer.Get(ctx).Lister(),
+		PodLister:                          podinformer.Get(ctx).Lister(),
+		KubeClient:                         kubeclient.Get(ctx),
+		NameGenerator:                      names.SimpleNameGenerator,
+		NewKafkaClient:                     sarama.NewClient,
+		InitOffsetsFunc:                    offset.InitOffsets,
+		SystemNamespace:                    system.Namespace(),
+		NewKafkaClusterAdminClient:         sarama.NewClusterAdmin,
+		KafkaFeatureFlags:                  config.DefaultFeaturesConfig(),
+		KedaClient:                         kedaclient.Get(ctx),
+		AutoscalerConfig:                   env.AutoscalerConfigMap,
+		DeleteConsumerGroupMetadataCounter: counter.NewExpiringCounter(ctx),
 	}
 
 	consumerInformer := consumer.Get(ctx)


### PR DESCRIPTION
When the secret is gone we successfully delete the KafkaSource but ConsumerGroup might be stuck in deletion since we can't connect to Kafka anymore.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Improve ConsumerGroup finalization when missing resources

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Improve ConsumerGroup finalization when missing resources
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
