### PR TITLE
Simplify `getAuthConfigFromSecret` and `extractProtocol`

### DIFF
--- a/control-plane/pkg/config/eventingkafkaconfig.go
+++ b/control-plane/pkg/config/eventingkafkaconfig.go
@@ -19,8 +19,6 @@ package config
 import (
 	"github.com/Shopify/sarama"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/security"
 )
 
 // EKKubernetesConfig and these EK sub-structs contain our custom configuration settings,
@@ -86,10 +84,9 @@ type EKSaramaConfig struct {
 
 // EventingKafkaConfig is the main struct that holds the Receiver, Dispatcher, and Kafka sub-items
 type EventingKafkaConfig struct {
-	Channel     EKChannelConfig           `json:"channel,omitempty"`
-	CloudEvents EKCloudEventConfig        `json:"cloudevents,omitempty"`
-	Kafka       EKKafkaConfig             `json:"kafka,omitempty"`
-	Sarama      EKSaramaConfig            `json:"sarama,omitempty"`
-	Source      EKSourceConfig            `json:"source,omitempty"`
-	Auth        *security.KafkaAuthConfig `json:"-"` // Not directly part of the configmap; loaded from the secret
+	Channel     EKChannelConfig    `json:"channel,omitempty"`
+	CloudEvents EKCloudEventConfig `json:"cloudevents,omitempty"`
+	Kafka       EKKafkaConfig      `json:"kafka,omitempty"`
+	Sarama      EKSaramaConfig     `json:"sarama,omitempty"`
+	Source      EKSourceConfig     `json:"source,omitempty"`
 }

--- a/control-plane/pkg/security/config.go
+++ b/control-plane/pkg/security/config.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Shopify/sarama"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -142,28 +141,4 @@ func (a *AnnotationsSecretLocator) SecretName() (string, bool) {
 func (a *AnnotationsSecretLocator) SecretNamespace() (string, bool) {
 	name, ok := a.SecretName()
 	return a.Namespace, len(a.Namespace) > 0 && ok && len(name) > 0
-}
-
-type KafkaAuthConfig struct {
-	TLS  *KafkaTlsConfig
-	SASL *KafkaSaslConfig
-}
-
-type KafkaTlsConfig struct {
-	Cacert   string
-	Usercert string
-	Userkey  string
-}
-
-type KafkaSaslConfig struct {
-	User     string
-	Password string
-	SaslType string
-}
-
-// HasSameSettings returns true if all of the SASL settings in the provided config are the same as in this struct
-func (c *KafkaSaslConfig) HasSameSettings(saramaConfig *sarama.Config) bool {
-	return saramaConfig.Net.SASL.User == c.User &&
-		saramaConfig.Net.SASL.Password == c.Password &&
-		string(saramaConfig.Net.SASL.Mechanism) == c.SaslType
 }

--- a/control-plane/pkg/security/secrets_provider_legacy_channel_secret.go
+++ b/control-plane/pkg/security/secrets_provider_legacy_channel_secret.go
@@ -19,7 +19,6 @@ package security
 import (
 	"strconv"
 
-	"github.com/Shopify/sarama"
 	corev1 "k8s.io/api/core/v1"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
@@ -30,8 +29,7 @@ func ResolveAuthContextFromLegacySecret(s *corev1.Secret) (*NetSpecAuthContext, 
 		return &NetSpecAuthContext{}, nil
 	}
 
-	legacyAuth := getAuthConfigFromSecret(s)
-	protocolStr, protocolContract := extractProtocol(legacyAuth)
+	protocolStr, protocolContract := getProtocolFromLegacyChannelSecret(s)
 
 	virtualSecret := s.DeepCopy()
 	virtualSecret.Data[ProtocolKey] = []byte(protocolStr)
@@ -104,83 +102,30 @@ func maybeAddKeyFieldRef(s *corev1.Secret, key string, field contract.SecretFiel
 	return false
 }
 
-func extractProtocol(auth *KafkaAuthConfig) (string, contract.Protocol) {
-	if hasTLSEnabled(auth) && hasSASLEnabled(auth) {
+func getProtocolFromLegacyChannelSecret(secret *corev1.Secret) (string, contract.Protocol) {
+	if hasTLSEnabled(secret) && hasSASLEnabled(secret) {
 		return ProtocolSASLSSL, contract.Protocol_SASL_SSL
 	}
-	if hasTLSEnabled(auth) {
+	if hasTLSEnabled(secret) {
 		return ProtocolSSL, contract.Protocol_SSL
 	}
-	if hasSASLEnabled(auth) {
+	if hasSASLEnabled(secret) {
 		return ProtocolSASLPlaintext, contract.Protocol_SASL_PLAINTEXT
 	}
 	return ProtocolPlaintext, contract.Protocol_PLAINTEXT
 }
 
-func hasTLSEnabled(auth *KafkaAuthConfig) bool {
-	return auth.TLS != nil && (auth.TLS.Userkey != "" || auth.TLS.Cacert != "" || auth.TLS.Usercert != "")
+func hasTLSEnabled(secret *corev1.Secret) bool {
+	tlsCaCert := secret.Data[CaCertificateKey]
+	tlsEnabled, _ := strconv.ParseBool(string(secret.Data[SSLLegacyEnabled]))
+
+	return tlsEnabled || string(tlsCaCert) != ""
 }
 
-func hasSASLEnabled(auth *KafkaAuthConfig) bool {
-	return auth.SASL != nil && auth.SASL.User != "" || auth.SASL.Password != ""
-}
+func hasSASLEnabled(secret *corev1.Secret) bool {
+	_, hasSaslPassword := secret.Data[SaslPasswordKey]
+	_, hasSaslUsername := secret.Data[SaslUsernameKey] // legacy secret
+	_, hasSaslUser := secret.Data[SaslUserKey]
 
-// getAuthConfigFromSecret Looks Up And Returns Kafka Auth Config And Brokers From Provided Secret
-func getAuthConfigFromSecret(secret *corev1.Secret) *KafkaAuthConfig {
-	if secret == nil || secret.Data == nil {
-		return nil
-	}
-
-	username := string(secret.Data[SaslUsernameKey])
-	saslType := string(secret.Data[SaslType])
-	var authConfig KafkaAuthConfig
-	// Backwards-compatibility - Support old consolidated secret fields if present
-	// (TLS data is now in the configmap, e.g. sarama.Config.Net.TLS.Config.RootPEMs)
-	_, hasTlsCaCert := secret.Data[CaCertificateKey]
-	_, hasTlsEnabled := secret.Data[SSLLegacyEnabled]
-	if hasTlsEnabled || hasTlsCaCert {
-		parseTls(secret, &authConfig)
-		username = string(secret.Data[SaslUserKey])
-		saslType = string(secret.Data[SaslTypeLegacy]) // old "saslType" is different than new "sasltype"
-	}
-
-	// If we don't convert the empty string to the "PLAIN" default, the client.HasSameSettings()
-	// function will assume that they should be treated as differences and needlessly reconfigure
-	if saslType == "" {
-		saslType = sarama.SASLTypePlaintext
-	}
-
-	authConfig.SASL = &KafkaSaslConfig{
-		User:     username,
-		Password: string(secret.Data[SaslPasswordKey]),
-		SaslType: saslType,
-	}
-
-	return &authConfig
-}
-
-// parseTls allows backward-compatibility with older consolidated channel secrets
-func parseTls(secret *corev1.Secret, kafkaAuthConfig *KafkaAuthConfig) {
-
-	// self-signed CERTs we need CA CERT, USER CERT and KEY
-	if string(secret.Data[CaCertificateKey]) != "" {
-		// We have a self-signed TLS cert
-		tls := &KafkaTlsConfig{
-			Cacert:   string(secret.Data[CaCertificateKey]),
-			Usercert: string(secret.Data[UserCertificate]),
-			Userkey:  string(secret.Data[UserKey]),
-		}
-		kafkaAuthConfig.TLS = tls
-	} else {
-		// Public CERTS from a proper CA do not need this,
-		// we can just say `tls.enabled: true`
-		tlsEnabled, err := strconv.ParseBool(string(secret.Data[SSLLegacyEnabled]))
-		if err != nil {
-			tlsEnabled = false
-		}
-		if tlsEnabled {
-			// Looks like TLS is desired/enabled:
-			kafkaAuthConfig.TLS = &KafkaTlsConfig{}
-		}
-	}
+	return hasSaslPassword && (hasSaslUsername || hasSaslUser)
 }


### PR DESCRIPTION
Fixes #2905

In #2902 we migrated the `getAuthConfigFromSecret` and `extractProtocol` functions, as they were used in `ResolveAuthContextFromLegacySecret`: https://github.com/knative-sandbox/eventing-kafka-broker/blob/df192313795eb858fc10132dac474bd7cfe8b032/control-plane/pkg/security/secrets_provider_legacy_channel_secret.go#L33-L34

At that place they are only to figure out the protocol and doesn't need all the other overhead. 
This PR addresses it and simplifies the  `getAuthConfigFromSecret` and `extractProtocol` functions to just have a function that given a "legacy channel secret" returns `protocolStr, protocolContract`.
In addition we cleanup the `KafkaAuthConfig` structs which are thus not needed anymore.

This is the follow up on https://github.com/knative-sandbox/eventing-kafka-broker/pull/2902#discussion_r1071235108

/kind cleanup
