### PR TITLE
Improve finalization on missing secret ref

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -342,10 +342,6 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 		brokerUUID := string(broker.GetUID())
 		if r.Counter.Inc(brokerUUID) <= 5 {
 			return controller.NewRequeueAfter(5 * time.Second)
-		} else {
-			r.Counter.Del(brokerUUID)
-			logger.Error("failed to get secret", zap.Error(err))
-			return nil
 		}
 	}
 

--- a/control-plane/pkg/reconciler/broker/broker_test.go
+++ b/control-plane/pkg/reconciler/broker/broker_test.go
@@ -2181,7 +2181,8 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 					"annotation_to_preserve": "value_to_preserve",
 				}),
 			},
-			Key: testKey,
+			Key:     testKey,
+			WantErr: true,
 			WantUpdates: []clientgotesting.UpdateActionImpl{
 				ConfigMapUpdate(env.DataPlaneConfigMapNamespace, env.ContractConfigMapName, env.ContractConfigMapFormat, &contract.Contract{
 					Resources:  []*contract.Resource{},

--- a/control-plane/pkg/reconciler/broker/broker_test.go
+++ b/control-plane/pkg/reconciler/broker/broker_test.go
@@ -22,6 +22,8 @@ import (
 	"net/url"
 	"testing"
 
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/counter"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"k8s.io/utils/pointer"
@@ -2427,8 +2429,9 @@ func useTable(t *testing.T, table TableTest, env *config.Env) {
 					T:                                      t,
 				}, nil
 			},
-			Env:    env,
-			Prober: proberMock,
+			Env:     env,
+			Prober:  proberMock,
+			Counter: counter.NewExpiringCounter(ctx),
 		}
 
 		reconciler.Tracker = &FakeTracker{}

--- a/test/e2e_new/broker_test.go
+++ b/test/e2e_new/broker_test.go
@@ -133,6 +133,22 @@ func TestBrokerExternalTopicAuthSecretDoesNotExist(t *testing.T) {
 	env.Test(ctx, t, features.BrokerExternalTopicAuthSecretDoesNotExist())
 }
 
+func TestBrokerAuthSecretForInternalTopicDoesNotExist(t *testing.T) {
+	// this test is observed to flake more when it is parallel
+	// t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.WithPollTimings(PollInterval, PollTimeout),
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, features.BrokerAuthSecretForInternalTopicDoesNotExist())
+}
+
 func TestTriggerLatestOffset(t *testing.T) {
 	// this test is observed to flake more when it is parallel
 	// t.Parallel()


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #2885

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- No different treatment on internal or external topic for finalization
- If secret is missing, we try a number of times, otherwise we let go and do not block finalization
- added `rekt` test for "non existing secret" for "internal topic

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
No different treatment on internal or external topic for finalization, and we no longer block if we can not resolve the secret reference for a number of times.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
