### PR TITLE
chore: Move up a check for errors on fetching the broker config map

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -326,15 +326,13 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 	}
 
 	brokerConfig, err := r.brokerConfigMap(logger, broker)
-
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
 	// If the broker config data is empty we simply return,
 	// as the configuration may already be gone
 	if len(brokerConfig.Data) == 0 {
 		return nil
-	}
-
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
 	}
 
 	_, externalTopic := isExternalTopic(broker)


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Move up a check for error on fetching the configmap for the brokerconfig, to avoid a later nil invocation

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
