### PR TITLE
Fix delete namespace with a namespaced broker stuck on finalizer

### DIFF
--- a/control-plane/pkg/prober/cache.go
+++ b/control-plane/pkg/prober/cache.go
@@ -28,6 +28,9 @@ const (
 	StatusReady Status = iota
 	// StatusUnknown signals that a given object is not ready and its state is unknown.
 	StatusUnknown
+	// StatusUnknownErr signals that a given object is not ready and its state is unknown due to
+	// networking problems between control plane and data plane.
+	StatusUnknownErr
 	// StatusNotReady signals that a given object is not ready.
 	StatusNotReady
 )

--- a/control-plane/pkg/prober/prober.go
+++ b/control-plane/pkg/prober/prober.go
@@ -81,7 +81,7 @@ func probe(ctx context.Context, client httpClient, logger *zap.Logger, address s
 	response, err := client.Do(r)
 	if err != nil {
 		logger.Error("Failed probe", zap.Error(err))
-		return StatusUnknown
+		return StatusUnknownErr
 	}
 
 	if response.StatusCode != http.StatusOK {

--- a/test/e2e_new/broker_test.go
+++ b/test/e2e_new/broker_test.go
@@ -25,6 +25,7 @@ import (
 
 	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 
@@ -175,4 +176,24 @@ func TestNamespacedBrokerResourcesPropagation(t *testing.T) {
 	)
 
 	env.Test(ctx, t, features.NamespacedBrokerResourcesPropagation())
+}
+
+func TestNamespacedBrokerNamespaceDeletion(t *testing.T) {
+
+	name := "broker"
+	namespace := feature.MakeRandomK8sName("test-namespaced-broker")
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.WithPollTimings(PollInterval, PollTimeout),
+		environment.WithTestLogger(t),
+		environment.InNamespace(namespace),
+	)
+
+	env.Test(ctx, t, features.SetupNamespace(namespace))
+	env.Test(ctx, t, features.SetupNamespacedBroker(name))
+	env.Test(ctx, t, features.CleanupNamespace(namespace))
 }


### PR DESCRIPTION
When the system namespace is deleted while we're running there is no point in
trying to delete the resource from the ConfigMap since the entire ConfigMap
is gone.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Fixes #2893 