### PR TITLE
Stream logs from system namespace in upgrade tests

### DIFF
--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -35,8 +35,6 @@ if ! ${SKIP_INITIALIZE}; then
   save_release_artifacts || fail_test "Failed to save release artifacts"
 fi
 
-export_logs_continuously
-
 set -Eeuo pipefail
 
 TIMEOUT=${TIMEOUT:-100m}

--- a/test/upgrade/postdowngrade.go
+++ b/test/upgrade/postdowngrade.go
@@ -52,7 +52,6 @@ func ChannelPostDowngradeTest() pkgupgrade.Operation {
 // SinkPostDowngradeTest tests sink basic operations after downgrade.
 func SinkPostDowngradeTest() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("SinkPostDowngradeTest", func(c pkgupgrade.Context) {
-		c.T.Error("Induce failure")
 		e2e_sink.RunTestKafkaSink(c.T, eventing.ModeBinary, nil)
 	})
 }

--- a/test/upgrade/postdowngrade.go
+++ b/test/upgrade/postdowngrade.go
@@ -52,6 +52,7 @@ func ChannelPostDowngradeTest() pkgupgrade.Operation {
 // SinkPostDowngradeTest tests sink basic operations after downgrade.
 func SinkPostDowngradeTest() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("SinkPostDowngradeTest", func(c pkgupgrade.Context) {
+		c.T.Error("Induce failure")
 		e2e_sink.RunTestKafkaSink(c.T, eventing.ModeBinary, nil)
 	})
 }

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -23,6 +23,9 @@ import (
 	"log"
 	"testing"
 
+	reconciler "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
+	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/pkg/system"
 	pkgupgrade "knative.dev/pkg/test/upgrade"
 	"knative.dev/pkg/test/zipkin"
 )
@@ -33,5 +36,18 @@ func TestUpgrades(t *testing.T) {
 	// place that cleans it up. If an individual test calls this instead, then it will break other
 	// tests that need the tracing in place.
 	defer zipkin.CleanupZipkinTracingSetup(log.Printf)
+
+	pods := []string{
+		reconciler.BrokerReceiverLabel,
+		reconciler.BrokerDispatcherLabel,
+		reconciler.ChannelReceiverLabel,
+		reconciler.ChannelDispatcherLabel,
+		reconciler.SinkReceiverLabel,
+		reconciler.SourceDispatcherLabel,
+	}
+
+	canceler := testlib.ExportLogStreamOnError(t, testlib.SystemLogsDir, system.Namespace(), pods...)
+	defer canceler()
+
 	suite.Execute(pkgupgrade.Configuration{T: t})
 }


### PR DESCRIPTION
Description: The original Bash solution for collecting logs doesn't work for upgrade tests because the Pods are restarted during upgrades and the exported logs are empty in the end. This can be seen e.g. [here](https://gcsweb.knative.dev/gcs/knative-prow/pr-logs/pull/knative-sandbox_eventing-kafka-broker/2946/upgrade-tests_eventing-kafka-broker_main/1626255704035692544/artifacts/knative-eventing/)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Re-use recently implemented changes from knative.dev/pkg and knative.dev/eventing for log streaming from system namespaces.
- Stream logs for a predefined set of Pods.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
