### PR TITLE
Strimzi 0.33 update

### DIFF
--- a/test/kafka/kafka_setup.sh
+++ b/test/kafka/kafka_setup.sh
@@ -24,7 +24,7 @@ SYSTEM_NAMESPACE=${SYSTEM_NAMESPACE:-"knative-eventing"}
 kubectl create namespace kafka --dry-run=client -o yaml | kubectl apply -f -
 
 header "Applying Strimzi Cluster Operator file"
-cat $(dirname $0)/strimzi-cluster-operator.yaml | sed "s/cluster.local/${CLUSTER_SUFFIX}/g" | kubectl apply -n kafka -f -
+cat $(dirname $0)/strimzi-cluster-operator.yaml | sed 's/namespace: .*/namespace: kafka/' | sed "s/cluster.local/${CLUSTER_SUFFIX}/g" | kubectl apply -n kafka -f -
 
 sleep 10
 

--- a/test/kafka/strimzi-cluster-operator.yaml
+++ b/test/kafka/strimzi-cluster-operator.yaml
@@ -1,7232 +1,3 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: strimzi-kafka-broker
-  labels:
-    app: strimzi
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      # The Kafka Brokers require "get" permissions to view the node they are on
-      # This information is used to generate a Rack ID that is used for High Availability configurations
-      - nodes
-    verbs:
-      - get
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: strimzi-cluster-operator-namespaced
-  labels:
-    app: strimzi
-rules:
-  # Resources in this role are used by the operator based on an operand being deployed in some namespace. When needed, you
-  # can deploy the operator as a cluster-wide operator. But grant the rights listed in this role only on the namespaces
-  # where the operands will be deployed. That way, you can limit the access the operator has to other namespaces where it
-  # does not manage any clusters.
-  - apiGroups:
-      - "rbac.authorization.k8s.io"
-    resources:
-      # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
-      - rolebindings
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-  - apiGroups:
-      - "rbac.authorization.k8s.io"
-    resources:
-      # The cluster operator needs to access and manage roles to grant the entity operator permissions
-      - roles
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-  - apiGroups:
-      - ""
-    resources:
-      # The cluster operator needs to access and delete pods, this is to allow it to monitor pod health and coordinate rolling updates
-      - pods
-      # The cluster operator needs to access and manage service accounts to grant Strimzi components cluster permissions
-      - serviceaccounts
-      # The cluster operator needs to access and manage config maps for Strimzi components configuration
-      - configmaps
-      # The cluster operator needs to access and manage services and endpoints to expose Strimzi components to network traffic
-      - services
-      - endpoints
-      # The cluster operator needs to access and manage secrets to handle credentials
-      - secrets
-      # The cluster operator needs to access and manage persistent volume claims to bind them to Strimzi components for persistent data
-      - persistentvolumeclaims
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-  - apiGroups:
-      # The cluster operator needs the extensions api as the operator supports Kubernetes version 1.11+
-      # apps/v1 was introduced in Kubernetes 1.14
-      - "extensions"
-    resources:
-      # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
-      - deployments
-      - deployments/scale
-      # The cluster operator needs to access replica sets to manage Strimzi components and to determine error states
-      - replicasets
-      # The cluster operator needs to access and manage replication controllers to manage replicasets
-      - replicationcontrollers
-      # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
-      - networkpolicies
-      # The cluster operator needs to access and manage ingresses which allow external access to the services in a cluster
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-  - apiGroups:
-      - "apps"
-    resources:
-      # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
-      - deployments
-      - deployments/scale
-      - deployments/status
-      # The cluster operator needs to access and manage stateful sets to run stateful sets based Strimzi components
-      - statefulsets
-      # The cluster operator needs to access replica-sets to manage Strimzi components and to determine error states
-      - replicasets
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-  - apiGroups:
-      - "" # legacy core events api, used by topic operator
-      - "events.k8s.io" # new events api, used by cluster operator
-    resources:
-      # The cluster operator needs to be able to create events and delegate permissions to do so
-      - events
-    verbs:
-      - create
-  - apiGroups:
-      # Kafka Connect Build on OpenShift requirement
-      - build.openshift.io
-    resources:
-      - buildconfigs
-      - buildconfigs/instantiate
-      - builds
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
-      - networkpolicies
-      # The cluster operator needs to access and manage ingresses which allow external access to the services in a cluster
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-  - apiGroups:
-      - route.openshift.io
-    resources:
-      # The cluster operator needs to access and manage routes to expose Strimzi components for external access
-      - routes
-      - routes/custom-host
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-  - apiGroups:
-      - policy
-    resources:
-      # The cluster operator needs to access and manage pod disruption budgets this limits the number of concurrent disruptions
-      # that a Strimzi component experiences, allowing for higher availability
-      - poddisruptionbudgets
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: kafkamirrormaker2s.kafka.strimzi.io
-  labels:
-    app: strimzi
-    strimzi.io/crd-install: "true"
-spec:
-  group: kafka.strimzi.io
-  names:
-    kind: KafkaMirrorMaker2
-    listKind: KafkaMirrorMaker2List
-    singular: kafkamirrormaker2
-    plural: kafkamirrormaker2s
-    shortNames:
-    - kmm2
-    categories:
-    - strimzi
-  scope: Namespaced
-  conversion:
-    strategy: None
-  versions:
-  - name: v1beta2
-    served: true
-    storage: true
-    subresources:
-      status: {}
-      scale:
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.replicas
-        labelSelectorPath: .status.labelSelector
-    additionalPrinterColumns:
-    - name: Desired replicas
-      description: The desired number of Kafka MirrorMaker 2.0 replicas
-      jsonPath: .spec.replicas
-      type: integer
-    - name: Ready
-      description: The state of the custom resource
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-      type: string
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              version:
-                type: string
-                description: "The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version."
-              replicas:
-                type: integer
-                description: The number of pods in the Kafka Connect group.
-              image:
-                type: string
-                description: The docker image for the pods.
-              connectCluster:
-                type: string
-                description: The cluster alias used for Kafka Connect. The alias must match a cluster in the list at `spec.clusters`.
-              clusters:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    alias:
-                      type: string
-                      pattern: "^[a-zA-Z0-9\\._\\-]{1,100}$"
-                      description: Alias used to reference the Kafka cluster.
-                    bootstrapServers:
-                      type: string
-                      description: A comma-separated list of `host:port` pairs for establishing the connection to the Kafka cluster.
-                    tls:
-                      type: object
-                      properties:
-                        trustedCertificates:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              certificate:
-                                type: string
-                                description: The name of the file certificate in the Secret.
-                              secretName:
-                                type: string
-                                description: The name of the Secret containing the certificate.
-                            required:
-                            - certificate
-                            - secretName
-                          description: Trusted certificates for TLS connection.
-                      description: TLS configuration for connecting MirrorMaker 2.0 connectors to a cluster.
-                    authentication:
-                      type: object
-                      properties:
-                        accessToken:
-                          type: object
-                          properties:
-                            key:
-                              type: string
-                              description: The key under which the secret value is stored in the Kubernetes Secret.
-                            secretName:
-                              type: string
-                              description: The name of the Kubernetes Secret containing the secret value.
-                          required:
-                          - key
-                          - secretName
-                          description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
-                        accessTokenIsJwt:
-                          type: boolean
-                          description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
-                        audience:
-                          type: string
-                          description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
-                        certificateAndKey:
-                          type: object
-                          properties:
-                            certificate:
-                              type: string
-                              description: The name of the file certificate in the Secret.
-                            key:
-                              type: string
-                              description: The name of the private key in the Secret.
-                            secretName:
-                              type: string
-                              description: The name of the Secret containing the certificate.
-                          required:
-                          - certificate
-                          - key
-                          - secretName
-                          description: Reference to the `Secret` which holds the certificate and private key pair.
-                        clientId:
-                          type: string
-                          description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
-                        clientSecret:
-                          type: object
-                          properties:
-                            key:
-                              type: string
-                              description: The key under which the secret value is stored in the Kubernetes Secret.
-                            secretName:
-                              type: string
-                              description: The name of the Kubernetes Secret containing the secret value.
-                          required:
-                          - key
-                          - secretName
-                          description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
-                        connectTimeoutSeconds:
-                          type: integer
-                          description: "The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds."
-                        disableTlsHostnameVerification:
-                          type: boolean
-                          description: Enable or disable TLS hostname verification. Default value is `false`.
-                        enableMetrics:
-                          type: boolean
-                          description: Enable or disable OAuth metrics. Default value is `false`.
-                        maxTokenExpirySeconds:
-                          type: integer
-                          description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
-                        passwordSecret:
-                          type: object
-                          properties:
-                            password:
-                              type: string
-                              description: The name of the key in the Secret under which the password is stored.
-                            secretName:
-                              type: string
-                              description: The name of the Secret containing the password.
-                          required:
-                          - password
-                          - secretName
-                          description: Reference to the `Secret` which holds the password.
-                        readTimeoutSeconds:
-                          type: integer
-                          description: "The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds."
-                        refreshToken:
-                          type: object
-                          properties:
-                            key:
-                              type: string
-                              description: The key under which the secret value is stored in the Kubernetes Secret.
-                            secretName:
-                              type: string
-                              description: The name of the Kubernetes Secret containing the secret value.
-                          required:
-                          - key
-                          - secretName
-                          description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
-                        scope:
-                          type: string
-                          description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
-                        tlsTrustedCertificates:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              certificate:
-                                type: string
-                                description: The name of the file certificate in the Secret.
-                              secretName:
-                                type: string
-                                description: The name of the Secret containing the certificate.
-                            required:
-                            - certificate
-                            - secretName
-                          description: Trusted certificates for TLS connection to the OAuth server.
-                        tokenEndpointUri:
-                          type: string
-                          description: Authorization server token endpoint URI.
-                        type:
-                          type: string
-                          enum:
-                          - tls
-                          - scram-sha-256
-                          - scram-sha-512
-                          - plain
-                          - oauth
-                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
-                        username:
-                          type: string
-                          description: Username used for the authentication.
-                      required:
-                      - type
-                      description: Authentication configuration for connecting to the cluster.
-                    config:
-                      x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                      description: "The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
-                  required:
-                  - alias
-                  - bootstrapServers
-                description: Kafka clusters for mirroring.
-              mirrors:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    sourceCluster:
-                      type: string
-                      description: The alias of the source cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
-                    targetCluster:
-                      type: string
-                      description: The alias of the target cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
-                    sourceConnector:
-                      type: object
-                      properties:
-                        tasksMax:
-                          type: integer
-                          minimum: 1
-                          description: The maximum number of tasks for the Kafka Connector.
-                        config:
-                          x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
-                        pause:
-                          type: boolean
-                          description: Whether the connector should be paused. Defaults to false.
-                      description: The specification of the Kafka MirrorMaker 2.0 source connector.
-                    heartbeatConnector:
-                      type: object
-                      properties:
-                        tasksMax:
-                          type: integer
-                          minimum: 1
-                          description: The maximum number of tasks for the Kafka Connector.
-                        config:
-                          x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
-                        pause:
-                          type: boolean
-                          description: Whether the connector should be paused. Defaults to false.
-                      description: The specification of the Kafka MirrorMaker 2.0 heartbeat connector.
-                    checkpointConnector:
-                      type: object
-                      properties:
-                        tasksMax:
-                          type: integer
-                          minimum: 1
-                          description: The maximum number of tasks for the Kafka Connector.
-                        config:
-                          x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
-                        pause:
-                          type: boolean
-                          description: Whether the connector should be paused. Defaults to false.
-                      description: The specification of the Kafka MirrorMaker 2.0 checkpoint connector.
-                    topicsPattern:
-                      type: string
-                      description: "A regular expression matching the topics to be mirrored, for example, \"topic1\\|topic2\\|topic3\". Comma-separated lists are also supported."
-                    topicsBlacklistPattern:
-                      type: string
-                      description: A regular expression matching the topics to exclude from mirroring. Comma-separated lists are also supported.
-                    topicsExcludePattern:
-                      type: string
-                      description: A regular expression matching the topics to exclude from mirroring. Comma-separated lists are also supported.
-                    groupsPattern:
-                      type: string
-                      description: A regular expression matching the consumer groups to be mirrored. Comma-separated lists are also supported.
-                    groupsBlacklistPattern:
-                      type: string
-                      description: A regular expression matching the consumer groups to exclude from mirroring. Comma-separated lists are also supported.
-                    groupsExcludePattern:
-                      type: string
-                      description: A regular expression matching the consumer groups to exclude from mirroring. Comma-separated lists are also supported.
-                  required:
-                  - sourceCluster
-                  - targetCluster
-                description: Configuration of the MirrorMaker 2.0 connectors.
-              resources:
-                type: object
-                properties:
-                  limits:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                  requests:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                description: The maximum limits for CPU and memory resources and the requested initial resources.
-              livenessProbe:
-                type: object
-                properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                  initialDelaySeconds:
-                    type: integer
-                    minimum: 0
-                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                  periodSeconds:
-                    type: integer
-                    minimum: 1
-                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                  successThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
-                    type: integer
-                    minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                description: Pod liveness checking.
-              readinessProbe:
-                type: object
-                properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                  initialDelaySeconds:
-                    type: integer
-                    minimum: 0
-                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                  periodSeconds:
-                    type: integer
-                    minimum: 1
-                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                  successThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
-                    type: integer
-                    minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                description: Pod readiness checking.
-              jvmOptions:
-                type: object
-                properties:
-                  "-XX":
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                    description: A map of -XX options to the JVM.
-                  "-Xms":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xms option to to the JVM.
-                  "-Xmx":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xmx option to to the JVM.
-                  gcLoggingEnabled:
-                    type: boolean
-                    description: Specifies whether the Garbage Collection logging is enabled. The default is false.
-                  javaSystemProperties:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                          description: The system property name.
-                        value:
-                          type: string
-                          description: The system property value.
-                    description: A map of additional system properties which will be passed using the `-D` option to the JVM.
-                description: JVM Options for pods.
-              jmxOptions:
-                type: object
-                properties:
-                  authentication:
-                    type: object
-                    properties:
-                      type:
-                        type: string
-                        enum:
-                        - password
-                        description: Authentication type. Currently the only supported types are `password`.`password` type creates a username and protected port with no TLS.
-                    required:
-                    - type
-                    description: Authentication configuration for connecting to the JMX port.
-                description: JMX Options.
-              logging:
-                type: object
-                properties:
-                  loggers:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                    description: A Map from logger name to logger level.
-                  type:
-                    type: string
-                    enum:
-                    - inline
-                    - external
-                    description: "Logging type, must be either 'inline' or 'external'."
-                  valueFrom:
-                    type: object
-                    properties:
-                      configMapKeyRef:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        description: Reference to the key in the ConfigMap containing the configuration.
-                    description: '`ConfigMap` entry where the logging configuration is stored. '
-                required:
-                - type
-                description: Logging configuration for Kafka Connect.
-              clientRackInitImage:
-                type: string
-                description: The image of the init container used for initializing the `client.rack`.
-              rack:
-                type: object
-                properties:
-                  topologyKey:
-                    type: string
-                    example: topology.kubernetes.io/zone
-                    description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
-                required:
-                - topologyKey
-                description: Configuration of the node label which will be used as the `client.rack` consumer configuration.
-              tracing:
-                type: object
-                properties:
-                  type:
-                    type: string
-                    enum:
-                    - jaeger
-                    - opentelemetry
-                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
-                required:
-                - type
-                description: The configuration of tracing in Kafka Connect.
-              template:
-                type: object
-                properties:
-                  deployment:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                      deploymentStrategy:
-                        type: string
-                        enum:
-                        - RollingUpdate
-                        - Recreate
-                        description: DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
-                    description: Template for Kafka Connect `Deployment`.
-                  pod:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                      imagePullSecrets:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                        description: "List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored."
-                      securityContext:
-                        type: object
-                        properties:
-                          fsGroup:
-                            type: integer
-                          fsGroupChangePolicy:
-                            type: string
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          supplementalGroups:
-                            type: array
-                            items:
-                              type: integer
-                          sysctls:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Configures pod-level security attributes and common container settings.
-                      terminationGracePeriodSeconds:
-                        type: integer
-                        minimum: 0
-                        description: "The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds."
-                      affinity:
-                        type: object
-                        properties:
-                          nodeAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    preference:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchFields:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: object
-                                properties:
-                                  nodeSelectorTerms:
-                                    type: array
-                                    items:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchFields:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                          podAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    podAffinityTerm:
-                                      type: object
-                                      properties:
-                                        labelSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaceSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaces:
-                                          type: array
-                                          items:
-                                            type: string
-                                        topologyKey:
-                                          type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    labelSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaceSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaces:
-                                      type: array
-                                      items:
-                                        type: string
-                                    topologyKey:
-                                      type: string
-                          podAntiAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    podAffinityTerm:
-                                      type: object
-                                      properties:
-                                        labelSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaceSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaces:
-                                          type: array
-                                          items:
-                                            type: string
-                                        topologyKey:
-                                          type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    labelSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaceSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaces:
-                                      type: array
-                                      items:
-                                        type: string
-                                    topologyKey:
-                                      type: string
-                        description: The pod's affinity rules.
-                      tolerations:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            effect:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            tolerationSeconds:
-                              type: integer
-                            value:
-                              type: string
-                        description: The pod's tolerations.
-                      priorityClassName:
-                        type: string
-                        description: "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}."
-                      schedulerName:
-                        type: string
-                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                      hostAliases:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            hostnames:
-                              type: array
-                              items:
-                                type: string
-                            ip:
-                              type: string
-                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                      tmpDirSizeLimit:
-                        type: string
-                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                      enableServiceLinks:
-                        type: boolean
-                        description: Indicates whether information about services should be injected into Pod's environment variables.
-                      topologySpreadConstraints:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            labelSelector:
-                              type: object
-                              properties:
-                                matchExpressions:
-                                  type: array
-                                  items:
-                                    type: object
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        type: array
-                                        items:
-                                          type: string
-                                matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                            matchLabelKeys:
-                              type: array
-                              items:
-                                type: string
-                            maxSkew:
-                              type: integer
-                            minDomains:
-                              type: integer
-                            nodeAffinityPolicy:
-                              type: string
-                            nodeTaintsPolicy:
-                              type: string
-                            topologyKey:
-                              type: string
-                            whenUnsatisfiable:
-                              type: string
-                        description: The pod's topology spread constraints.
-                    description: Template for Kafka Connect `Pods`.
-                  apiService:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                      ipFamilyPolicy:
-                        type: string
-                        enum:
-                        - SingleStack
-                        - PreferDualStack
-                        - RequireDualStack
-                        description: "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer."
-                      ipFamilies:
-                        type: array
-                        items:
-                          type: string
-                          enum:
-                          - IPv4
-                          - IPv6
-                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer."
-                    description: Template for Kafka Connect API `Service`.
-                  connectContainer:
-                    type: object
-                    properties:
-                      env:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: The environment variable key.
-                            value:
-                              type: string
-                              description: The environment variable value.
-                        description: Environment variables which should be applied to the container.
-                      securityContext:
-                        type: object
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            type: object
-                            properties:
-                              add:
-                                type: array
-                                items:
-                                  type: string
-                              drop:
-                                type: array
-                                items:
-                                  type: string
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Security context for the container.
-                    description: Template for the Kafka Connect container.
-                  initContainer:
-                    type: object
-                    properties:
-                      env:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: The environment variable key.
-                            value:
-                              type: string
-                              description: The environment variable value.
-                        description: Environment variables which should be applied to the container.
-                      securityContext:
-                        type: object
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            type: object
-                            properties:
-                              add:
-                                type: array
-                                items:
-                                  type: string
-                              drop:
-                                type: array
-                                items:
-                                  type: string
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Security context for the container.
-                    description: Template for the Kafka init container.
-                  podDisruptionBudget:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
-                      maxUnavailable:
-                        type: integer
-                        minimum: 0
-                        description: "Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1."
-                    description: Template for Kafka Connect `PodDisruptionBudget`.
-                  serviceAccount:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                    description: Template for the Kafka Connect service account.
-                  clusterRoleBinding:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                    description: Template for the Kafka Connect ClusterRoleBinding.
-                  buildPod:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                      imagePullSecrets:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                        description: "List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored."
-                      securityContext:
-                        type: object
-                        properties:
-                          fsGroup:
-                            type: integer
-                          fsGroupChangePolicy:
-                            type: string
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          supplementalGroups:
-                            type: array
-                            items:
-                              type: integer
-                          sysctls:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Configures pod-level security attributes and common container settings.
-                      terminationGracePeriodSeconds:
-                        type: integer
-                        minimum: 0
-                        description: "The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds."
-                      affinity:
-                        type: object
-                        properties:
-                          nodeAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    preference:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchFields:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: object
-                                properties:
-                                  nodeSelectorTerms:
-                                    type: array
-                                    items:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchFields:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                          podAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    podAffinityTerm:
-                                      type: object
-                                      properties:
-                                        labelSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaceSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaces:
-                                          type: array
-                                          items:
-                                            type: string
-                                        topologyKey:
-                                          type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    labelSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaceSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaces:
-                                      type: array
-                                      items:
-                                        type: string
-                                    topologyKey:
-                                      type: string
-                          podAntiAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    podAffinityTerm:
-                                      type: object
-                                      properties:
-                                        labelSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaceSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaces:
-                                          type: array
-                                          items:
-                                            type: string
-                                        topologyKey:
-                                          type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    labelSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaceSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaces:
-                                      type: array
-                                      items:
-                                        type: string
-                                    topologyKey:
-                                      type: string
-                        description: The pod's affinity rules.
-                      tolerations:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            effect:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            tolerationSeconds:
-                              type: integer
-                            value:
-                              type: string
-                        description: The pod's tolerations.
-                      priorityClassName:
-                        type: string
-                        description: "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}."
-                      schedulerName:
-                        type: string
-                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                      hostAliases:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            hostnames:
-                              type: array
-                              items:
-                                type: string
-                            ip:
-                              type: string
-                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                      tmpDirSizeLimit:
-                        type: string
-                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                      enableServiceLinks:
-                        type: boolean
-                        description: Indicates whether information about services should be injected into Pod's environment variables.
-                      topologySpreadConstraints:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            labelSelector:
-                              type: object
-                              properties:
-                                matchExpressions:
-                                  type: array
-                                  items:
-                                    type: object
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        type: array
-                                        items:
-                                          type: string
-                                matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                            matchLabelKeys:
-                              type: array
-                              items:
-                                type: string
-                            maxSkew:
-                              type: integer
-                            minDomains:
-                              type: integer
-                            nodeAffinityPolicy:
-                              type: string
-                            nodeTaintsPolicy:
-                              type: string
-                            topologyKey:
-                              type: string
-                            whenUnsatisfiable:
-                              type: string
-                        description: The pod's topology spread constraints.
-                    description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
-                  buildContainer:
-                    type: object
-                    properties:
-                      env:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: The environment variable key.
-                            value:
-                              type: string
-                              description: The environment variable value.
-                        description: Environment variables which should be applied to the container.
-                      securityContext:
-                        type: object
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            type: object
-                            properties:
-                              add:
-                                type: array
-                                items:
-                                  type: string
-                              drop:
-                                type: array
-                                items:
-                                  type: string
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Security context for the container.
-                    description: Template for the Kafka Connect Build container. The build container is used only on Kubernetes.
-                  buildConfig:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
-                      pullSecret:
-                        type: string
-                        description: Container Registry Secret with the credentials for pulling the base image.
-                    description: Template for the Kafka Connect BuildConfig used to build new container images. The BuildConfig is used only on OpenShift.
-                  buildServiceAccount:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                    description: Template for the Kafka Connect Build service account.
-                  jmxSecret:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                    description: Template for Secret of the Kafka Connect Cluster JMX authentication.
-                description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated."
-              externalConfiguration:
-                type: object
-                properties:
-                  env:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                          description: Name of the environment variable which will be passed to the Kafka Connect pods. The name of the environment variable cannot start with `KAFKA_` or `STRIMZI_`.
-                        valueFrom:
-                          type: object
-                          properties:
-                            configMapKeyRef:
-                              type: object
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              description: Reference to a key in a ConfigMap.
-                            secretKeyRef:
-                              type: object
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              description: Reference to a key in a Secret.
-                          description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
-                      required:
-                      - name
-                      - valueFrom
-                    description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as environment variables.
-                  volumes:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        configMap:
-                          type: object
-                          properties:
-                            defaultMode:
-                              type: integer
-                            items:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    type: integer
-                                  path:
-                                    type: string
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
-                        name:
-                          type: string
-                          description: Name of the volume which will be added to the Kafka Connect pods.
-                        secret:
-                          type: object
-                          properties:
-                            defaultMode:
-                              type: integer
-                            items:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    type: integer
-                                  path:
-                                    type: string
-                            optional:
-                              type: boolean
-                            secretName:
-                              type: string
-                          description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
-                      required:
-                      - name
-                    description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
-                description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
-              metricsConfig:
-                type: object
-                properties:
-                  type:
-                    type: string
-                    enum:
-                    - jmxPrometheusExporter
-                    description: Metrics type. Only 'jmxPrometheusExporter' supported currently.
-                  valueFrom:
-                    type: object
-                    properties:
-                      configMapKeyRef:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        description: Reference to the key in the ConfigMap containing the configuration.
-                    description: "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. For details of the structure of this configuration, see the {JMXExporter}."
-                required:
-                - type
-                - valueFrom
-                description: Metrics configuration.
-            required:
-            - connectCluster
-            description: The specification of the Kafka MirrorMaker 2.0 cluster.
-          status:
-            type: object
-            properties:
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
-                    status:
-                      type: string
-                      description: "The status of the condition, either True, False or Unknown."
-                    lastTransitionTime:
-                      type: string
-                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
-                    reason:
-                      type: string
-                      description: The reason for the condition's last transition (a single word in CamelCase).
-                    message:
-                      type: string
-                      description: Human-readable message indicating details about the condition's last transition.
-                description: List of status conditions.
-              observedGeneration:
-                type: integer
-                description: The generation of the CRD that was last reconciled by the operator.
-              url:
-                type: string
-                description: The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
-              connectorPlugins:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      description: The type of the connector plugin. The available types are `sink` and `source`.
-                    version:
-                      type: string
-                      description: The version of the connector plugin.
-                    class:
-                      type: string
-                      description: The class of the connector plugin.
-                description: The list of connector plugins available in this Kafka Connect deployment.
-              connectors:
-                type: array
-                items:
-                  x-kubernetes-preserve-unknown-fields: true
-                  type: object
-                description: "List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API."
-              labelSelector:
-                type: string
-                description: Label selector for pods providing this resource.
-              replicas:
-                type: integer
-                description: The current number of pods being used to provide this resource.
-            description: The status of the Kafka MirrorMaker 2.0 cluster.
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: strimzi-cluster-operator-leader-election
-  labels:
-    app: strimzi
-subjects:
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: kafka
-roleRef:
-  kind: ClusterRole
-  name: strimzi-cluster-operator-leader-election
-  apiGroup: rbac.authorization.k8s.io
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: kafkaconnectors.kafka.strimzi.io
-  labels:
-    app: strimzi
-    strimzi.io/crd-install: "true"
-spec:
-  group: kafka.strimzi.io
-  names:
-    kind: KafkaConnector
-    listKind: KafkaConnectorList
-    singular: kafkaconnector
-    plural: kafkaconnectors
-    shortNames:
-    - kctr
-    categories:
-    - strimzi
-  scope: Namespaced
-  conversion:
-    strategy: None
-  versions:
-  - name: v1beta2
-    served: true
-    storage: true
-    subresources:
-      status: {}
-      scale:
-        specReplicasPath: .spec.tasksMax
-        statusReplicasPath: .status.tasksMax
-    additionalPrinterColumns:
-    - name: Cluster
-      description: The name of the Kafka Connect cluster this connector belongs to
-      jsonPath: .metadata.labels.strimzi\.io/cluster
-      type: string
-    - name: Connector class
-      description: The class used by this connector
-      jsonPath: .spec.class
-      type: string
-    - name: Max Tasks
-      description: Maximum number of tasks
-      jsonPath: .spec.tasksMax
-      type: integer
-    - name: Ready
-      description: The state of the custom resource
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-      type: string
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              class:
-                type: string
-                description: The Class for the Kafka Connector.
-              tasksMax:
-                type: integer
-                minimum: 1
-                description: The maximum number of tasks for the Kafka Connector.
-              config:
-                x-kubernetes-preserve-unknown-fields: true
-                type: object
-                description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
-              pause:
-                type: boolean
-                description: Whether the connector should be paused. Defaults to false.
-            description: The specification of the Kafka Connector.
-          status:
-            type: object
-            properties:
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
-                    status:
-                      type: string
-                      description: "The status of the condition, either True, False or Unknown."
-                    lastTransitionTime:
-                      type: string
-                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
-                    reason:
-                      type: string
-                      description: The reason for the condition's last transition (a single word in CamelCase).
-                    message:
-                      type: string
-                      description: Human-readable message indicating details about the condition's last transition.
-                description: List of status conditions.
-              observedGeneration:
-                type: integer
-                description: The generation of the CRD that was last reconciled by the operator.
-              connectorStatus:
-                x-kubernetes-preserve-unknown-fields: true
-                type: object
-                description: "The connector status, as reported by the Kafka Connect REST API."
-              tasksMax:
-                type: integer
-                description: The maximum number of tasks for the Kafka Connector.
-              topics:
-                type: array
-                items:
-                  type: string
-                description: The list of topics used by the Kafka Connector.
-            description: The status of the Kafka Connector.
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: kafkabridges.kafka.strimzi.io
-  labels:
-    app: strimzi
-    strimzi.io/crd-install: "true"
-spec:
-  group: kafka.strimzi.io
-  names:
-    kind: KafkaBridge
-    listKind: KafkaBridgeList
-    singular: kafkabridge
-    plural: kafkabridges
-    shortNames:
-    - kb
-    categories:
-    - strimzi
-  scope: Namespaced
-  conversion:
-    strategy: None
-  versions:
-  - name: v1beta2
-    served: true
-    storage: true
-    subresources:
-      status: {}
-      scale:
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.replicas
-        labelSelectorPath: .status.labelSelector
-    additionalPrinterColumns:
-    - name: Desired replicas
-      description: The desired number of Kafka Bridge replicas
-      jsonPath: .spec.replicas
-      type: integer
-    - name: Bootstrap Servers
-      description: The boostrap servers
-      jsonPath: .spec.bootstrapServers
-      type: string
-      priority: 1
-    - name: Ready
-      description: The state of the custom resource
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-      type: string
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              replicas:
-                type: integer
-                minimum: 0
-                description: The number of pods in the `Deployment`.
-              image:
-                type: string
-                description: The docker image for the pods.
-              bootstrapServers:
-                type: string
-                description: A list of host:port pairs for establishing the initial connection to the Kafka cluster.
-              tls:
-                type: object
-                properties:
-                  trustedCertificates:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        certificate:
-                          type: string
-                          description: The name of the file certificate in the Secret.
-                        secretName:
-                          type: string
-                          description: The name of the Secret containing the certificate.
-                      required:
-                      - certificate
-                      - secretName
-                    description: Trusted certificates for TLS connection.
-                description: TLS configuration for connecting Kafka Bridge to the cluster.
-              authentication:
-                type: object
-                properties:
-                  accessToken:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                        description: The key under which the secret value is stored in the Kubernetes Secret.
-                      secretName:
-                        type: string
-                        description: The name of the Kubernetes Secret containing the secret value.
-                    required:
-                    - key
-                    - secretName
-                    description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
-                  accessTokenIsJwt:
-                    type: boolean
-                    description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
-                  audience:
-                    type: string
-                    description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
-                  certificateAndKey:
-                    type: object
-                    properties:
-                      certificate:
-                        type: string
-                        description: The name of the file certificate in the Secret.
-                      key:
-                        type: string
-                        description: The name of the private key in the Secret.
-                      secretName:
-                        type: string
-                        description: The name of the Secret containing the certificate.
-                    required:
-                    - certificate
-                    - key
-                    - secretName
-                    description: Reference to the `Secret` which holds the certificate and private key pair.
-                  clientId:
-                    type: string
-                    description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
-                  clientSecret:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                        description: The key under which the secret value is stored in the Kubernetes Secret.
-                      secretName:
-                        type: string
-                        description: The name of the Kubernetes Secret containing the secret value.
-                    required:
-                    - key
-                    - secretName
-                    description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
-                  connectTimeoutSeconds:
-                    type: integer
-                    description: "The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds."
-                  disableTlsHostnameVerification:
-                    type: boolean
-                    description: Enable or disable TLS hostname verification. Default value is `false`.
-                  enableMetrics:
-                    type: boolean
-                    description: Enable or disable OAuth metrics. Default value is `false`.
-                  maxTokenExpirySeconds:
-                    type: integer
-                    description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
-                  passwordSecret:
-                    type: object
-                    properties:
-                      password:
-                        type: string
-                        description: The name of the key in the Secret under which the password is stored.
-                      secretName:
-                        type: string
-                        description: The name of the Secret containing the password.
-                    required:
-                    - password
-                    - secretName
-                    description: Reference to the `Secret` which holds the password.
-                  readTimeoutSeconds:
-                    type: integer
-                    description: "The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds."
-                  refreshToken:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                        description: The key under which the secret value is stored in the Kubernetes Secret.
-                      secretName:
-                        type: string
-                        description: The name of the Kubernetes Secret containing the secret value.
-                    required:
-                    - key
-                    - secretName
-                    description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
-                  scope:
-                    type: string
-                    description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
-                  tlsTrustedCertificates:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        certificate:
-                          type: string
-                          description: The name of the file certificate in the Secret.
-                        secretName:
-                          type: string
-                          description: The name of the Secret containing the certificate.
-                      required:
-                      - certificate
-                      - secretName
-                    description: Trusted certificates for TLS connection to the OAuth server.
-                  tokenEndpointUri:
-                    type: string
-                    description: Authorization server token endpoint URI.
-                  type:
-                    type: string
-                    enum:
-                    - tls
-                    - scram-sha-256
-                    - scram-sha-512
-                    - plain
-                    - oauth
-                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
-                  username:
-                    type: string
-                    description: Username used for the authentication.
-                required:
-                - type
-                description: Authentication configuration for connecting to the cluster.
-              http:
-                type: object
-                properties:
-                  port:
-                    type: integer
-                    minimum: 1023
-                    description: The port which is the server listening on.
-                  cors:
-                    type: object
-                    properties:
-                      allowedOrigins:
-                        type: array
-                        items:
-                          type: string
-                        description: List of allowed origins. Java regular expressions can be used.
-                      allowedMethods:
-                        type: array
-                        items:
-                          type: string
-                        description: List of allowed HTTP methods.
-                    required:
-                    - allowedOrigins
-                    - allowedMethods
-                    description: CORS configuration for the HTTP Bridge.
-                description: The HTTP related configuration.
-              adminClient:
-                type: object
-                properties:
-                  config:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                    description: The Kafka AdminClient configuration used for AdminClient instances created by the bridge.
-                description: Kafka AdminClient related configuration.
-              consumer:
-                type: object
-                properties:
-                  config:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                    description: "The Kafka consumer configuration used for consumer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
-                description: Kafka consumer related configuration.
-              producer:
-                type: object
-                properties:
-                  config:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                    description: "The Kafka producer configuration used for producer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
-                description: Kafka producer related configuration.
-              resources:
-                type: object
-                properties:
-                  limits:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                  requests:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                description: CPU and memory resources to reserve.
-              jvmOptions:
-                type: object
-                properties:
-                  "-XX":
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                    description: A map of -XX options to the JVM.
-                  "-Xms":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xms option to to the JVM.
-                  "-Xmx":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xmx option to to the JVM.
-                  gcLoggingEnabled:
-                    type: boolean
-                    description: Specifies whether the Garbage Collection logging is enabled. The default is false.
-                  javaSystemProperties:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                          description: The system property name.
-                        value:
-                          type: string
-                          description: The system property value.
-                    description: A map of additional system properties which will be passed using the `-D` option to the JVM.
-                description: '**Currently not supported** JVM Options for pods.'
-              logging:
-                type: object
-                properties:
-                  loggers:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                    description: A Map from logger name to logger level.
-                  type:
-                    type: string
-                    enum:
-                    - inline
-                    - external
-                    description: "Logging type, must be either 'inline' or 'external'."
-                  valueFrom:
-                    type: object
-                    properties:
-                      configMapKeyRef:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        description: Reference to the key in the ConfigMap containing the configuration.
-                    description: '`ConfigMap` entry where the logging configuration is stored. '
-                required:
-                - type
-                description: Logging configuration for Kafka Bridge.
-              clientRackInitImage:
-                type: string
-                description: The image of the init container used for initializing the `client.rack`.
-              rack:
-                type: object
-                properties:
-                  topologyKey:
-                    type: string
-                    example: topology.kubernetes.io/zone
-                    description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
-                required:
-                - topologyKey
-                description: Configuration of the node label which will be used as the client.rack consumer configuration.
-              enableMetrics:
-                type: boolean
-                description: Enable the metrics for the Kafka Bridge. Default is false.
-              livenessProbe:
-                type: object
-                properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                  initialDelaySeconds:
-                    type: integer
-                    minimum: 0
-                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                  periodSeconds:
-                    type: integer
-                    minimum: 1
-                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                  successThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
-                    type: integer
-                    minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                description: Pod liveness checking.
-              readinessProbe:
-                type: object
-                properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                  initialDelaySeconds:
-                    type: integer
-                    minimum: 0
-                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                  periodSeconds:
-                    type: integer
-                    minimum: 1
-                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                  successThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
-                    type: integer
-                    minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                description: Pod readiness checking.
-              template:
-                type: object
-                properties:
-                  deployment:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                      deploymentStrategy:
-                        type: string
-                        enum:
-                        - RollingUpdate
-                        - Recreate
-                        description: DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
-                    description: Template for Kafka Bridge `Deployment`.
-                  pod:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                      imagePullSecrets:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                        description: "List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored."
-                      securityContext:
-                        type: object
-                        properties:
-                          fsGroup:
-                            type: integer
-                          fsGroupChangePolicy:
-                            type: string
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          supplementalGroups:
-                            type: array
-                            items:
-                              type: integer
-                          sysctls:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Configures pod-level security attributes and common container settings.
-                      terminationGracePeriodSeconds:
-                        type: integer
-                        minimum: 0
-                        description: "The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds."
-                      affinity:
-                        type: object
-                        properties:
-                          nodeAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    preference:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchFields:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: object
-                                properties:
-                                  nodeSelectorTerms:
-                                    type: array
-                                    items:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchFields:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                          podAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    podAffinityTerm:
-                                      type: object
-                                      properties:
-                                        labelSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaceSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaces:
-                                          type: array
-                                          items:
-                                            type: string
-                                        topologyKey:
-                                          type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    labelSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaceSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaces:
-                                      type: array
-                                      items:
-                                        type: string
-                                    topologyKey:
-                                      type: string
-                          podAntiAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    podAffinityTerm:
-                                      type: object
-                                      properties:
-                                        labelSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaceSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaces:
-                                          type: array
-                                          items:
-                                            type: string
-                                        topologyKey:
-                                          type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    labelSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaceSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaces:
-                                      type: array
-                                      items:
-                                        type: string
-                                    topologyKey:
-                                      type: string
-                        description: The pod's affinity rules.
-                      tolerations:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            effect:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            tolerationSeconds:
-                              type: integer
-                            value:
-                              type: string
-                        description: The pod's tolerations.
-                      priorityClassName:
-                        type: string
-                        description: "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}."
-                      schedulerName:
-                        type: string
-                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                      hostAliases:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            hostnames:
-                              type: array
-                              items:
-                                type: string
-                            ip:
-                              type: string
-                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                      tmpDirSizeLimit:
-                        type: string
-                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                      enableServiceLinks:
-                        type: boolean
-                        description: Indicates whether information about services should be injected into Pod's environment variables.
-                      topologySpreadConstraints:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            labelSelector:
-                              type: object
-                              properties:
-                                matchExpressions:
-                                  type: array
-                                  items:
-                                    type: object
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        type: array
-                                        items:
-                                          type: string
-                                matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                            matchLabelKeys:
-                              type: array
-                              items:
-                                type: string
-                            maxSkew:
-                              type: integer
-                            minDomains:
-                              type: integer
-                            nodeAffinityPolicy:
-                              type: string
-                            nodeTaintsPolicy:
-                              type: string
-                            topologyKey:
-                              type: string
-                            whenUnsatisfiable:
-                              type: string
-                        description: The pod's topology spread constraints.
-                    description: Template for Kafka Bridge `Pods`.
-                  apiService:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                      ipFamilyPolicy:
-                        type: string
-                        enum:
-                        - SingleStack
-                        - PreferDualStack
-                        - RequireDualStack
-                        description: "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer."
-                      ipFamilies:
-                        type: array
-                        items:
-                          type: string
-                          enum:
-                          - IPv4
-                          - IPv6
-                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer."
-                    description: Template for Kafka Bridge API `Service`.
-                  podDisruptionBudget:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
-                      maxUnavailable:
-                        type: integer
-                        minimum: 0
-                        description: "Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1."
-                    description: Template for Kafka Bridge `PodDisruptionBudget`.
-                  bridgeContainer:
-                    type: object
-                    properties:
-                      env:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: The environment variable key.
-                            value:
-                              type: string
-                              description: The environment variable value.
-                        description: Environment variables which should be applied to the container.
-                      securityContext:
-                        type: object
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            type: object
-                            properties:
-                              add:
-                                type: array
-                                items:
-                                  type: string
-                              drop:
-                                type: array
-                                items:
-                                  type: string
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Security context for the container.
-                    description: Template for the Kafka Bridge container.
-                  serviceAccount:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                    description: Template for the Kafka Bridge service account.
-                  initContainer:
-                    type: object
-                    properties:
-                      env:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: The environment variable key.
-                            value:
-                              type: string
-                              description: The environment variable value.
-                        description: Environment variables which should be applied to the container.
-                      securityContext:
-                        type: object
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            type: object
-                            properties:
-                              add:
-                                type: array
-                                items:
-                                  type: string
-                              drop:
-                                type: array
-                                items:
-                                  type: string
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Security context for the container.
-                    description: Template for the Kafka Bridge init container.
-                description: Template for Kafka Bridge resources. The template allows users to specify how a `Deployment` and `Pod` is generated.
-              tracing:
-                type: object
-                properties:
-                  type:
-                    type: string
-                    enum:
-                    - jaeger
-                    - opentelemetry
-                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
-                required:
-                - type
-                description: The configuration of tracing in Kafka Bridge.
-            required:
-            - bootstrapServers
-            description: The specification of the Kafka Bridge.
-          status:
-            type: object
-            properties:
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
-                    status:
-                      type: string
-                      description: "The status of the condition, either True, False or Unknown."
-                    lastTransitionTime:
-                      type: string
-                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
-                    reason:
-                      type: string
-                      description: The reason for the condition's last transition (a single word in CamelCase).
-                    message:
-                      type: string
-                      description: Human-readable message indicating details about the condition's last transition.
-                description: List of status conditions.
-              observedGeneration:
-                type: integer
-                description: The generation of the CRD that was last reconciled by the operator.
-              url:
-                type: string
-                description: The URL at which external client applications can access the Kafka Bridge.
-              labelSelector:
-                type: string
-                description: Label selector for pods providing this resource.
-              replicas:
-                type: integer
-                description: The current number of pods being used to provide this resource.
-            description: The status of the Kafka Bridge.
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: kafkamirrormakers.kafka.strimzi.io
-  labels:
-    app: strimzi
-    strimzi.io/crd-install: "true"
-spec:
-  group: kafka.strimzi.io
-  names:
-    kind: KafkaMirrorMaker
-    listKind: KafkaMirrorMakerList
-    singular: kafkamirrormaker
-    plural: kafkamirrormakers
-    shortNames:
-    - kmm
-    categories:
-    - strimzi
-  scope: Namespaced
-  conversion:
-    strategy: None
-  versions:
-  - name: v1beta2
-    served: true
-    storage: true
-    subresources:
-      status: {}
-      scale:
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.replicas
-        labelSelectorPath: .status.labelSelector
-    additionalPrinterColumns:
-    - name: Desired replicas
-      description: The desired number of Kafka MirrorMaker replicas
-      jsonPath: .spec.replicas
-      type: integer
-    - name: Consumer Bootstrap Servers
-      description: The boostrap servers for the consumer
-      jsonPath: .spec.consumer.bootstrapServers
-      type: string
-      priority: 1
-    - name: Producer Bootstrap Servers
-      description: The boostrap servers for the producer
-      jsonPath: .spec.producer.bootstrapServers
-      type: string
-      priority: 1
-    - name: Ready
-      description: The state of the custom resource
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-      type: string
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              version:
-                type: string
-                description: "The Kafka MirrorMaker version. Defaults to {DefaultKafkaVersion}. Consult the documentation to understand the process required to upgrade or downgrade the version."
-              replicas:
-                type: integer
-                minimum: 0
-                description: The number of pods in the `Deployment`.
-              image:
-                type: string
-                description: The docker image for the pods.
-              consumer:
-                type: object
-                properties:
-                  numStreams:
-                    type: integer
-                    minimum: 1
-                    description: Specifies the number of consumer stream threads to create.
-                  offsetCommitInterval:
-                    type: integer
-                    description: Specifies the offset auto-commit interval in ms. Default value is 60000.
-                  bootstrapServers:
-                    type: string
-                    description: A list of host:port pairs for establishing the initial connection to the Kafka cluster.
-                  groupId:
-                    type: string
-                    description: A unique string that identifies the consumer group this consumer belongs to.
-                  authentication:
-                    type: object
-                    properties:
-                      accessToken:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                            description: The key under which the secret value is stored in the Kubernetes Secret.
-                          secretName:
-                            type: string
-                            description: The name of the Kubernetes Secret containing the secret value.
-                        required:
-                        - key
-                        - secretName
-                        description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
-                      accessTokenIsJwt:
-                        type: boolean
-                        description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
-                      audience:
-                        type: string
-                        description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
-                      certificateAndKey:
-                        type: object
-                        properties:
-                          certificate:
-                            type: string
-                            description: The name of the file certificate in the Secret.
-                          key:
-                            type: string
-                            description: The name of the private key in the Secret.
-                          secretName:
-                            type: string
-                            description: The name of the Secret containing the certificate.
-                        required:
-                        - certificate
-                        - key
-                        - secretName
-                        description: Reference to the `Secret` which holds the certificate and private key pair.
-                      clientId:
-                        type: string
-                        description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
-                      clientSecret:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                            description: The key under which the secret value is stored in the Kubernetes Secret.
-                          secretName:
-                            type: string
-                            description: The name of the Kubernetes Secret containing the secret value.
-                        required:
-                        - key
-                        - secretName
-                        description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
-                      connectTimeoutSeconds:
-                        type: integer
-                        description: "The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds."
-                      disableTlsHostnameVerification:
-                        type: boolean
-                        description: Enable or disable TLS hostname verification. Default value is `false`.
-                      enableMetrics:
-                        type: boolean
-                        description: Enable or disable OAuth metrics. Default value is `false`.
-                      maxTokenExpirySeconds:
-                        type: integer
-                        description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
-                      passwordSecret:
-                        type: object
-                        properties:
-                          password:
-                            type: string
-                            description: The name of the key in the Secret under which the password is stored.
-                          secretName:
-                            type: string
-                            description: The name of the Secret containing the password.
-                        required:
-                        - password
-                        - secretName
-                        description: Reference to the `Secret` which holds the password.
-                      readTimeoutSeconds:
-                        type: integer
-                        description: "The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds."
-                      refreshToken:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                            description: The key under which the secret value is stored in the Kubernetes Secret.
-                          secretName:
-                            type: string
-                            description: The name of the Kubernetes Secret containing the secret value.
-                        required:
-                        - key
-                        - secretName
-                        description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
-                      scope:
-                        type: string
-                        description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
-                      tlsTrustedCertificates:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            certificate:
-                              type: string
-                              description: The name of the file certificate in the Secret.
-                            secretName:
-                              type: string
-                              description: The name of the Secret containing the certificate.
-                          required:
-                          - certificate
-                          - secretName
-                        description: Trusted certificates for TLS connection to the OAuth server.
-                      tokenEndpointUri:
-                        type: string
-                        description: Authorization server token endpoint URI.
-                      type:
-                        type: string
-                        enum:
-                        - tls
-                        - scram-sha-256
-                        - scram-sha-512
-                        - plain
-                        - oauth
-                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
-                      username:
-                        type: string
-                        description: Username used for the authentication.
-                    required:
-                    - type
-                    description: Authentication configuration for connecting to the cluster.
-                  config:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                    description: "The MirrorMaker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
-                  tls:
-                    type: object
-                    properties:
-                      trustedCertificates:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            certificate:
-                              type: string
-                              description: The name of the file certificate in the Secret.
-                            secretName:
-                              type: string
-                              description: The name of the Secret containing the certificate.
-                          required:
-                          - certificate
-                          - secretName
-                        description: Trusted certificates for TLS connection.
-                    description: TLS configuration for connecting MirrorMaker to the cluster.
-                required:
-                - bootstrapServers
-                - groupId
-                description: Configuration of source cluster.
-              producer:
-                type: object
-                properties:
-                  bootstrapServers:
-                    type: string
-                    description: A list of host:port pairs for establishing the initial connection to the Kafka cluster.
-                  abortOnSendFailure:
-                    type: boolean
-                    description: Flag to set the MirrorMaker to exit on a failed send. Default value is `true`.
-                  authentication:
-                    type: object
-                    properties:
-                      accessToken:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                            description: The key under which the secret value is stored in the Kubernetes Secret.
-                          secretName:
-                            type: string
-                            description: The name of the Kubernetes Secret containing the secret value.
-                        required:
-                        - key
-                        - secretName
-                        description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
-                      accessTokenIsJwt:
-                        type: boolean
-                        description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
-                      audience:
-                        type: string
-                        description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
-                      certificateAndKey:
-                        type: object
-                        properties:
-                          certificate:
-                            type: string
-                            description: The name of the file certificate in the Secret.
-                          key:
-                            type: string
-                            description: The name of the private key in the Secret.
-                          secretName:
-                            type: string
-                            description: The name of the Secret containing the certificate.
-                        required:
-                        - certificate
-                        - key
-                        - secretName
-                        description: Reference to the `Secret` which holds the certificate and private key pair.
-                      clientId:
-                        type: string
-                        description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
-                      clientSecret:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                            description: The key under which the secret value is stored in the Kubernetes Secret.
-                          secretName:
-                            type: string
-                            description: The name of the Kubernetes Secret containing the secret value.
-                        required:
-                        - key
-                        - secretName
-                        description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
-                      connectTimeoutSeconds:
-                        type: integer
-                        description: "The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds."
-                      disableTlsHostnameVerification:
-                        type: boolean
-                        description: Enable or disable TLS hostname verification. Default value is `false`.
-                      enableMetrics:
-                        type: boolean
-                        description: Enable or disable OAuth metrics. Default value is `false`.
-                      maxTokenExpirySeconds:
-                        type: integer
-                        description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
-                      passwordSecret:
-                        type: object
-                        properties:
-                          password:
-                            type: string
-                            description: The name of the key in the Secret under which the password is stored.
-                          secretName:
-                            type: string
-                            description: The name of the Secret containing the password.
-                        required:
-                        - password
-                        - secretName
-                        description: Reference to the `Secret` which holds the password.
-                      readTimeoutSeconds:
-                        type: integer
-                        description: "The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds."
-                      refreshToken:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                            description: The key under which the secret value is stored in the Kubernetes Secret.
-                          secretName:
-                            type: string
-                            description: The name of the Kubernetes Secret containing the secret value.
-                        required:
-                        - key
-                        - secretName
-                        description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
-                      scope:
-                        type: string
-                        description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
-                      tlsTrustedCertificates:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            certificate:
-                              type: string
-                              description: The name of the file certificate in the Secret.
-                            secretName:
-                              type: string
-                              description: The name of the Secret containing the certificate.
-                          required:
-                          - certificate
-                          - secretName
-                        description: Trusted certificates for TLS connection to the OAuth server.
-                      tokenEndpointUri:
-                        type: string
-                        description: Authorization server token endpoint URI.
-                      type:
-                        type: string
-                        enum:
-                        - tls
-                        - scram-sha-256
-                        - scram-sha-512
-                        - plain
-                        - oauth
-                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
-                      username:
-                        type: string
-                        description: Username used for the authentication.
-                    required:
-                    - type
-                    description: Authentication configuration for connecting to the cluster.
-                  config:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                    description: "The MirrorMaker producer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
-                  tls:
-                    type: object
-                    properties:
-                      trustedCertificates:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            certificate:
-                              type: string
-                              description: The name of the file certificate in the Secret.
-                            secretName:
-                              type: string
-                              description: The name of the Secret containing the certificate.
-                          required:
-                          - certificate
-                          - secretName
-                        description: Trusted certificates for TLS connection.
-                    description: TLS configuration for connecting MirrorMaker to the cluster.
-                required:
-                - bootstrapServers
-                description: Configuration of target cluster.
-              resources:
-                type: object
-                properties:
-                  limits:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                  requests:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                description: CPU and memory resources to reserve.
-              whitelist:
-                type: string
-                description: "List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the expression `A\\|B`. Or, as a special case, you can mirror all topics using the regular expression `*`. You can also specify multiple regular expressions separated by commas."
-              include:
-                type: string
-                description: "List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the expression `A\\|B`. Or, as a special case, you can mirror all topics using the regular expression `*`. You can also specify multiple regular expressions separated by commas."
-              jvmOptions:
-                type: object
-                properties:
-                  "-XX":
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                    description: A map of -XX options to the JVM.
-                  "-Xms":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xms option to to the JVM.
-                  "-Xmx":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xmx option to to the JVM.
-                  gcLoggingEnabled:
-                    type: boolean
-                    description: Specifies whether the Garbage Collection logging is enabled. The default is false.
-                  javaSystemProperties:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                          description: The system property name.
-                        value:
-                          type: string
-                          description: The system property value.
-                    description: A map of additional system properties which will be passed using the `-D` option to the JVM.
-                description: JVM Options for pods.
-              logging:
-                type: object
-                properties:
-                  loggers:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                    description: A Map from logger name to logger level.
-                  type:
-                    type: string
-                    enum:
-                    - inline
-                    - external
-                    description: "Logging type, must be either 'inline' or 'external'."
-                  valueFrom:
-                    type: object
-                    properties:
-                      configMapKeyRef:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        description: Reference to the key in the ConfigMap containing the configuration.
-                    description: '`ConfigMap` entry where the logging configuration is stored. '
-                required:
-                - type
-                description: Logging configuration for MirrorMaker.
-              metricsConfig:
-                type: object
-                properties:
-                  type:
-                    type: string
-                    enum:
-                    - jmxPrometheusExporter
-                    description: Metrics type. Only 'jmxPrometheusExporter' supported currently.
-                  valueFrom:
-                    type: object
-                    properties:
-                      configMapKeyRef:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        description: Reference to the key in the ConfigMap containing the configuration.
-                    description: "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. For details of the structure of this configuration, see the {JMXExporter}."
-                required:
-                - type
-                - valueFrom
-                description: Metrics configuration.
-              tracing:
-                type: object
-                properties:
-                  type:
-                    type: string
-                    enum:
-                    - jaeger
-                    - opentelemetry
-                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
-                required:
-                - type
-                description: The configuration of tracing in Kafka MirrorMaker.
-              template:
-                type: object
-                properties:
-                  deployment:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                      deploymentStrategy:
-                        type: string
-                        enum:
-                        - RollingUpdate
-                        - Recreate
-                        description: DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
-                    description: Template for Kafka MirrorMaker `Deployment`.
-                  pod:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                      imagePullSecrets:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                        description: "List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored."
-                      securityContext:
-                        type: object
-                        properties:
-                          fsGroup:
-                            type: integer
-                          fsGroupChangePolicy:
-                            type: string
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          supplementalGroups:
-                            type: array
-                            items:
-                              type: integer
-                          sysctls:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Configures pod-level security attributes and common container settings.
-                      terminationGracePeriodSeconds:
-                        type: integer
-                        minimum: 0
-                        description: "The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds."
-                      affinity:
-                        type: object
-                        properties:
-                          nodeAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    preference:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchFields:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: object
-                                properties:
-                                  nodeSelectorTerms:
-                                    type: array
-                                    items:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchFields:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                          podAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    podAffinityTerm:
-                                      type: object
-                                      properties:
-                                        labelSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaceSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaces:
-                                          type: array
-                                          items:
-                                            type: string
-                                        topologyKey:
-                                          type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    labelSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaceSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaces:
-                                      type: array
-                                      items:
-                                        type: string
-                                    topologyKey:
-                                      type: string
-                          podAntiAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    podAffinityTerm:
-                                      type: object
-                                      properties:
-                                        labelSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaceSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaces:
-                                          type: array
-                                          items:
-                                            type: string
-                                        topologyKey:
-                                          type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    labelSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaceSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaces:
-                                      type: array
-                                      items:
-                                        type: string
-                                    topologyKey:
-                                      type: string
-                        description: The pod's affinity rules.
-                      tolerations:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            effect:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            tolerationSeconds:
-                              type: integer
-                            value:
-                              type: string
-                        description: The pod's tolerations.
-                      priorityClassName:
-                        type: string
-                        description: "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}."
-                      schedulerName:
-                        type: string
-                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                      hostAliases:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            hostnames:
-                              type: array
-                              items:
-                                type: string
-                            ip:
-                              type: string
-                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                      tmpDirSizeLimit:
-                        type: string
-                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                      enableServiceLinks:
-                        type: boolean
-                        description: Indicates whether information about services should be injected into Pod's environment variables.
-                      topologySpreadConstraints:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            labelSelector:
-                              type: object
-                              properties:
-                                matchExpressions:
-                                  type: array
-                                  items:
-                                    type: object
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        type: array
-                                        items:
-                                          type: string
-                                matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                            matchLabelKeys:
-                              type: array
-                              items:
-                                type: string
-                            maxSkew:
-                              type: integer
-                            minDomains:
-                              type: integer
-                            nodeAffinityPolicy:
-                              type: string
-                            nodeTaintsPolicy:
-                              type: string
-                            topologyKey:
-                              type: string
-                            whenUnsatisfiable:
-                              type: string
-                        description: The pod's topology spread constraints.
-                    description: Template for Kafka MirrorMaker `Pods`.
-                  podDisruptionBudget:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
-                      maxUnavailable:
-                        type: integer
-                        minimum: 0
-                        description: "Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1."
-                    description: Template for Kafka MirrorMaker `PodDisruptionBudget`.
-                  mirrorMakerContainer:
-                    type: object
-                    properties:
-                      env:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: The environment variable key.
-                            value:
-                              type: string
-                              description: The environment variable value.
-                        description: Environment variables which should be applied to the container.
-                      securityContext:
-                        type: object
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            type: object
-                            properties:
-                              add:
-                                type: array
-                                items:
-                                  type: string
-                              drop:
-                                type: array
-                                items:
-                                  type: string
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Security context for the container.
-                    description: Template for Kafka MirrorMaker container.
-                  serviceAccount:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                    description: Template for the Kafka MirrorMaker service account.
-                description: "Template to specify how Kafka MirrorMaker resources, `Deployments` and `Pods`, are generated."
-              livenessProbe:
-                type: object
-                properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                  initialDelaySeconds:
-                    type: integer
-                    minimum: 0
-                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                  periodSeconds:
-                    type: integer
-                    minimum: 1
-                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                  successThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
-                    type: integer
-                    minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                description: Pod liveness checking.
-              readinessProbe:
-                type: object
-                properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                  initialDelaySeconds:
-                    type: integer
-                    minimum: 0
-                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                  periodSeconds:
-                    type: integer
-                    minimum: 1
-                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                  successThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
-                    type: integer
-                    minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                description: Pod readiness checking.
-            oneOf:
-            - properties:
-                include: {}
-              required:
-              - include
-            - properties:
-                whitelist: {}
-              required:
-              - whitelist
-            required:
-            - replicas
-            - consumer
-            - producer
-            description: The specification of Kafka MirrorMaker.
-          status:
-            type: object
-            properties:
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
-                    status:
-                      type: string
-                      description: "The status of the condition, either True, False or Unknown."
-                    lastTransitionTime:
-                      type: string
-                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
-                    reason:
-                      type: string
-                      description: The reason for the condition's last transition (a single word in CamelCase).
-                    message:
-                      type: string
-                      description: Human-readable message indicating details about the condition's last transition.
-                description: List of status conditions.
-              observedGeneration:
-                type: integer
-                description: The generation of the CRD that was last reconciled by the operator.
-              labelSelector:
-                type: string
-                description: Label selector for pods providing this resource.
-              replicas:
-                type: integer
-                description: The current number of pods being used to provide this resource.
-            description: The status of Kafka MirrorMaker.
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: strimzi-cluster-operator-kafka-broker-delegation
-  labels:
-    app: strimzi
-# The Kafka broker cluster role must be bound to the cluster operator service account so that it can delegate the cluster role to the Kafka brokers.
-# This must be done to avoid escalating privileges which would be blocked by Kubernetes.
-subjects:
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: kafka
-roleRef:
-  kind: ClusterRole
-  name: strimzi-kafka-broker
-  apiGroup: rbac.authorization.k8s.io
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: strimzi-cluster-operator-watched
-  labels:
-    app: strimzi
-subjects:
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: kafka
-roleRef:
-  kind: ClusterRole
-  name: strimzi-cluster-operator-watched
-  apiGroup: rbac.authorization.k8s.io
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: strimzi-cluster-operator
-  labels:
-    app: strimzi
-subjects:
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: kafka
-roleRef:
-  kind: ClusterRole
-  name: strimzi-cluster-operator-global
-  apiGroup: rbac.authorization.k8s.io
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: kafkatopics.kafka.strimzi.io
-  labels:
-    app: strimzi
-    strimzi.io/crd-install: "true"
-spec:
-  group: kafka.strimzi.io
-  names:
-    kind: KafkaTopic
-    listKind: KafkaTopicList
-    singular: kafkatopic
-    plural: kafkatopics
-    shortNames:
-    - kt
-    categories:
-    - strimzi
-  scope: Namespaced
-  conversion:
-    strategy: None
-  versions:
-  - name: v1beta2
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    additionalPrinterColumns:
-    - name: Cluster
-      description: The name of the Kafka cluster this topic belongs to
-      jsonPath: .metadata.labels.strimzi\.io/cluster
-      type: string
-    - name: Partitions
-      description: The desired number of partitions in the topic
-      jsonPath: .spec.partitions
-      type: integer
-    - name: Replication factor
-      description: The desired number of replicas of each partition
-      jsonPath: .spec.replicas
-      type: integer
-    - name: Ready
-      description: The state of the custom resource
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-      type: string
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              partitions:
-                type: integer
-                minimum: 1
-                description: "The number of partitions the topic should have. This cannot be decreased after topic creation. It can be increased after topic creation, but it is important to understand the consequences that has, especially for topics with semantic partitioning. When absent this will default to the broker configuration for `num.partitions`."
-              replicas:
-                type: integer
-                minimum: 1
-                maximum: 32767
-                description: The number of replicas the topic should have. When absent this will default to the broker configuration for `default.replication.factor`.
-              config:
-                x-kubernetes-preserve-unknown-fields: true
-                type: object
-                description: The topic configuration.
-              topicName:
-                type: string
-                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
-            description: The specification of the topic.
-          status:
-            type: object
-            properties:
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
-                    status:
-                      type: string
-                      description: "The status of the condition, either True, False or Unknown."
-                    lastTransitionTime:
-                      type: string
-                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
-                    reason:
-                      type: string
-                      description: The reason for the condition's last transition (a single word in CamelCase).
-                    message:
-                      type: string
-                      description: Human-readable message indicating details about the condition's last transition.
-                description: List of status conditions.
-              observedGeneration:
-                type: integer
-                description: The generation of the CRD that was last reconciled by the operator.
-              topicName:
-                type: string
-                description: Topic name.
-            description: The status of the topic.
-  - name: v1beta1
-    served: true
-    storage: false
-    subresources:
-      status: {}
-    additionalPrinterColumns:
-    - name: Cluster
-      description: The name of the Kafka cluster this topic belongs to
-      jsonPath: .metadata.labels.strimzi\.io/cluster
-      type: string
-    - name: Partitions
-      description: The desired number of partitions in the topic
-      jsonPath: .spec.partitions
-      type: integer
-    - name: Replication factor
-      description: The desired number of replicas of each partition
-      jsonPath: .spec.replicas
-      type: integer
-    - name: Ready
-      description: The state of the custom resource
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-      type: string
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              partitions:
-                type: integer
-                minimum: 1
-                description: "The number of partitions the topic should have. This cannot be decreased after topic creation. It can be increased after topic creation, but it is important to understand the consequences that has, especially for topics with semantic partitioning. When absent this will default to the broker configuration for `num.partitions`."
-              replicas:
-                type: integer
-                minimum: 1
-                maximum: 32767
-                description: The number of replicas the topic should have. When absent this will default to the broker configuration for `default.replication.factor`.
-              config:
-                x-kubernetes-preserve-unknown-fields: true
-                type: object
-                description: The topic configuration.
-              topicName:
-                type: string
-                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
-            description: The specification of the topic.
-          status:
-            type: object
-            properties:
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
-                    status:
-                      type: string
-                      description: "The status of the condition, either True, False or Unknown."
-                    lastTransitionTime:
-                      type: string
-                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
-                    reason:
-                      type: string
-                      description: The reason for the condition's last transition (a single word in CamelCase).
-                    message:
-                      type: string
-                      description: Human-readable message indicating details about the condition's last transition.
-                description: List of status conditions.
-              observedGeneration:
-                type: integer
-                description: The generation of the CRD that was last reconciled by the operator.
-              topicName:
-                type: string
-                description: Topic name.
-            description: The status of the topic.
-  - name: v1alpha1
-    served: true
-    storage: false
-    subresources:
-      status: {}
-    additionalPrinterColumns:
-    - name: Cluster
-      description: The name of the Kafka cluster this topic belongs to
-      jsonPath: .metadata.labels.strimzi\.io/cluster
-      type: string
-    - name: Partitions
-      description: The desired number of partitions in the topic
-      jsonPath: .spec.partitions
-      type: integer
-    - name: Replication factor
-      description: The desired number of replicas of each partition
-      jsonPath: .spec.replicas
-      type: integer
-    - name: Ready
-      description: The state of the custom resource
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-      type: string
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              partitions:
-                type: integer
-                minimum: 1
-                description: "The number of partitions the topic should have. This cannot be decreased after topic creation. It can be increased after topic creation, but it is important to understand the consequences that has, especially for topics with semantic partitioning. When absent this will default to the broker configuration for `num.partitions`."
-              replicas:
-                type: integer
-                minimum: 1
-                maximum: 32767
-                description: The number of replicas the topic should have. When absent this will default to the broker configuration for `default.replication.factor`.
-              config:
-                x-kubernetes-preserve-unknown-fields: true
-                type: object
-                description: The topic configuration.
-              topicName:
-                type: string
-                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
-            description: The specification of the topic.
-          status:
-            type: object
-            properties:
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
-                    status:
-                      type: string
-                      description: "The status of the condition, either True, False or Unknown."
-                    lastTransitionTime:
-                      type: string
-                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
-                    reason:
-                      type: string
-                      description: The reason for the condition's last transition (a single word in CamelCase).
-                    message:
-                      type: string
-                      description: Human-readable message indicating details about the condition's last transition.
-                description: List of status conditions.
-              observedGeneration:
-                type: integer
-                description: The generation of the CRD that was last reconciled by the operator.
-              topicName:
-                type: string
-                description: Topic name.
-            description: The status of the topic.
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: kafkaconnects.kafka.strimzi.io
-  labels:
-    app: strimzi
-    strimzi.io/crd-install: "true"
-spec:
-  group: kafka.strimzi.io
-  names:
-    kind: KafkaConnect
-    listKind: KafkaConnectList
-    singular: kafkaconnect
-    plural: kafkaconnects
-    shortNames:
-    - kc
-    categories:
-    - strimzi
-  scope: Namespaced
-  conversion:
-    strategy: None
-  versions:
-  - name: v1beta2
-    served: true
-    storage: true
-    subresources:
-      status: {}
-      scale:
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.replicas
-        labelSelectorPath: .status.labelSelector
-    additionalPrinterColumns:
-    - name: Desired replicas
-      description: The desired number of Kafka Connect replicas
-      jsonPath: .spec.replicas
-      type: integer
-    - name: Ready
-      description: The state of the custom resource
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-      type: string
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              version:
-                type: string
-                description: "The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version."
-              replicas:
-                type: integer
-                description: The number of pods in the Kafka Connect group.
-              image:
-                type: string
-                description: The docker image for the pods.
-              bootstrapServers:
-                type: string
-                description: Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:_<port>_ pairs.
-              tls:
-                type: object
-                properties:
-                  trustedCertificates:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        certificate:
-                          type: string
-                          description: The name of the file certificate in the Secret.
-                        secretName:
-                          type: string
-                          description: The name of the Secret containing the certificate.
-                      required:
-                      - certificate
-                      - secretName
-                    description: Trusted certificates for TLS connection.
-                description: TLS configuration.
-              authentication:
-                type: object
-                properties:
-                  accessToken:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                        description: The key under which the secret value is stored in the Kubernetes Secret.
-                      secretName:
-                        type: string
-                        description: The name of the Kubernetes Secret containing the secret value.
-                    required:
-                    - key
-                    - secretName
-                    description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
-                  accessTokenIsJwt:
-                    type: boolean
-                    description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
-                  audience:
-                    type: string
-                    description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
-                  certificateAndKey:
-                    type: object
-                    properties:
-                      certificate:
-                        type: string
-                        description: The name of the file certificate in the Secret.
-                      key:
-                        type: string
-                        description: The name of the private key in the Secret.
-                      secretName:
-                        type: string
-                        description: The name of the Secret containing the certificate.
-                    required:
-                    - certificate
-                    - key
-                    - secretName
-                    description: Reference to the `Secret` which holds the certificate and private key pair.
-                  clientId:
-                    type: string
-                    description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
-                  clientSecret:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                        description: The key under which the secret value is stored in the Kubernetes Secret.
-                      secretName:
-                        type: string
-                        description: The name of the Kubernetes Secret containing the secret value.
-                    required:
-                    - key
-                    - secretName
-                    description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
-                  connectTimeoutSeconds:
-                    type: integer
-                    description: "The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds."
-                  disableTlsHostnameVerification:
-                    type: boolean
-                    description: Enable or disable TLS hostname verification. Default value is `false`.
-                  enableMetrics:
-                    type: boolean
-                    description: Enable or disable OAuth metrics. Default value is `false`.
-                  maxTokenExpirySeconds:
-                    type: integer
-                    description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
-                  passwordSecret:
-                    type: object
-                    properties:
-                      password:
-                        type: string
-                        description: The name of the key in the Secret under which the password is stored.
-                      secretName:
-                        type: string
-                        description: The name of the Secret containing the password.
-                    required:
-                    - password
-                    - secretName
-                    description: Reference to the `Secret` which holds the password.
-                  readTimeoutSeconds:
-                    type: integer
-                    description: "The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds."
-                  refreshToken:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                        description: The key under which the secret value is stored in the Kubernetes Secret.
-                      secretName:
-                        type: string
-                        description: The name of the Kubernetes Secret containing the secret value.
-                    required:
-                    - key
-                    - secretName
-                    description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
-                  scope:
-                    type: string
-                    description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
-                  tlsTrustedCertificates:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        certificate:
-                          type: string
-                          description: The name of the file certificate in the Secret.
-                        secretName:
-                          type: string
-                          description: The name of the Secret containing the certificate.
-                      required:
-                      - certificate
-                      - secretName
-                    description: Trusted certificates for TLS connection to the OAuth server.
-                  tokenEndpointUri:
-                    type: string
-                    description: Authorization server token endpoint URI.
-                  type:
-                    type: string
-                    enum:
-                    - tls
-                    - scram-sha-256
-                    - scram-sha-512
-                    - plain
-                    - oauth
-                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
-                  username:
-                    type: string
-                    description: Username used for the authentication.
-                required:
-                - type
-                description: Authentication configuration for Kafka Connect.
-              config:
-                x-kubernetes-preserve-unknown-fields: true
-                type: object
-                description: "The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
-              resources:
-                type: object
-                properties:
-                  limits:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                  requests:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                description: The maximum limits for CPU and memory resources and the requested initial resources.
-              livenessProbe:
-                type: object
-                properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                  initialDelaySeconds:
-                    type: integer
-                    minimum: 0
-                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                  periodSeconds:
-                    type: integer
-                    minimum: 1
-                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                  successThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
-                    type: integer
-                    minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                description: Pod liveness checking.
-              readinessProbe:
-                type: object
-                properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                  initialDelaySeconds:
-                    type: integer
-                    minimum: 0
-                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                  periodSeconds:
-                    type: integer
-                    minimum: 1
-                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                  successThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
-                    type: integer
-                    minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                description: Pod readiness checking.
-              jvmOptions:
-                type: object
-                properties:
-                  "-XX":
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                    description: A map of -XX options to the JVM.
-                  "-Xms":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xms option to to the JVM.
-                  "-Xmx":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xmx option to to the JVM.
-                  gcLoggingEnabled:
-                    type: boolean
-                    description: Specifies whether the Garbage Collection logging is enabled. The default is false.
-                  javaSystemProperties:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                          description: The system property name.
-                        value:
-                          type: string
-                          description: The system property value.
-                    description: A map of additional system properties which will be passed using the `-D` option to the JVM.
-                description: JVM Options for pods.
-              jmxOptions:
-                type: object
-                properties:
-                  authentication:
-                    type: object
-                    properties:
-                      type:
-                        type: string
-                        enum:
-                        - password
-                        description: Authentication type. Currently the only supported types are `password`.`password` type creates a username and protected port with no TLS.
-                    required:
-                    - type
-                    description: Authentication configuration for connecting to the JMX port.
-                description: JMX Options.
-              logging:
-                type: object
-                properties:
-                  loggers:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                    description: A Map from logger name to logger level.
-                  type:
-                    type: string
-                    enum:
-                    - inline
-                    - external
-                    description: "Logging type, must be either 'inline' or 'external'."
-                  valueFrom:
-                    type: object
-                    properties:
-                      configMapKeyRef:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        description: Reference to the key in the ConfigMap containing the configuration.
-                    description: '`ConfigMap` entry where the logging configuration is stored. '
-                required:
-                - type
-                description: Logging configuration for Kafka Connect.
-              clientRackInitImage:
-                type: string
-                description: The image of the init container used for initializing the `client.rack`.
-              rack:
-                type: object
-                properties:
-                  topologyKey:
-                    type: string
-                    example: topology.kubernetes.io/zone
-                    description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
-                required:
-                - topologyKey
-                description: Configuration of the node label which will be used as the `client.rack` consumer configuration.
-              tracing:
-                type: object
-                properties:
-                  type:
-                    type: string
-                    enum:
-                    - jaeger
-                    - opentelemetry
-                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
-                required:
-                - type
-                description: The configuration of tracing in Kafka Connect.
-              template:
-                type: object
-                properties:
-                  deployment:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                      deploymentStrategy:
-                        type: string
-                        enum:
-                        - RollingUpdate
-                        - Recreate
-                        description: DeploymentStrategy which will be used for this Deployment. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
-                    description: Template for Kafka Connect `Deployment`.
-                  pod:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                      imagePullSecrets:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                        description: "List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored."
-                      securityContext:
-                        type: object
-                        properties:
-                          fsGroup:
-                            type: integer
-                          fsGroupChangePolicy:
-                            type: string
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          supplementalGroups:
-                            type: array
-                            items:
-                              type: integer
-                          sysctls:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Configures pod-level security attributes and common container settings.
-                      terminationGracePeriodSeconds:
-                        type: integer
-                        minimum: 0
-                        description: "The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds."
-                      affinity:
-                        type: object
-                        properties:
-                          nodeAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    preference:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchFields:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: object
-                                properties:
-                                  nodeSelectorTerms:
-                                    type: array
-                                    items:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchFields:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                          podAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    podAffinityTerm:
-                                      type: object
-                                      properties:
-                                        labelSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaceSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaces:
-                                          type: array
-                                          items:
-                                            type: string
-                                        topologyKey:
-                                          type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    labelSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaceSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaces:
-                                      type: array
-                                      items:
-                                        type: string
-                                    topologyKey:
-                                      type: string
-                          podAntiAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    podAffinityTerm:
-                                      type: object
-                                      properties:
-                                        labelSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaceSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaces:
-                                          type: array
-                                          items:
-                                            type: string
-                                        topologyKey:
-                                          type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    labelSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaceSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaces:
-                                      type: array
-                                      items:
-                                        type: string
-                                    topologyKey:
-                                      type: string
-                        description: The pod's affinity rules.
-                      tolerations:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            effect:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            tolerationSeconds:
-                              type: integer
-                            value:
-                              type: string
-                        description: The pod's tolerations.
-                      priorityClassName:
-                        type: string
-                        description: "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}."
-                      schedulerName:
-                        type: string
-                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                      hostAliases:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            hostnames:
-                              type: array
-                              items:
-                                type: string
-                            ip:
-                              type: string
-                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                      tmpDirSizeLimit:
-                        type: string
-                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                      enableServiceLinks:
-                        type: boolean
-                        description: Indicates whether information about services should be injected into Pod's environment variables.
-                      topologySpreadConstraints:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            labelSelector:
-                              type: object
-                              properties:
-                                matchExpressions:
-                                  type: array
-                                  items:
-                                    type: object
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        type: array
-                                        items:
-                                          type: string
-                                matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                            matchLabelKeys:
-                              type: array
-                              items:
-                                type: string
-                            maxSkew:
-                              type: integer
-                            minDomains:
-                              type: integer
-                            nodeAffinityPolicy:
-                              type: string
-                            nodeTaintsPolicy:
-                              type: string
-                            topologyKey:
-                              type: string
-                            whenUnsatisfiable:
-                              type: string
-                        description: The pod's topology spread constraints.
-                    description: Template for Kafka Connect `Pods`.
-                  apiService:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                      ipFamilyPolicy:
-                        type: string
-                        enum:
-                        - SingleStack
-                        - PreferDualStack
-                        - RequireDualStack
-                        description: "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer."
-                      ipFamilies:
-                        type: array
-                        items:
-                          type: string
-                          enum:
-                          - IPv4
-                          - IPv6
-                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer."
-                    description: Template for Kafka Connect API `Service`.
-                  connectContainer:
-                    type: object
-                    properties:
-                      env:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: The environment variable key.
-                            value:
-                              type: string
-                              description: The environment variable value.
-                        description: Environment variables which should be applied to the container.
-                      securityContext:
-                        type: object
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            type: object
-                            properties:
-                              add:
-                                type: array
-                                items:
-                                  type: string
-                              drop:
-                                type: array
-                                items:
-                                  type: string
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Security context for the container.
-                    description: Template for the Kafka Connect container.
-                  initContainer:
-                    type: object
-                    properties:
-                      env:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: The environment variable key.
-                            value:
-                              type: string
-                              description: The environment variable value.
-                        description: Environment variables which should be applied to the container.
-                      securityContext:
-                        type: object
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            type: object
-                            properties:
-                              add:
-                                type: array
-                                items:
-                                  type: string
-                              drop:
-                                type: array
-                                items:
-                                  type: string
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Security context for the container.
-                    description: Template for the Kafka init container.
-                  podDisruptionBudget:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
-                      maxUnavailable:
-                        type: integer
-                        minimum: 0
-                        description: "Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1."
-                    description: Template for Kafka Connect `PodDisruptionBudget`.
-                  serviceAccount:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                    description: Template for the Kafka Connect service account.
-                  clusterRoleBinding:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                    description: Template for the Kafka Connect ClusterRoleBinding.
-                  buildPod:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                      imagePullSecrets:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                        description: "List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored."
-                      securityContext:
-                        type: object
-                        properties:
-                          fsGroup:
-                            type: integer
-                          fsGroupChangePolicy:
-                            type: string
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          supplementalGroups:
-                            type: array
-                            items:
-                              type: integer
-                          sysctls:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Configures pod-level security attributes and common container settings.
-                      terminationGracePeriodSeconds:
-                        type: integer
-                        minimum: 0
-                        description: "The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds."
-                      affinity:
-                        type: object
-                        properties:
-                          nodeAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    preference:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchFields:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: object
-                                properties:
-                                  nodeSelectorTerms:
-                                    type: array
-                                    items:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchFields:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                          podAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    podAffinityTerm:
-                                      type: object
-                                      properties:
-                                        labelSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaceSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaces:
-                                          type: array
-                                          items:
-                                            type: string
-                                        topologyKey:
-                                          type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    labelSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaceSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaces:
-                                      type: array
-                                      items:
-                                        type: string
-                                    topologyKey:
-                                      type: string
-                          podAntiAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    podAffinityTerm:
-                                      type: object
-                                      properties:
-                                        labelSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaceSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
-                                              type: object
-                                        namespaces:
-                                          type: array
-                                          items:
-                                            type: string
-                                        topologyKey:
-                                          type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    labelSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaceSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                          type: object
-                                    namespaces:
-                                      type: array
-                                      items:
-                                        type: string
-                                    topologyKey:
-                                      type: string
-                        description: The pod's affinity rules.
-                      tolerations:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            effect:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            tolerationSeconds:
-                              type: integer
-                            value:
-                              type: string
-                        description: The pod's tolerations.
-                      priorityClassName:
-                        type: string
-                        description: "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}."
-                      schedulerName:
-                        type: string
-                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                      hostAliases:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            hostnames:
-                              type: array
-                              items:
-                                type: string
-                            ip:
-                              type: string
-                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                      tmpDirSizeLimit:
-                        type: string
-                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                      enableServiceLinks:
-                        type: boolean
-                        description: Indicates whether information about services should be injected into Pod's environment variables.
-                      topologySpreadConstraints:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            labelSelector:
-                              type: object
-                              properties:
-                                matchExpressions:
-                                  type: array
-                                  items:
-                                    type: object
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        type: array
-                                        items:
-                                          type: string
-                                matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                            matchLabelKeys:
-                              type: array
-                              items:
-                                type: string
-                            maxSkew:
-                              type: integer
-                            minDomains:
-                              type: integer
-                            nodeAffinityPolicy:
-                              type: string
-                            nodeTaintsPolicy:
-                              type: string
-                            topologyKey:
-                              type: string
-                            whenUnsatisfiable:
-                              type: string
-                        description: The pod's topology spread constraints.
-                    description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
-                  buildContainer:
-                    type: object
-                    properties:
-                      env:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: The environment variable key.
-                            value:
-                              type: string
-                              description: The environment variable value.
-                        description: Environment variables which should be applied to the container.
-                      securityContext:
-                        type: object
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            type: object
-                            properties:
-                              add:
-                                type: array
-                                items:
-                                  type: string
-                              drop:
-                                type: array
-                                items:
-                                  type: string
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Security context for the container.
-                    description: Template for the Kafka Connect Build container. The build container is used only on Kubernetes.
-                  buildConfig:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
-                      pullSecret:
-                        type: string
-                        description: Container Registry Secret with the credentials for pulling the base image.
-                    description: Template for the Kafka Connect BuildConfig used to build new container images. The BuildConfig is used only on OpenShift.
-                  buildServiceAccount:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                    description: Template for the Kafka Connect Build service account.
-                  jmxSecret:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                          annotations:
-                            x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
-                        description: Metadata applied to the resource.
-                    description: Template for Secret of the Kafka Connect Cluster JMX authentication.
-                description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated."
-              externalConfiguration:
-                type: object
-                properties:
-                  env:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                          description: Name of the environment variable which will be passed to the Kafka Connect pods. The name of the environment variable cannot start with `KAFKA_` or `STRIMZI_`.
-                        valueFrom:
-                          type: object
-                          properties:
-                            configMapKeyRef:
-                              type: object
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              description: Reference to a key in a ConfigMap.
-                            secretKeyRef:
-                              type: object
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              description: Reference to a key in a Secret.
-                          description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
-                      required:
-                      - name
-                      - valueFrom
-                    description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as environment variables.
-                  volumes:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        configMap:
-                          type: object
-                          properties:
-                            defaultMode:
-                              type: integer
-                            items:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    type: integer
-                                  path:
-                                    type: string
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
-                        name:
-                          type: string
-                          description: Name of the volume which will be added to the Kafka Connect pods.
-                        secret:
-                          type: object
-                          properties:
-                            defaultMode:
-                              type: integer
-                            items:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    type: integer
-                                  path:
-                                    type: string
-                            optional:
-                              type: boolean
-                            secretName:
-                              type: string
-                          description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
-                      required:
-                      - name
-                    description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
-                description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
-              build:
-                type: object
-                properties:
-                  output:
-                    type: object
-                    properties:
-                      additionalKanikoOptions:
-                        type: array
-                        items:
-                          type: string
-                        description: "Configures additional options which will be passed to the Kaniko executor when building the new Connect image. Allowed options are: --customPlatform, --insecure, --insecure-pull, --insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run. These options will be used only on Kubernetes where the Kaniko executor is used. They will be ignored on OpenShift. The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. Changing this field does not trigger new build of the Kafka Connect image."
-                      image:
-                        type: string
-                        description: The name of the image which will be built. Required.
-                      pushSecret:
-                        type: string
-                        description: Container Registry Secret with the credentials for pushing the newly built image.
-                      type:
-                        type: string
-                        enum:
-                        - docker
-                        - imagestream
-                        description: Output type. Must be either `docker` for pushing the newly build image to Docker compatible registry or `imagestream` for pushing the image to OpenShift ImageStream. Required.
-                    required:
-                    - image
-                    - type
-                    description: Configures where should the newly built image be stored. Required.
-                  resources:
-                    type: object
-                    properties:
-                      limits:
-                        x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      requests:
-                        x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                    description: CPU and memory resources to reserve for the build.
-                  plugins:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                          pattern: "^[a-z0-9][-_a-z0-9]*[a-z0-9]$"
-                          description: "The unique name of the connector plugin. Will be used to generate the path where the connector artifacts will be stored. The name has to be unique within the KafkaConnect resource. The name has to follow the following pattern: `^[a-z][-_a-z0-9]*[a-z]$`. Required."
-                        artifacts:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              artifact:
-                                type: string
-                                description: Maven artifact id. Applicable to the `maven` artifact type only.
-                              fileName:
-                                type: string
-                                description: Name under which the artifact will be stored.
-                              group:
-                                type: string
-                                description: Maven group id. Applicable to the `maven` artifact type only.
-                              insecure:
-                                type: boolean
-                                description: "By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure."
-                              repository:
-                                type: string
-                                description: Maven repository to download the artifact from. Applicable to the `maven` artifact type only.
-                              sha512sum:
-                                type: string
-                                description: "SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type. "
-                              type:
-                                type: string
-                                enum:
-                                - jar
-                                - tgz
-                                - zip
-                                - maven
-                                - other
-                                description: "Artifact type. Currently, the supported artifact types are `tgz`, `jar`, `zip`, `other` and `maven`."
-                              url:
-                                type: string
-                                pattern: "^(https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]$"
-                                description: "URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required for `jar`, `zip`, `tgz` and `other` artifacts. Not applicable to the `maven` artifact type."
-                              version:
-                                type: string
-                                description: Maven version number. Applicable to the `maven` artifact type only.
-                            required:
-                            - type
-                          description: List of artifacts which belong to this connector plugin. Required.
-                      required:
-                      - name
-                      - artifacts
-                    description: List of connector plugins which should be added to the Kafka Connect. Required.
-                required:
-                - output
-                - plugins
-                description: Configures how the Connect container image should be built. Optional.
-              metricsConfig:
-                type: object
-                properties:
-                  type:
-                    type: string
-                    enum:
-                    - jmxPrometheusExporter
-                    description: Metrics type. Only 'jmxPrometheusExporter' supported currently.
-                  valueFrom:
-                    type: object
-                    properties:
-                      configMapKeyRef:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        description: Reference to the key in the ConfigMap containing the configuration.
-                    description: "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. For details of the structure of this configuration, see the {JMXExporter}."
-                required:
-                - type
-                - valueFrom
-                description: Metrics configuration.
-            required:
-            - bootstrapServers
-            description: The specification of the Kafka Connect cluster.
-          status:
-            type: object
-            properties:
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
-                    status:
-                      type: string
-                      description: "The status of the condition, either True, False or Unknown."
-                    lastTransitionTime:
-                      type: string
-                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
-                    reason:
-                      type: string
-                      description: The reason for the condition's last transition (a single word in CamelCase).
-                    message:
-                      type: string
-                      description: Human-readable message indicating details about the condition's last transition.
-                description: List of status conditions.
-              observedGeneration:
-                type: integer
-                description: The generation of the CRD that was last reconciled by the operator.
-              url:
-                type: string
-                description: The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
-              connectorPlugins:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      description: The type of the connector plugin. The available types are `sink` and `source`.
-                    version:
-                      type: string
-                      description: The version of the connector plugin.
-                    class:
-                      type: string
-                      description: The class of the connector plugin.
-                description: The list of connector plugins available in this Kafka Connect deployment.
-              labelSelector:
-                type: string
-                description: Label selector for pods providing this resource.
-              replicas:
-                type: integer
-                description: The current number of pods being used to provide this resource.
-            description: The status of the Kafka Connect cluster.
-
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: strimzi-cluster-operator
-  labels:
-    app: strimzi
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      name: strimzi-cluster-operator
-      strimzi.io/kind: cluster-operator
-  template:
-    metadata:
-      labels:
-        name: strimzi-cluster-operator
-        strimzi.io/kind: cluster-operator
-    spec:
-      serviceAccountName: strimzi-cluster-operator
-      volumes:
-        - name: strimzi-tmp
-          emptyDir:
-            medium: Memory
-            sizeLimit: 1Mi
-        - name: co-config-volume
-          configMap:
-            name: strimzi-cluster-operator
-      containers:
-        - name: strimzi-cluster-operator
-          image: quay.io/strimzi/operator:0.32.0
-          ports:
-            - containerPort: 8080
-              name: http
-          args:
-            - /opt/strimzi/bin/cluster_operator_run.sh
-          volumeMounts:
-            - name: strimzi-tmp
-              mountPath: /tmp
-            - name: co-config-volume
-              mountPath: /opt/strimzi/custom-config/
-          env:
-            - name: STRIMZI_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
-              value: "120000"
-            - name: STRIMZI_OPERATION_TIMEOUT_MS
-              value: "300000"
-            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
-              value: quay.io/strimzi/kafka:0.32.0-kafka-3.3.1
-            - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
-              value: quay.io/strimzi/kafka:0.32.0-kafka-3.3.1
-            - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
-              value: quay.io/strimzi/kafka:0.32.0-kafka-3.3.1
-            - name: STRIMZI_KAFKA_IMAGES
-              value: |
-                3.2.0=quay.io/strimzi/kafka:0.32.0-kafka-3.2.0
-                3.2.1=quay.io/strimzi/kafka:0.32.0-kafka-3.2.1
-                3.2.3=quay.io/strimzi/kafka:0.32.0-kafka-3.2.3
-                3.3.1=quay.io/strimzi/kafka:0.32.0-kafka-3.3.1
-            - name: STRIMZI_KAFKA_CONNECT_IMAGES
-              value: |
-                3.2.0=quay.io/strimzi/kafka:0.32.0-kafka-3.2.0
-                3.2.1=quay.io/strimzi/kafka:0.32.0-kafka-3.2.1
-                3.2.3=quay.io/strimzi/kafka:0.32.0-kafka-3.2.3
-                3.3.1=quay.io/strimzi/kafka:0.32.0-kafka-3.3.1
-            - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
-              value: |
-                3.2.0=quay.io/strimzi/kafka:0.32.0-kafka-3.2.0
-                3.2.1=quay.io/strimzi/kafka:0.32.0-kafka-3.2.1
-                3.2.3=quay.io/strimzi/kafka:0.32.0-kafka-3.2.3
-                3.3.1=quay.io/strimzi/kafka:0.32.0-kafka-3.3.1
-            - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
-              value: |
-                3.2.0=quay.io/strimzi/kafka:0.32.0-kafka-3.2.0
-                3.2.1=quay.io/strimzi/kafka:0.32.0-kafka-3.2.1
-                3.2.3=quay.io/strimzi/kafka:0.32.0-kafka-3.2.3
-                3.3.1=quay.io/strimzi/kafka:0.32.0-kafka-3.3.1
-            - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
-              value: quay.io/strimzi/operator:0.32.0
-            - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
-              value: quay.io/strimzi/operator:0.32.0
-            - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
-              value: quay.io/strimzi/operator:0.32.0
-            - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
-              value: quay.io/strimzi/kafka-bridge:0.22.3
-            - name: STRIMZI_DEFAULT_JMXTRANS_IMAGE
-              value: quay.io/strimzi/jmxtrans:0.32.0
-            - name: STRIMZI_DEFAULT_KANIKO_EXECUTOR_IMAGE
-              value: quay.io/strimzi/kaniko-executor:0.32.0
-            - name: STRIMZI_DEFAULT_MAVEN_BUILDER
-              value: quay.io/strimzi/maven-builder:0.32.0
-            - name: STRIMZI_OPERATOR_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: STRIMZI_FEATURE_GATES
-              value: ""
-            - name: STRIMZI_LEADER_ELECTION_ENABLED
-              value: "true"
-            - name: STRIMZI_LEADER_ELECTION_LEASE_NAME
-              value: "strimzi-cluster-operator"
-            - name: STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: STRIMZI_LEADER_ELECTION_IDENTITY
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-          livenessProbe:
-            httpGet:
-              path: /healthy
-              port: http
-            initialDelaySeconds: 10
-            periodSeconds: 30
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: http
-            initialDelaySeconds: 10
-            periodSeconds: 30
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 384Mi
-            requests:
-              cpu: 200m
-              memory: 384Mi
-  strategy:
-    type: Recreate
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: strimzi-cluster-operator-global
-  labels:
-    app: strimzi
-rules:
-  - apiGroups:
-      - "rbac.authorization.k8s.io"
-    resources:
-      # The cluster operator needs to create and manage cluster role bindings in the case of an install where a user
-      # has specified they want their cluster role bindings generated
-      - clusterrolebindings
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-  - apiGroups:
-      - storage.k8s.io
-    resources:
-      # The cluster operator requires "get" permissions to view storage class details
-      # This is because only a persistent volume of a supported storage class type can be resized
-      - storageclasses
-    verbs:
-      - get
-  - apiGroups:
-      - ""
-    resources:
-      # The cluster operator requires "list" permissions to view all nodes in a cluster
-      # The listing is used to determine the node addresses when NodePort access is configured
-      # These addresses are then exposed in the custom resource states
-      - nodes
-    verbs:
-      - list
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: kafkarebalances.kafka.strimzi.io
-  labels:
-    app: strimzi
-    strimzi.io/crd-install: "true"
-spec:
-  group: kafka.strimzi.io
-  names:
-    kind: KafkaRebalance
-    listKind: KafkaRebalanceList
-    singular: kafkarebalance
-    plural: kafkarebalances
-    shortNames:
-    - kr
-    categories:
-    - strimzi
-  scope: Namespaced
-  conversion:
-    strategy: None
-  versions:
-  - name: v1beta2
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    additionalPrinterColumns:
-    - name: Cluster
-      description: The name of the Kafka cluster this resource rebalances
-      jsonPath: .metadata.labels.strimzi\.io/cluster
-      type: string
-    - name: PendingProposal
-      description: A proposal has been requested from Cruise Control
-      jsonPath: ".status.conditions[?(@.type==\"PendingProposal\")].status"
-      type: string
-    - name: ProposalReady
-      description: A proposal is ready and waiting for approval
-      jsonPath: ".status.conditions[?(@.type==\"ProposalReady\")].status"
-      type: string
-    - name: Rebalancing
-      description: Cruise Control is doing the rebalance
-      jsonPath: ".status.conditions[?(@.type==\"Rebalancing\")].status"
-      type: string
-    - name: Ready
-      description: The rebalance is complete
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-      type: string
-    - name: NotReady
-      description: There is an error on the custom resource
-      jsonPath: ".status.conditions[?(@.type==\"NotReady\")].status"
-      type: string
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              mode:
-                type: string
-                enum:
-                - full
-                - add-brokers
-                - remove-brokers
-                description: "Mode to run the rebalancing. The supported modes are `full`, `add-brokers`, `remove-brokers`.\nIf not specified, the `full` mode is used by default. \n\n* `full` mode runs the rebalancing across all the brokers in the cluster.\n* `add-brokers` mode can be used after scaling up the cluster to move some replicas to the newly added brokers.\n* `remove-brokers` mode can be used before scaling down the cluster to move replicas out of the brokers to be removed.\n"
-              brokers:
-                type: array
-                items:
-                  type: integer
-                description: The list of newly added brokers in case of scaling up or the ones to be removed in case of scaling down to use for rebalancing. This list can be used only with rebalancing mode `add-brokers` and `removed-brokers`. It is ignored with `full` mode.
-              goals:
-                type: array
-                items:
-                  type: string
-                description: "A list of goals, ordered by decreasing priority, to use for generating and executing the rebalance proposal. The supported goals are available at https://github.com/linkedin/cruise-control#goals. If an empty goals list is provided, the goals declared in the default.goals Cruise Control configuration parameter are used."
-              skipHardGoalCheck:
-                type: boolean
-                description: Whether to allow the hard goals specified in the Kafka CR to be skipped in optimization proposal generation. This can be useful when some of those hard goals are preventing a balance solution being found. Default is false.
-              rebalanceDisk:
-                type: boolean
-                description: "Enables intra-broker disk balancing, which balances disk space utilization between disks on the same broker. Only applies to Kafka deployments that use JBOD storage with multiple disks. When enabled, inter-broker balancing is disabled. Default is false."
-              excludedTopics:
-                type: string
-                description: A regular expression where any matching topics will be excluded from the calculation of optimization proposals. This expression will be parsed by the java.util.regex.Pattern class; for more information on the supported format consult the documentation for that class.
-              concurrentPartitionMovementsPerBroker:
-                type: integer
-                minimum: 0
-                description: The upper bound of ongoing partition replica movements going into/out of each broker. Default is 5.
-              concurrentIntraBrokerPartitionMovements:
-                type: integer
-                minimum: 0
-                description: The upper bound of ongoing partition replica movements between disks within each broker. Default is 2.
-              concurrentLeaderMovements:
-                type: integer
-                minimum: 0
-                description: The upper bound of ongoing partition leadership movements. Default is 1000.
-              replicationThrottle:
-                type: integer
-                minimum: 0
-                description: "The upper bound, in bytes per second, on the bandwidth used to move replicas. There is no limit by default."
-              replicaMovementStrategies:
-                type: array
-                items:
-                  type: string
-                description: "A list of strategy class names used to determine the execution order for the replica movements in the generated optimization proposal. By default BaseReplicaMovementStrategy is used, which will execute the replica movements in the order that they were generated."
-            description: The specification of the Kafka rebalance.
-          status:
-            type: object
-            properties:
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
-                    status:
-                      type: string
-                      description: "The status of the condition, either True, False or Unknown."
-                    lastTransitionTime:
-                      type: string
-                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
-                    reason:
-                      type: string
-                      description: The reason for the condition's last transition (a single word in CamelCase).
-                    message:
-                      type: string
-                      description: Human-readable message indicating details about the condition's last transition.
-                description: List of status conditions.
-              observedGeneration:
-                type: integer
-                description: The generation of the CRD that was last reconciled by the operator.
-              sessionId:
-                type: string
-                description: The session identifier for requests to Cruise Control pertaining to this KafkaRebalance resource. This is used by the Kafka Rebalance operator to track the status of ongoing rebalancing operations.
-              optimizationResult:
-                x-kubernetes-preserve-unknown-fields: true
-                type: object
-                description: A JSON object describing the optimization result.
-            description: The status of the Kafka rebalance.
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: strimzi-cluster-operator-leader-election
-  labels:
-    app: strimzi
-rules:
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      # The cluster operator needs to access and manage leases for leader election
-      # The "create" verb cannot be used with "resourceNames"
-      - leases
-    verbs:
-      - create
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      # The cluster operator needs to access and manage leases for leader election
-      - leases
-    resourceNames:
-      # The default RBAC files give the operator only access to the Lease resource names strimzi-cluster-operator
-      # If you want to use another resource name or resource namespace, you have to configure the RBAC resources accordingly
-      - strimzi-cluster-operator
-    verbs:
-      - get
-      - list
-      - watch
-      - delete
-      - patch
-      - update
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: strimzi-cluster-operator-kafka-client-delegation
-  labels:
-    app: strimzi
-# The Kafka clients cluster role must be bound to the cluster operator service account so that it can delegate the
-# cluster role to the Kafka clients using it for consuming from closest replica.
-# This must be done to avoid escalating privileges which would be blocked by Kubernetes.
-subjects:
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: kafka
-roleRef:
-  kind: ClusterRole
-  name: strimzi-kafka-client
-  apiGroup: rbac.authorization.k8s.io
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -7914,332 +685,6 @@ spec:
             description: The status of the Kafka User.
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: strimzi-cluster-operator-watched
-  labels:
-    app: strimzi
-rules:
-  # Resources in this role are being watched by the operator. When operator is deployed as cluster-wide, these permissions
-  # need to be granted to the operator on a cluster wide level as well, even if the operands will be deployed only in
-  # few of the namespaces in given cluster. This is required to set up the Kubernetes watches and informers.
-  # Note: The rights included in this role might change in the future
-  - apiGroups:
-      - ""
-    resources:
-      # The cluster operator needs to access and delete pods, this is to allow it to monitor pod health and coordinate rolling updates
-      - pods
-    verbs:
-      - watch
-      - list
-  - apiGroups:
-      - "kafka.strimzi.io"
-    resources:
-      # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
-      - kafkas
-      - kafkas/status
-      # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
-      - kafkaconnects
-      - kafkaconnects/status
-      # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
-      - kafkaconnectors
-      - kafkaconnectors/status
-      # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
-      - kafkamirrormakers
-      - kafkamirrormakers/status
-      # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
-      - kafkabridges
-      - kafkabridges/status
-      # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
-      - kafkamirrormaker2s
-      - kafkamirrormaker2s/status
-      # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
-      - kafkarebalances
-      - kafkarebalances/status
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-  - apiGroups:
-      - "core.strimzi.io"
-    resources:
-      # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
-      - strimzipodsets
-      - strimzipodsets/status
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: strimzi-kafka-client
-  labels:
-    app: strimzi
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      # The Kafka clients (Connect, Mirror Maker, etc.) require "get" permissions to view the node they are on
-      # This information is used to generate a Rack ID (client.rack option) that is used for consuming from the closest
-      # replicas when enabled
-      - nodes
-    verbs:
-      - get
-
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: strimzi-cluster-operator
-  labels:
-    app: strimzi
-data:
-  log4j2.properties: |
-    name = COConfig
-    monitorInterval = 30
-
-    appender.console.type = Console
-    appender.console.name = STDOUT
-    appender.console.layout.type = PatternLayout
-    appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
-
-    rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
-    rootLogger.appenderRefs = stdout
-    rootLogger.appenderRef.console.ref = STDOUT
-
-    # Kafka AdminClient logging is a bit noisy at INFO level
-    logger.kafka.name = org.apache.kafka
-    logger.kafka.level = WARN
-
-    # Zookeeper is very verbose even on INFO level -> We set it to WARN by default
-    logger.zookeepertrustmanager.name = org.apache.zookeeper
-    logger.zookeepertrustmanager.level = WARN
-
-    # Keeps separate level for Netty logging -> to not be changed by the root logger
-    logger.netty.name = io.netty
-    logger.netty.level = INFO
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: strimzi-entity-operator
-  labels:
-    app: strimzi
-rules:
-  - apiGroups:
-      - "kafka.strimzi.io"
-    resources:
-      # The entity operator runs the KafkaTopic assembly operator, which needs to access and manage KafkaTopic resources
-      - kafkatopics
-      - kafkatopics/status
-      # The entity operator runs the KafkaUser assembly operator, which needs to access and manage KafkaUser resources
-      - kafkausers
-      - kafkausers/status
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - patch
-      - update
-      - delete
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      # The entity operator needs to be able to create events
-      - create
-  - apiGroups:
-      - ""
-    resources:
-      # The entity operator user-operator needs to access and manage secrets to store generated credentials
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - patch
-      - update
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: strimzi-cluster-operator-entity-operator-delegation
-  labels:
-    app: strimzi
-# The Entity Operator cluster role must be bound to the cluster operator service account so that it can delegate the cluster role to the Entity Operator.
-# This must be done to avoid escalating privileges which would be blocked by Kubernetes.
-subjects:
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: kafka
-roleRef:
-  kind: ClusterRole
-  name: strimzi-entity-operator
-  apiGroup: rbac.authorization.k8s.io
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: strimzi-cluster-operator
-  labels:
-    app: strimzi
-subjects:
-  - kind: ServiceAccount
-    name: strimzi-cluster-operator
-    namespace: kafka
-roleRef:
-  kind: ClusterRole
-  name: strimzi-cluster-operator-namespaced
-  apiGroup: rbac.authorization.k8s.io
-
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: strimzi-cluster-operator
-  labels:
-    app: strimzi
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: strimzipodsets.core.strimzi.io
-  labels:
-    app: strimzi
-    strimzi.io/crd-install: "true"
-spec:
-  group: core.strimzi.io
-  names:
-    kind: StrimziPodSet
-    listKind: StrimziPodSetList
-    singular: strimzipodset
-    plural: strimzipodsets
-    shortNames:
-    - sps
-    categories:
-    - strimzi
-  scope: Namespaced
-  conversion:
-    strategy: None
-  versions:
-  - name: v1beta2
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    additionalPrinterColumns:
-    - name: Pods
-      description: Number of pods managed by the StrimziPodSet
-      jsonPath: .status.pods
-      type: integer
-    - name: Ready Pods
-      description: Number of ready pods managed by the StrimziPodSet
-      jsonPath: .status.readyPods
-      type: integer
-    - name: Current Pods
-      description: Number of up-to-date pods managed by the StrimziPodSet
-      jsonPath: .status.currentPods
-      type: integer
-    - name: Age
-      description: Age of the StrimziPodSet
-      jsonPath: .metadata.creationTimestamp
-      type: date
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              selector:
-                type: object
-                properties:
-                  matchExpressions:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          type: string
-                        operator:
-                          type: string
-                        values:
-                          type: array
-                          items:
-                            type: string
-                  matchLabels:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                description: "Selector is a label query which matches all the pods managed by this `StrimziPodSet`. Only `matchLabels` is supported. If `matchExpressions` is set, it will be ignored."
-              pods:
-                type: array
-                items:
-                  x-kubernetes-preserve-unknown-fields: true
-                  type: object
-                description: The Pods managed by this StrimziPodSet.
-            required:
-            - selector
-            - pods
-            description: The specification of the StrimziPodSet.
-          status:
-            type: object
-            properties:
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
-                    status:
-                      type: string
-                      description: "The status of the condition, either True, False or Unknown."
-                    lastTransitionTime:
-                      type: string
-                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
-                    reason:
-                      type: string
-                      description: The reason for the condition's last transition (a single word in CamelCase).
-                    message:
-                      type: string
-                      description: Human-readable message indicating details about the condition's last transition.
-                description: List of status conditions.
-              observedGeneration:
-                type: integer
-                description: The generation of the CRD that was last reconciled by the operator.
-              pods:
-                type: integer
-                description: Number of pods managed by the StrimziPodSet controller.
-              readyPods:
-                type: integer
-                description: Number of pods managed by the StrimziPodSet controller that are ready.
-              currentPods:
-                type: integer
-                description: Number of pods managed by the StrimziPodSet controller that have the current revision.
-            description: The status of the StrimziPodSet.
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -8327,7 +772,7 @@ spec:
                           - nodeport
                           - ingress
                           - cluster-ip
-                          description: "Type of the listener. Currently the supported types are `internal`, `route`, `loadbalancer`, `nodeport` and `ingress`. \n\n* `internal` type exposes Kafka internally only within the Kubernetes cluster.\n* `route` type uses OpenShift Routes to expose Kafka.\n* `loadbalancer` type uses LoadBalancer type services to expose Kafka.\n* `nodeport` type uses NodePort type services to expose Kafka.\n* `ingress` type uses Kubernetes Nginx Ingress to expose Kafka with TLS passthrought.\n* `cluster-ip` type uses ClusterIP service with per broker port number. Can be exposed over Nginx Ingress Controller with tcp port config.\n"
+                          description: "Type of the listener. Currently the supported types are `internal`, `route`, `loadbalancer`, `nodeport` and `ingress`. \n\n* `internal` type exposes Kafka internally only within the Kubernetes cluster.\n* `route` type uses OpenShift Routes to expose Kafka.\n* `loadbalancer` type uses LoadBalancer type services to expose Kafka.\n* `nodeport` type uses NodePort type services to expose Kafka.\n* `ingress` type uses Kubernetes Nginx Ingress to expose Kafka with TLS passthrough.\n* `cluster-ip` type uses a per-broker `ClusterIP` service.\n"
                         tls:
                           type: boolean
                           description: Enables TLS encryption on the listener. This is a required property.
@@ -8605,7 +1050,7 @@ spec:
                               description: Whether to create the bootstrap service or not. The bootstrap service is created by default (if not specified differently). This field can be used with the `loadBalancer` type listener.
                             class:
                               type: string
-                              description: "Configures the `Ingress` class that defines which `Ingress` controller will be used. This field can be used only with `ingress` type listener. If not specified, the default Ingress controller will be used."
+                              description: "Configures a specific class for `Ingress` and `LoadBalancer` that defines which controller will be used. This field can only be used with `ingress` and `loadbalancer` type listeners. If not specified, the default controller is used. For an `ingress` listener, set the `ingressClassName` property in the `Ingress` resources. For a `loadbalancer` listener, set the `loadBalancerClass` property  in the `Service` resources."
                             finalizers:
                               type: array
                               items:
@@ -8637,7 +1082,7 @@ spec:
                                 This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
                             useServiceDnsDomain:
                               type: boolean
-                              description: "Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` type listener."
+                              description: "Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip` type listeners."
                           description: Additional listener configuration.
                         networkPolicyPeers:
                           type: array
@@ -8701,7 +1146,7 @@ spec:
                   config:
                     x-kubernetes-preserve-unknown-fields: true
                     type: object
-                    description: "Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers,node.id, process.roles, controller. (with the exception of: zookeeper.connection.timeout.ms, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, sasl.server.max.receive.size,cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms,cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms,cruise.control.metrics.topic.min.insync.replicas,controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms)."
+                    description: "Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers,node.id, process.roles, controller. (with the exception of: zookeeper.connection.timeout.ms, sasl.server.max.receive.size,ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation,cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms,cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms,cruise.control.metrics.topic.min.insync.replicas,controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms)."
                   storage:
                     type: object
                     properties:
@@ -11984,6 +4429,54 @@ spec:
                                 description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                             description: Metadata applied to the resource.
                         description: Template for the Entity Operator service account.
+                      entityOperatorRole:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                              annotations:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                            description: Metadata applied to the resource.
+                        description: Template for the Entity Operator Role.
+                      topicOperatorRoleBinding:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                              annotations:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                            description: Metadata applied to the resource.
+                        description: Template for the Entity Topic Operator RoleBinding.
+                      userOperatorRoleBinding:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                              annotations:
+                                x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                            description: Metadata applied to the resource.
+                        description: Template for the Entity Topic Operator RoleBinding.
                     description: Template for Entity Operator resources. The template allows users to specify how a `Deployment` and `Pod` is generated.
                 description: Configuration of the Entity Operator.
               clusterCa:
@@ -13641,7 +6134,7 @@ spec:
                                 type: object
                                 description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                             description: Metadata applied to the resource.
-                        description: Template for the JMX Trans service account.
+                        description: Template for the JmxTrans service account.
                     description: Template for JmxTrans resources.
                 required:
                 - outputDefinitions
@@ -13693,6 +6186,12 @@ spec:
                                 type: object
                                 description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
                             description: Metadata applied to the resource.
+                          deploymentStrategy:
+                            type: string
+                            enum:
+                            - RollingUpdate
+                            - Recreate
+                            description: Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
                         description: Template for Kafka Exporter `Deployment`.
                       pod:
                         type: object
@@ -14377,5 +6876,7635 @@ spec:
                 type: string
                 description: Kafka cluster Id.
             description: "The status of the Kafka and ZooKeeper clusters, and Topic Operator."
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-cluster-operator-global
+  labels:
+    app: strimzi
+rules:
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      # The cluster operator needs to create and manage cluster role bindings in the case of an install where a user
+      # has specified they want their cluster role bindings generated
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      # The cluster operator requires "get" permissions to view storage class details
+      # This is because only a persistent volume of a supported storage class type can be resized
+      - storageclasses
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      # The cluster operator requires "list" permissions to view all nodes in a cluster
+      # The listing is used to determine the node addresses when NodePort access is configured
+      # These addresses are then exposed in the custom resource states
+      - nodes
+    verbs:
+      - list
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-kafka-client
+  labels:
+    app: strimzi
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      # The Kafka clients (Connect, Mirror Maker, etc.) require "get" permissions to view the node they are on
+      # This information is used to generate a Rack ID (client.rack option) that is used for consuming from the closest
+      # replicas when enabled
+      - nodes
+    verbs:
+      - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: strimzi-cluster-operator-leader-election
+  labels:
+    app: strimzi
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: myproject
+roleRef:
+  kind: ClusterRole
+  name: strimzi-cluster-operator-leader-election
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkatopics.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  names:
+    kind: KafkaTopic
+    listKind: KafkaTopicList
+    singular: kafkatopic
+    plural: kafkatopics
+    shortNames:
+    - kt
+    categories:
+    - strimzi
+  scope: Namespaced
+  conversion:
+    strategy: None
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Cluster
+      description: The name of the Kafka cluster this topic belongs to
+      jsonPath: .metadata.labels.strimzi\.io/cluster
+      type: string
+    - name: Partitions
+      description: The desired number of partitions in the topic
+      jsonPath: .spec.partitions
+      type: integer
+    - name: Replication factor
+      description: The desired number of replicas of each partition
+      jsonPath: .spec.replicas
+      type: integer
+    - name: Ready
+      description: The state of the custom resource
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+      type: string
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              partitions:
+                type: integer
+                minimum: 1
+                description: "The number of partitions the topic should have. This cannot be decreased after topic creation. It can be increased after topic creation, but it is important to understand the consequences that has, especially for topics with semantic partitioning. When absent this will default to the broker configuration for `num.partitions`."
+              replicas:
+                type: integer
+                minimum: 1
+                maximum: 32767
+                description: The number of replicas the topic should have. When absent this will default to the broker configuration for `default.replication.factor`.
+              config:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+                description: The topic configuration.
+              topicName:
+                type: string
+                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
+            description: The specification of the topic.
+          status:
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
+                    status:
+                      type: string
+                      description: "The status of the condition, either True, False or Unknown."
+                    lastTransitionTime:
+                      type: string
+                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                    reason:
+                      type: string
+                      description: The reason for the condition's last transition (a single word in CamelCase).
+                    message:
+                      type: string
+                      description: Human-readable message indicating details about the condition's last transition.
+                description: List of status conditions.
+              observedGeneration:
+                type: integer
+                description: The generation of the CRD that was last reconciled by the operator.
+              topicName:
+                type: string
+                description: Topic name.
+            description: The status of the topic.
+  - name: v1beta1
+    served: true
+    storage: false
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Cluster
+      description: The name of the Kafka cluster this topic belongs to
+      jsonPath: .metadata.labels.strimzi\.io/cluster
+      type: string
+    - name: Partitions
+      description: The desired number of partitions in the topic
+      jsonPath: .spec.partitions
+      type: integer
+    - name: Replication factor
+      description: The desired number of replicas of each partition
+      jsonPath: .spec.replicas
+      type: integer
+    - name: Ready
+      description: The state of the custom resource
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+      type: string
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              partitions:
+                type: integer
+                minimum: 1
+                description: "The number of partitions the topic should have. This cannot be decreased after topic creation. It can be increased after topic creation, but it is important to understand the consequences that has, especially for topics with semantic partitioning. When absent this will default to the broker configuration for `num.partitions`."
+              replicas:
+                type: integer
+                minimum: 1
+                maximum: 32767
+                description: The number of replicas the topic should have. When absent this will default to the broker configuration for `default.replication.factor`.
+              config:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+                description: The topic configuration.
+              topicName:
+                type: string
+                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
+            description: The specification of the topic.
+          status:
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
+                    status:
+                      type: string
+                      description: "The status of the condition, either True, False or Unknown."
+                    lastTransitionTime:
+                      type: string
+                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                    reason:
+                      type: string
+                      description: The reason for the condition's last transition (a single word in CamelCase).
+                    message:
+                      type: string
+                      description: Human-readable message indicating details about the condition's last transition.
+                description: List of status conditions.
+              observedGeneration:
+                type: integer
+                description: The generation of the CRD that was last reconciled by the operator.
+              topicName:
+                type: string
+                description: Topic name.
+            description: The status of the topic.
+  - name: v1alpha1
+    served: true
+    storage: false
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Cluster
+      description: The name of the Kafka cluster this topic belongs to
+      jsonPath: .metadata.labels.strimzi\.io/cluster
+      type: string
+    - name: Partitions
+      description: The desired number of partitions in the topic
+      jsonPath: .spec.partitions
+      type: integer
+    - name: Replication factor
+      description: The desired number of replicas of each partition
+      jsonPath: .spec.replicas
+      type: integer
+    - name: Ready
+      description: The state of the custom resource
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+      type: string
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              partitions:
+                type: integer
+                minimum: 1
+                description: "The number of partitions the topic should have. This cannot be decreased after topic creation. It can be increased after topic creation, but it is important to understand the consequences that has, especially for topics with semantic partitioning. When absent this will default to the broker configuration for `num.partitions`."
+              replicas:
+                type: integer
+                minimum: 1
+                maximum: 32767
+                description: The number of replicas the topic should have. When absent this will default to the broker configuration for `default.replication.factor`.
+              config:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+                description: The topic configuration.
+              topicName:
+                type: string
+                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
+            description: The specification of the topic.
+          status:
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
+                    status:
+                      type: string
+                      description: "The status of the condition, either True, False or Unknown."
+                    lastTransitionTime:
+                      type: string
+                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                    reason:
+                      type: string
+                      description: The reason for the condition's last transition (a single word in CamelCase).
+                    message:
+                      type: string
+                      description: Human-readable message indicating details about the condition's last transition.
+                description: List of status conditions.
+              observedGeneration:
+                type: integer
+                description: The generation of the CRD that was last reconciled by the operator.
+              topicName:
+                type: string
+                description: Topic name.
+            description: The status of the topic.
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-cluster-operator-namespaced
+  labels:
+    app: strimzi
+rules:
+  # Resources in this role are used by the operator based on an operand being deployed in some namespace. When needed, you
+  # can deploy the operator as a cluster-wide operator. But grant the rights listed in this role only on the namespaces
+  # where the operands will be deployed. That way, you can limit the access the operator has to other namespaces where it
+  # does not manage any clusters.
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      # The cluster operator needs to access and manage roles to grant the entity operator permissions
+      - roles
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      # The cluster operator needs to access and delete pods, this is to allow it to monitor pod health and coordinate rolling updates
+      - pods
+      # The cluster operator needs to access and manage service accounts to grant Strimzi components cluster permissions
+      - serviceaccounts
+      # The cluster operator needs to access and manage config maps for Strimzi components configuration
+      - configmaps
+      # The cluster operator needs to access and manage services and endpoints to expose Strimzi components to network traffic
+      - services
+      - endpoints
+      # The cluster operator needs to access and manage secrets to handle credentials
+      - secrets
+      # The cluster operator needs to access and manage persistent volume claims to bind them to Strimzi components for persistent data
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - "apps"
+    resources:
+      # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
+      - deployments
+      - deployments/scale
+      - deployments/status
+      # The cluster operator needs to access and manage stateful sets to run stateful sets based Strimzi components
+      - statefulsets
+      # The cluster operator needs to access replica-sets to manage Strimzi components and to determine error states
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - "" # legacy core events api, used by topic operator
+      - "events.k8s.io" # new events api, used by cluster operator
+    resources:
+      # The cluster operator needs to be able to create events and delegate permissions to do so
+      - events
+    verbs:
+      - create
+  - apiGroups:
+      # Kafka Connect Build on OpenShift requirement
+      - build.openshift.io
+    resources:
+      - buildconfigs
+      - buildconfigs/instantiate
+      - builds
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
+      - networkpolicies
+      # The cluster operator needs to access and manage ingresses which allow external access to the services in a cluster
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      # The cluster operator needs to access and manage routes to expose Strimzi components for external access
+      - routes
+      - routes/custom-host
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - image.openshift.io
+    resources:
+      # The cluster operator needs to verify the image stream when used for Kafka Connect image build
+      - imagestreams
+    verbs:
+      - get
+  - apiGroups:
+      - policy
+    resources:
+      # The cluster operator needs to access and manage pod disruption budgets this limits the number of concurrent disruptions
+      # that a Strimzi component experiences, allowing for higher availability
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: strimzi
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: myproject
+roleRef:
+  kind: ClusterRole
+  name: strimzi-cluster-operator-global
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: strimzi
+spec:
+  acquireTime: "1970-01-01T00:00:01.000000Z"
+  holderIdentity: ""
+  leaseDurationSeconds: 15
+  leaseTransitions: 0
+  renewTime: "1970-01-01T00:00:01.000000Z"
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: strimzi
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkaconnects.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  names:
+    kind: KafkaConnect
+    listKind: KafkaConnectList
+    singular: kafkaconnect
+    plural: kafkaconnects
+    shortNames:
+    - kc
+    categories:
+    - strimzi
+  scope: Namespaced
+  conversion:
+    strategy: None
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+        labelSelectorPath: .status.labelSelector
+    additionalPrinterColumns:
+    - name: Desired replicas
+      description: The desired number of Kafka Connect replicas
+      jsonPath: .spec.replicas
+      type: integer
+    - name: Ready
+      description: The state of the custom resource
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+      type: string
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              version:
+                type: string
+                description: "The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version."
+              replicas:
+                type: integer
+                description: The number of pods in the Kafka Connect group.
+              image:
+                type: string
+                description: The docker image for the pods.
+              bootstrapServers:
+                type: string
+                description: Bootstrap servers to connect to. This should be given as a comma separated list of _<hostname>_:_<port>_ pairs.
+              tls:
+                type: object
+                properties:
+                  trustedCertificates:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        certificate:
+                          type: string
+                          description: The name of the file certificate in the Secret.
+                        secretName:
+                          type: string
+                          description: The name of the Secret containing the certificate.
+                      required:
+                      - certificate
+                      - secretName
+                    description: Trusted certificates for TLS connection.
+                description: TLS configuration.
+              authentication:
+                type: object
+                properties:
+                  accessToken:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                        description: The key under which the secret value is stored in the Kubernetes Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Kubernetes Secret containing the secret value.
+                    required:
+                    - key
+                    - secretName
+                    description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
+                  accessTokenIsJwt:
+                    type: boolean
+                    description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                  audience:
+                    type: string
+                    description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
+                  certificateAndKey:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                        description: The name of the file certificate in the Secret.
+                      key:
+                        type: string
+                        description: The name of the private key in the Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Secret containing the certificate.
+                    required:
+                    - certificate
+                    - key
+                    - secretName
+                    description: Reference to the `Secret` which holds the certificate and private key pair.
+                  clientId:
+                    type: string
+                    description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                  clientSecret:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                        description: The key under which the secret value is stored in the Kubernetes Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Kubernetes Secret containing the secret value.
+                    required:
+                    - key
+                    - secretName
+                    description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                  connectTimeoutSeconds:
+                    type: integer
+                    description: "The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds."
+                  disableTlsHostnameVerification:
+                    type: boolean
+                    description: Enable or disable TLS hostname verification. Default value is `false`.
+                  enableMetrics:
+                    type: boolean
+                    description: Enable or disable OAuth metrics. Default value is `false`.
+                  maxTokenExpirySeconds:
+                    type: integer
+                    description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
+                  passwordSecret:
+                    type: object
+                    properties:
+                      password:
+                        type: string
+                        description: The name of the key in the Secret under which the password is stored.
+                      secretName:
+                        type: string
+                        description: The name of the Secret containing the password.
+                    required:
+                    - password
+                    - secretName
+                    description: Reference to the `Secret` which holds the password.
+                  readTimeoutSeconds:
+                    type: integer
+                    description: "The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds."
+                  refreshToken:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                        description: The key under which the secret value is stored in the Kubernetes Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Kubernetes Secret containing the secret value.
+                    required:
+                    - key
+                    - secretName
+                    description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
+                  scope:
+                    type: string
+                    description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
+                  tlsTrustedCertificates:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        certificate:
+                          type: string
+                          description: The name of the file certificate in the Secret.
+                        secretName:
+                          type: string
+                          description: The name of the Secret containing the certificate.
+                      required:
+                      - certificate
+                      - secretName
+                    description: Trusted certificates for TLS connection to the OAuth server.
+                  tokenEndpointUri:
+                    type: string
+                    description: Authorization server token endpoint URI.
+                  type:
+                    type: string
+                    enum:
+                    - tls
+                    - scram-sha-256
+                    - scram-sha-512
+                    - plain
+                    - oauth
+                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                  username:
+                    type: string
+                    description: Username used for the authentication.
+                required:
+                - type
+                description: Authentication configuration for Kafka Connect.
+              config:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+                description: "The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+              resources:
+                type: object
+                properties:
+                  limits:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  requests:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                description: The maximum limits for CPU and memory resources and the requested initial resources.
+              livenessProbe:
+                type: object
+                properties:
+                  failureThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                  initialDelaySeconds:
+                    type: integer
+                    minimum: 0
+                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  periodSeconds:
+                    type: integer
+                    minimum: 1
+                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                  successThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                description: Pod liveness checking.
+              readinessProbe:
+                type: object
+                properties:
+                  failureThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                  initialDelaySeconds:
+                    type: integer
+                    minimum: 0
+                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  periodSeconds:
+                    type: integer
+                    minimum: 1
+                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                  successThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                description: Pod readiness checking.
+              jvmOptions:
+                type: object
+                properties:
+                  "-XX":
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: A map of -XX options to the JVM.
+                  "-Xms":
+                    type: string
+                    pattern: "^[0-9]+[mMgG]?$"
+                    description: -Xms option to to the JVM.
+                  "-Xmx":
+                    type: string
+                    pattern: "^[0-9]+[mMgG]?$"
+                    description: -Xmx option to to the JVM.
+                  gcLoggingEnabled:
+                    type: boolean
+                    description: Specifies whether the Garbage Collection logging is enabled. The default is false.
+                  javaSystemProperties:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          description: The system property name.
+                        value:
+                          type: string
+                          description: The system property value.
+                    description: A map of additional system properties which will be passed using the `-D` option to the JVM.
+                description: JVM Options for pods.
+              jmxOptions:
+                type: object
+                properties:
+                  authentication:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                        - password
+                        description: Authentication type. Currently the only supported types are `password`.`password` type creates a username and protected port with no TLS.
+                    required:
+                    - type
+                    description: Authentication configuration for connecting to the JMX port.
+                description: JMX Options.
+              logging:
+                type: object
+                properties:
+                  loggers:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: A Map from logger name to logger level.
+                  type:
+                    type: string
+                    enum:
+                    - inline
+                    - external
+                    description: "Logging type, must be either 'inline' or 'external'."
+                  valueFrom:
+                    type: object
+                    properties:
+                      configMapKeyRef:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        description: Reference to the key in the ConfigMap containing the configuration.
+                    description: '`ConfigMap` entry where the logging configuration is stored. '
+                required:
+                - type
+                description: Logging configuration for Kafka Connect.
+              clientRackInitImage:
+                type: string
+                description: The image of the init container used for initializing the `client.rack`.
+              rack:
+                type: object
+                properties:
+                  topologyKey:
+                    type: string
+                    example: topology.kubernetes.io/zone
+                    description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
+                required:
+                - topologyKey
+                description: Configuration of the node label which will be used as the `client.rack` consumer configuration.
+              tracing:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                    - jaeger
+                    - opentelemetry
+                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
+                required:
+                - type
+                description: The configuration of tracing in Kafka Connect.
+              template:
+                type: object
+                properties:
+                  deployment:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                      deploymentStrategy:
+                        type: string
+                        enum:
+                        - RollingUpdate
+                        - Recreate
+                        description: Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
+                    description: Template for Kafka Connect `Deployment`.
+                  pod:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                      imagePullSecrets:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        description: "List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored."
+                      securityContext:
+                        type: object
+                        properties:
+                          fsGroup:
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          supplementalGroups:
+                            type: array
+                            items:
+                              type: integer
+                          sysctls:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Configures pod-level security attributes and common container settings.
+                      terminationGracePeriodSeconds:
+                        type: integer
+                        minimum: 0
+                        description: "The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds."
+                      affinity:
+                        type: object
+                        properties:
+                          nodeAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    preference:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchFields:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: object
+                                properties:
+                                  nodeSelectorTerms:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchFields:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                          podAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaceSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaceSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                          podAntiAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaceSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaceSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                        description: The pod's affinity rules.
+                      tolerations:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              type: integer
+                            value:
+                              type: string
+                        description: The pod's tolerations.
+                      priorityClassName:
+                        type: string
+                        description: "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}."
+                      schedulerName:
+                        type: string
+                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                      hostAliases:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
+                            ip:
+                              type: string
+                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                      tmpDirSizeLimit:
+                        type: string
+                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services should be injected into Pod's environment variables.
+                      topologySpreadConstraints:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            labelSelector:
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            maxSkew:
+                              type: integer
+                            minDomains:
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                        description: The pod's topology spread constraints.
+                    description: Template for Kafka Connect `Pods`.
+                  apiService:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                      ipFamilyPolicy:
+                        type: string
+                        enum:
+                        - SingleStack
+                        - PreferDualStack
+                        - RequireDualStack
+                        description: "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer."
+                      ipFamilies:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                          - IPv4
+                          - IPv6
+                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer."
+                    description: Template for Kafka Connect API `Service`.
+                  connectContainer:
+                    type: object
+                    properties:
+                      env:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: The environment variable key.
+                            value:
+                              type: string
+                              description: The environment variable value.
+                        description: Environment variables which should be applied to the container.
+                      securityContext:
+                        type: object
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            type: object
+                            properties:
+                              add:
+                                type: array
+                                items:
+                                  type: string
+                              drop:
+                                type: array
+                                items:
+                                  type: string
+                          privileged:
+                            type: boolean
+                          procMount:
+                            type: string
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Security context for the container.
+                    description: Template for the Kafka Connect container.
+                  initContainer:
+                    type: object
+                    properties:
+                      env:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: The environment variable key.
+                            value:
+                              type: string
+                              description: The environment variable value.
+                        description: Environment variables which should be applied to the container.
+                      securityContext:
+                        type: object
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            type: object
+                            properties:
+                              add:
+                                type: array
+                                items:
+                                  type: string
+                              drop:
+                                type: array
+                                items:
+                                  type: string
+                          privileged:
+                            type: boolean
+                          procMount:
+                            type: string
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Security context for the container.
+                    description: Template for the Kafka init container.
+                  podDisruptionBudget:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
+                      maxUnavailable:
+                        type: integer
+                        minimum: 0
+                        description: "Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1."
+                    description: Template for Kafka Connect `PodDisruptionBudget`.
+                  serviceAccount:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                    description: Template for the Kafka Connect service account.
+                  clusterRoleBinding:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                    description: Template for the Kafka Connect ClusterRoleBinding.
+                  buildPod:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                      imagePullSecrets:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        description: "List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored."
+                      securityContext:
+                        type: object
+                        properties:
+                          fsGroup:
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          supplementalGroups:
+                            type: array
+                            items:
+                              type: integer
+                          sysctls:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Configures pod-level security attributes and common container settings.
+                      terminationGracePeriodSeconds:
+                        type: integer
+                        minimum: 0
+                        description: "The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds."
+                      affinity:
+                        type: object
+                        properties:
+                          nodeAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    preference:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchFields:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: object
+                                properties:
+                                  nodeSelectorTerms:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchFields:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                          podAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaceSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaceSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                          podAntiAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaceSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaceSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                        description: The pod's affinity rules.
+                      tolerations:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              type: integer
+                            value:
+                              type: string
+                        description: The pod's tolerations.
+                      priorityClassName:
+                        type: string
+                        description: "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}."
+                      schedulerName:
+                        type: string
+                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                      hostAliases:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
+                            ip:
+                              type: string
+                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                      tmpDirSizeLimit:
+                        type: string
+                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services should be injected into Pod's environment variables.
+                      topologySpreadConstraints:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            labelSelector:
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            maxSkew:
+                              type: integer
+                            minDomains:
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                        description: The pod's topology spread constraints.
+                    description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
+                  buildContainer:
+                    type: object
+                    properties:
+                      env:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: The environment variable key.
+                            value:
+                              type: string
+                              description: The environment variable value.
+                        description: Environment variables which should be applied to the container.
+                      securityContext:
+                        type: object
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            type: object
+                            properties:
+                              add:
+                                type: array
+                                items:
+                                  type: string
+                              drop:
+                                type: array
+                                items:
+                                  type: string
+                          privileged:
+                            type: boolean
+                          procMount:
+                            type: string
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Security context for the container.
+                    description: Template for the Kafka Connect Build container. The build container is used only on Kubernetes.
+                  buildConfig:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
+                      pullSecret:
+                        type: string
+                        description: Container Registry Secret with the credentials for pulling the base image.
+                    description: Template for the Kafka Connect BuildConfig used to build new container images. The BuildConfig is used only on OpenShift.
+                  buildServiceAccount:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                    description: Template for the Kafka Connect Build service account.
+                  jmxSecret:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                    description: Template for Secret of the Kafka Connect Cluster JMX authentication.
+                description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated."
+              externalConfiguration:
+                type: object
+                properties:
+                  env:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          description: Name of the environment variable which will be passed to the Kafka Connect pods. The name of the environment variable cannot start with `KAFKA_` or `STRIMZI_`.
+                        valueFrom:
+                          type: object
+                          properties:
+                            configMapKeyRef:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: Reference to a key in a ConfigMap.
+                            secretKeyRef:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: Reference to a key in a Secret.
+                          description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
+                      required:
+                      - name
+                      - valueFrom
+                    description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as environment variables.
+                  volumes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        configMap:
+                          type: object
+                          properties:
+                            defaultMode:
+                              type: integer
+                            items:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  mode:
+                                    type: integer
+                                  path:
+                                    type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
+                        name:
+                          type: string
+                          description: Name of the volume which will be added to the Kafka Connect pods.
+                        secret:
+                          type: object
+                          properties:
+                            defaultMode:
+                              type: integer
+                            items:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  mode:
+                                    type: integer
+                                  path:
+                                    type: string
+                            optional:
+                              type: boolean
+                            secretName:
+                              type: string
+                          description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
+                      required:
+                      - name
+                    description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
+                description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
+              build:
+                type: object
+                properties:
+                  output:
+                    type: object
+                    properties:
+                      additionalKanikoOptions:
+                        type: array
+                        items:
+                          type: string
+                        description: "Configures additional options which will be passed to the Kaniko executor when building the new Connect image. Allowed options are: --customPlatform, --insecure, --insecure-pull, --insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run. These options will be used only on Kubernetes where the Kaniko executor is used. They will be ignored on OpenShift. The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. Changing this field does not trigger new build of the Kafka Connect image."
+                      image:
+                        type: string
+                        description: The name of the image which will be built. Required.
+                      pushSecret:
+                        type: string
+                        description: Container Registry Secret with the credentials for pushing the newly built image.
+                      type:
+                        type: string
+                        enum:
+                        - docker
+                        - imagestream
+                        description: Output type. Must be either `docker` for pushing the newly build image to Docker compatible registry or `imagestream` for pushing the image to OpenShift ImageStream. Required.
+                    required:
+                    - image
+                    - type
+                    description: Configures where should the newly built image be stored. Required.
+                  resources:
+                    type: object
+                    properties:
+                      limits:
+                        x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      requests:
+                        x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    description: CPU and memory resources to reserve for the build.
+                  plugins:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          pattern: "^[a-z0-9][-_a-z0-9]*[a-z0-9]$"
+                          description: "The unique name of the connector plugin. Will be used to generate the path where the connector artifacts will be stored. The name has to be unique within the KafkaConnect resource. The name has to follow the following pattern: `^[a-z][-_a-z0-9]*[a-z]$`. Required."
+                        artifacts:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              artifact:
+                                type: string
+                                description: Maven artifact id. Applicable to the `maven` artifact type only.
+                              fileName:
+                                type: string
+                                description: Name under which the artifact will be stored.
+                              group:
+                                type: string
+                                description: Maven group id. Applicable to the `maven` artifact type only.
+                              insecure:
+                                type: boolean
+                                description: "By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure."
+                              repository:
+                                type: string
+                                description: Maven repository to download the artifact from. Applicable to the `maven` artifact type only.
+                              sha512sum:
+                                type: string
+                                description: "SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type. "
+                              type:
+                                type: string
+                                enum:
+                                - jar
+                                - tgz
+                                - zip
+                                - maven
+                                - other
+                                description: "Artifact type. Currently, the supported artifact types are `tgz`, `jar`, `zip`, `other` and `maven`."
+                              url:
+                                type: string
+                                pattern: "^(https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]$"
+                                description: "URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required for `jar`, `zip`, `tgz` and `other` artifacts. Not applicable to the `maven` artifact type."
+                              version:
+                                type: string
+                                description: Maven version number. Applicable to the `maven` artifact type only.
+                            required:
+                            - type
+                          description: List of artifacts which belong to this connector plugin. Required.
+                      required:
+                      - name
+                      - artifacts
+                    description: List of connector plugins which should be added to the Kafka Connect. Required.
+                required:
+                - output
+                - plugins
+                description: Configures how the Connect container image should be built. Optional.
+              metricsConfig:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                    - jmxPrometheusExporter
+                    description: Metrics type. Only 'jmxPrometheusExporter' supported currently.
+                  valueFrom:
+                    type: object
+                    properties:
+                      configMapKeyRef:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        description: Reference to the key in the ConfigMap containing the configuration.
+                    description: "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. For details of the structure of this configuration, see the {JMXExporter}."
+                required:
+                - type
+                - valueFrom
+                description: Metrics configuration.
+            required:
+            - bootstrapServers
+            description: The specification of the Kafka Connect cluster.
+          status:
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
+                    status:
+                      type: string
+                      description: "The status of the condition, either True, False or Unknown."
+                    lastTransitionTime:
+                      type: string
+                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                    reason:
+                      type: string
+                      description: The reason for the condition's last transition (a single word in CamelCase).
+                    message:
+                      type: string
+                      description: Human-readable message indicating details about the condition's last transition.
+                description: List of status conditions.
+              observedGeneration:
+                type: integer
+                description: The generation of the CRD that was last reconciled by the operator.
+              url:
+                type: string
+                description: The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
+              connectorPlugins:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: The type of the connector plugin. The available types are `sink` and `source`.
+                    version:
+                      type: string
+                      description: The version of the connector plugin.
+                    class:
+                      type: string
+                      description: The class of the connector plugin.
+                description: The list of connector plugins available in this Kafka Connect deployment.
+              labelSelector:
+                type: string
+                description: Label selector for pods providing this resource.
+              replicas:
+                type: integer
+                description: The current number of pods being used to provide this resource.
+            description: The status of the Kafka Connect cluster.
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkaconnectors.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  names:
+    kind: KafkaConnector
+    listKind: KafkaConnectorList
+    singular: kafkaconnector
+    plural: kafkaconnectors
+    shortNames:
+    - kctr
+    categories:
+    - strimzi
+  scope: Namespaced
+  conversion:
+    strategy: None
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+      scale:
+        specReplicasPath: .spec.tasksMax
+        statusReplicasPath: .status.tasksMax
+    additionalPrinterColumns:
+    - name: Cluster
+      description: The name of the Kafka Connect cluster this connector belongs to
+      jsonPath: .metadata.labels.strimzi\.io/cluster
+      type: string
+    - name: Connector class
+      description: The class used by this connector
+      jsonPath: .spec.class
+      type: string
+    - name: Max Tasks
+      description: Maximum number of tasks
+      jsonPath: .spec.tasksMax
+      type: integer
+    - name: Ready
+      description: The state of the custom resource
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+      type: string
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              class:
+                type: string
+                description: The Class for the Kafka Connector.
+              tasksMax:
+                type: integer
+                minimum: 1
+                description: The maximum number of tasks for the Kafka Connector.
+              autoRestart:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                    description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                description: Automatic restart of connector and tasks configuration.
+              config:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+                description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+              pause:
+                type: boolean
+                description: Whether the connector should be paused. Defaults to false.
+            description: The specification of the Kafka Connector.
+          status:
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
+                    status:
+                      type: string
+                      description: "The status of the condition, either True, False or Unknown."
+                    lastTransitionTime:
+                      type: string
+                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                    reason:
+                      type: string
+                      description: The reason for the condition's last transition (a single word in CamelCase).
+                    message:
+                      type: string
+                      description: Human-readable message indicating details about the condition's last transition.
+                description: List of status conditions.
+              observedGeneration:
+                type: integer
+                description: The generation of the CRD that was last reconciled by the operator.
+              autoRestart:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    description: The number of times the connector or task is restarted.
+                  connectorName:
+                    type: string
+                    description: The name of the connector being restarted.
+                  lastRestartTimestamp:
+                    type: string
+                    description: The last time the automatic restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ' in the UTC time zone.
+                description: The auto restart status.
+              connectorStatus:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+                description: "The connector status, as reported by the Kafka Connect REST API."
+              tasksMax:
+                type: integer
+                description: The maximum number of tasks for the Kafka Connector.
+              topics:
+                type: array
+                items:
+                  type: string
+                description: The list of topics used by the Kafka Connector.
+            description: The status of the Kafka Connector.
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: strimzi-cluster-operator-kafka-broker-delegation
+  labels:
+    app: strimzi
+# The Kafka broker cluster role must be bound to the cluster operator service account so that it can delegate the cluster role to the Kafka brokers.
+# This must be done to avoid escalating privileges which would be blocked by Kubernetes.
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: myproject
+roleRef:
+  kind: ClusterRole
+  name: strimzi-kafka-broker
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: strimzi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: strimzi-cluster-operator
+      strimzi.io/kind: cluster-operator
+  template:
+    metadata:
+      labels:
+        name: strimzi-cluster-operator
+        strimzi.io/kind: cluster-operator
+    spec:
+      serviceAccountName: strimzi-cluster-operator
+      volumes:
+        - name: strimzi-tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Mi
+        - name: co-config-volume
+          configMap:
+            name: strimzi-cluster-operator
+      containers:
+        - name: strimzi-cluster-operator
+          image: quay.io/strimzi/operator:0.33.0
+          ports:
+            - containerPort: 8080
+              name: http
+          args:
+            - /opt/strimzi/bin/cluster_operator_run.sh
+          volumeMounts:
+            - name: strimzi-tmp
+              mountPath: /tmp
+            - name: co-config-volume
+              mountPath: /opt/strimzi/custom-config/
+          env:
+            - name: STRIMZI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
+              value: "120000"
+            - name: STRIMZI_OPERATION_TIMEOUT_MS
+              value: "300000"
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: quay.io/strimzi/kafka:0.33.0-kafka-3.3.2
+            - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
+              value: quay.io/strimzi/kafka:0.33.0-kafka-3.3.2
+            - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
+              value: quay.io/strimzi/kafka:0.33.0-kafka-3.3.2
+            - name: STRIMZI_KAFKA_IMAGES
+              value: |
+                3.2.0=quay.io/strimzi/kafka:0.33.0-kafka-3.2.0
+                3.2.1=quay.io/strimzi/kafka:0.33.0-kafka-3.2.1
+                3.2.3=quay.io/strimzi/kafka:0.33.0-kafka-3.2.3
+                3.3.1=quay.io/strimzi/kafka:0.33.0-kafka-3.3.1
+                3.3.2=quay.io/strimzi/kafka:0.33.0-kafka-3.3.2
+            - name: STRIMZI_KAFKA_CONNECT_IMAGES
+              value: |
+                3.2.0=quay.io/strimzi/kafka:0.33.0-kafka-3.2.0
+                3.2.1=quay.io/strimzi/kafka:0.33.0-kafka-3.2.1
+                3.2.3=quay.io/strimzi/kafka:0.33.0-kafka-3.2.3
+                3.3.1=quay.io/strimzi/kafka:0.33.0-kafka-3.3.1
+                3.3.2=quay.io/strimzi/kafka:0.33.0-kafka-3.3.2
+            - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
+              value: |
+                3.2.0=quay.io/strimzi/kafka:0.33.0-kafka-3.2.0
+                3.2.1=quay.io/strimzi/kafka:0.33.0-kafka-3.2.1
+                3.2.3=quay.io/strimzi/kafka:0.33.0-kafka-3.2.3
+                3.3.1=quay.io/strimzi/kafka:0.33.0-kafka-3.3.1
+                3.3.2=quay.io/strimzi/kafka:0.33.0-kafka-3.3.2
+            - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
+              value: |
+                3.2.0=quay.io/strimzi/kafka:0.33.0-kafka-3.2.0
+                3.2.1=quay.io/strimzi/kafka:0.33.0-kafka-3.2.1
+                3.2.3=quay.io/strimzi/kafka:0.33.0-kafka-3.2.3
+                3.3.1=quay.io/strimzi/kafka:0.33.0-kafka-3.3.1
+                3.3.2=quay.io/strimzi/kafka:0.33.0-kafka-3.3.2
+            - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
+              value: quay.io/strimzi/operator:0.33.0
+            - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
+              value: quay.io/strimzi/operator:0.33.0
+            - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
+              value: quay.io/strimzi/operator:0.33.0
+            - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
+              value: quay.io/strimzi/kafka-bridge:0.24.0
+            - name: STRIMZI_DEFAULT_JMXTRANS_IMAGE
+              value: quay.io/strimzi/jmxtrans:0.33.0
+            - name: STRIMZI_DEFAULT_KANIKO_EXECUTOR_IMAGE
+              value: quay.io/strimzi/kaniko-executor:0.33.0
+            - name: STRIMZI_DEFAULT_MAVEN_BUILDER
+              value: quay.io/strimzi/maven-builder:0.33.0
+            - name: STRIMZI_OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_FEATURE_GATES
+              value: ""
+            - name: STRIMZI_LEADER_ELECTION_ENABLED
+              value: "true"
+            - name: STRIMZI_LEADER_ELECTION_LEASE_NAME
+              value: "strimzi-cluster-operator"
+            - name: STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_LEADER_ELECTION_IDENTITY
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          livenessProbe:
+            httpGet:
+              path: /healthy
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 384Mi
+            requests:
+              cpu: 200m
+              memory: 384Mi
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: strimzipodsets.core.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: core.strimzi.io
+  names:
+    kind: StrimziPodSet
+    listKind: StrimziPodSetList
+    singular: strimzipodset
+    plural: strimzipodsets
+    shortNames:
+    - sps
+    categories:
+    - strimzi
+  scope: Namespaced
+  conversion:
+    strategy: None
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Pods
+      description: Number of pods managed by the StrimziPodSet
+      jsonPath: .status.pods
+      type: integer
+    - name: Ready Pods
+      description: Number of ready pods managed by the StrimziPodSet
+      jsonPath: .status.readyPods
+      type: integer
+    - name: Current Pods
+      description: Number of up-to-date pods managed by the StrimziPodSet
+      jsonPath: .status.currentPods
+      type: integer
+    - name: Age
+      description: Age of the StrimziPodSet
+      jsonPath: .metadata.creationTimestamp
+      type: date
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              selector:
+                type: object
+                properties:
+                  matchExpressions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          type: array
+                          items:
+                            type: string
+                  matchLabels:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                description: "Selector is a label query which matches all the pods managed by this `StrimziPodSet`. Only `matchLabels` is supported. If `matchExpressions` is set, it will be ignored."
+              pods:
+                type: array
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                description: The Pods managed by this StrimziPodSet.
+            required:
+            - selector
+            - pods
+            description: The specification of the StrimziPodSet.
+          status:
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
+                    status:
+                      type: string
+                      description: "The status of the condition, either True, False or Unknown."
+                    lastTransitionTime:
+                      type: string
+                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                    reason:
+                      type: string
+                      description: The reason for the condition's last transition (a single word in CamelCase).
+                    message:
+                      type: string
+                      description: Human-readable message indicating details about the condition's last transition.
+                description: List of status conditions.
+              observedGeneration:
+                type: integer
+                description: The generation of the CRD that was last reconciled by the operator.
+              pods:
+                type: integer
+                description: Number of pods managed by the StrimziPodSet controller.
+              readyPods:
+                type: integer
+                description: Number of pods managed by the StrimziPodSet controller that are ready.
+              currentPods:
+                type: integer
+                description: Number of pods managed by the StrimziPodSet controller that have the current revision.
+            description: The status of the StrimziPodSet.
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-entity-operator
+  labels:
+    app: strimzi
+rules:
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # The entity operator runs the KafkaTopic assembly operator, which needs to access and manage KafkaTopic resources
+      - kafkatopics
+      - kafkatopics/status
+      # The entity operator runs the KafkaUser assembly operator, which needs to access and manage KafkaUser resources
+      - kafkausers
+      - kafkausers/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      # The entity operator needs to be able to create events
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      # The entity operator user-operator needs to access and manage secrets to store generated credentials
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkamirrormakers.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  names:
+    kind: KafkaMirrorMaker
+    listKind: KafkaMirrorMakerList
+    singular: kafkamirrormaker
+    plural: kafkamirrormakers
+    shortNames:
+    - kmm
+    categories:
+    - strimzi
+  scope: Namespaced
+  conversion:
+    strategy: None
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+        labelSelectorPath: .status.labelSelector
+    additionalPrinterColumns:
+    - name: Desired replicas
+      description: The desired number of Kafka MirrorMaker replicas
+      jsonPath: .spec.replicas
+      type: integer
+    - name: Consumer Bootstrap Servers
+      description: The boostrap servers for the consumer
+      jsonPath: .spec.consumer.bootstrapServers
+      type: string
+      priority: 1
+    - name: Producer Bootstrap Servers
+      description: The boostrap servers for the producer
+      jsonPath: .spec.producer.bootstrapServers
+      type: string
+      priority: 1
+    - name: Ready
+      description: The state of the custom resource
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+      type: string
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              version:
+                type: string
+                description: "The Kafka MirrorMaker version. Defaults to {DefaultKafkaVersion}. Consult the documentation to understand the process required to upgrade or downgrade the version."
+              replicas:
+                type: integer
+                minimum: 0
+                description: The number of pods in the `Deployment`.
+              image:
+                type: string
+                description: The docker image for the pods.
+              consumer:
+                type: object
+                properties:
+                  numStreams:
+                    type: integer
+                    minimum: 1
+                    description: Specifies the number of consumer stream threads to create.
+                  offsetCommitInterval:
+                    type: integer
+                    description: Specifies the offset auto-commit interval in ms. Default value is 60000.
+                  bootstrapServers:
+                    type: string
+                    description: A list of host:port pairs for establishing the initial connection to the Kafka cluster.
+                  groupId:
+                    type: string
+                    description: A unique string that identifies the consumer group this consumer belongs to.
+                  authentication:
+                    type: object
+                    properties:
+                      accessToken:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: The key under which the secret value is stored in the Kubernetes Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Kubernetes Secret containing the secret value.
+                        required:
+                        - key
+                        - secretName
+                        description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
+                      accessTokenIsJwt:
+                        type: boolean
+                        description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                      audience:
+                        type: string
+                        description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
+                      certificateAndKey:
+                        type: object
+                        properties:
+                          certificate:
+                            type: string
+                            description: The name of the file certificate in the Secret.
+                          key:
+                            type: string
+                            description: The name of the private key in the Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Secret containing the certificate.
+                        required:
+                        - certificate
+                        - key
+                        - secretName
+                        description: Reference to the `Secret` which holds the certificate and private key pair.
+                      clientId:
+                        type: string
+                        description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                      clientSecret:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: The key under which the secret value is stored in the Kubernetes Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Kubernetes Secret containing the secret value.
+                        required:
+                        - key
+                        - secretName
+                        description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                      connectTimeoutSeconds:
+                        type: integer
+                        description: "The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds."
+                      disableTlsHostnameVerification:
+                        type: boolean
+                        description: Enable or disable TLS hostname verification. Default value is `false`.
+                      enableMetrics:
+                        type: boolean
+                        description: Enable or disable OAuth metrics. Default value is `false`.
+                      maxTokenExpirySeconds:
+                        type: integer
+                        description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
+                      passwordSecret:
+                        type: object
+                        properties:
+                          password:
+                            type: string
+                            description: The name of the key in the Secret under which the password is stored.
+                          secretName:
+                            type: string
+                            description: The name of the Secret containing the password.
+                        required:
+                        - password
+                        - secretName
+                        description: Reference to the `Secret` which holds the password.
+                      readTimeoutSeconds:
+                        type: integer
+                        description: "The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds."
+                      refreshToken:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: The key under which the secret value is stored in the Kubernetes Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Kubernetes Secret containing the secret value.
+                        required:
+                        - key
+                        - secretName
+                        description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
+                      scope:
+                        type: string
+                        description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
+                      tlsTrustedCertificates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            certificate:
+                              type: string
+                              description: The name of the file certificate in the Secret.
+                            secretName:
+                              type: string
+                              description: The name of the Secret containing the certificate.
+                          required:
+                          - certificate
+                          - secretName
+                        description: Trusted certificates for TLS connection to the OAuth server.
+                      tokenEndpointUri:
+                        type: string
+                        description: Authorization server token endpoint URI.
+                      type:
+                        type: string
+                        enum:
+                        - tls
+                        - scram-sha-256
+                        - scram-sha-512
+                        - plain
+                        - oauth
+                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                      username:
+                        type: string
+                        description: Username used for the authentication.
+                    required:
+                    - type
+                    description: Authentication configuration for connecting to the cluster.
+                  config:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: "The MirrorMaker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+                  tls:
+                    type: object
+                    properties:
+                      trustedCertificates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            certificate:
+                              type: string
+                              description: The name of the file certificate in the Secret.
+                            secretName:
+                              type: string
+                              description: The name of the Secret containing the certificate.
+                          required:
+                          - certificate
+                          - secretName
+                        description: Trusted certificates for TLS connection.
+                    description: TLS configuration for connecting MirrorMaker to the cluster.
+                required:
+                - bootstrapServers
+                - groupId
+                description: Configuration of source cluster.
+              producer:
+                type: object
+                properties:
+                  bootstrapServers:
+                    type: string
+                    description: A list of host:port pairs for establishing the initial connection to the Kafka cluster.
+                  abortOnSendFailure:
+                    type: boolean
+                    description: Flag to set the MirrorMaker to exit on a failed send. Default value is `true`.
+                  authentication:
+                    type: object
+                    properties:
+                      accessToken:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: The key under which the secret value is stored in the Kubernetes Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Kubernetes Secret containing the secret value.
+                        required:
+                        - key
+                        - secretName
+                        description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
+                      accessTokenIsJwt:
+                        type: boolean
+                        description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                      audience:
+                        type: string
+                        description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
+                      certificateAndKey:
+                        type: object
+                        properties:
+                          certificate:
+                            type: string
+                            description: The name of the file certificate in the Secret.
+                          key:
+                            type: string
+                            description: The name of the private key in the Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Secret containing the certificate.
+                        required:
+                        - certificate
+                        - key
+                        - secretName
+                        description: Reference to the `Secret` which holds the certificate and private key pair.
+                      clientId:
+                        type: string
+                        description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                      clientSecret:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: The key under which the secret value is stored in the Kubernetes Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Kubernetes Secret containing the secret value.
+                        required:
+                        - key
+                        - secretName
+                        description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                      connectTimeoutSeconds:
+                        type: integer
+                        description: "The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds."
+                      disableTlsHostnameVerification:
+                        type: boolean
+                        description: Enable or disable TLS hostname verification. Default value is `false`.
+                      enableMetrics:
+                        type: boolean
+                        description: Enable or disable OAuth metrics. Default value is `false`.
+                      maxTokenExpirySeconds:
+                        type: integer
+                        description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
+                      passwordSecret:
+                        type: object
+                        properties:
+                          password:
+                            type: string
+                            description: The name of the key in the Secret under which the password is stored.
+                          secretName:
+                            type: string
+                            description: The name of the Secret containing the password.
+                        required:
+                        - password
+                        - secretName
+                        description: Reference to the `Secret` which holds the password.
+                      readTimeoutSeconds:
+                        type: integer
+                        description: "The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds."
+                      refreshToken:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: The key under which the secret value is stored in the Kubernetes Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Kubernetes Secret containing the secret value.
+                        required:
+                        - key
+                        - secretName
+                        description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
+                      scope:
+                        type: string
+                        description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
+                      tlsTrustedCertificates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            certificate:
+                              type: string
+                              description: The name of the file certificate in the Secret.
+                            secretName:
+                              type: string
+                              description: The name of the Secret containing the certificate.
+                          required:
+                          - certificate
+                          - secretName
+                        description: Trusted certificates for TLS connection to the OAuth server.
+                      tokenEndpointUri:
+                        type: string
+                        description: Authorization server token endpoint URI.
+                      type:
+                        type: string
+                        enum:
+                        - tls
+                        - scram-sha-256
+                        - scram-sha-512
+                        - plain
+                        - oauth
+                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                      username:
+                        type: string
+                        description: Username used for the authentication.
+                    required:
+                    - type
+                    description: Authentication configuration for connecting to the cluster.
+                  config:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: "The MirrorMaker producer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+                  tls:
+                    type: object
+                    properties:
+                      trustedCertificates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            certificate:
+                              type: string
+                              description: The name of the file certificate in the Secret.
+                            secretName:
+                              type: string
+                              description: The name of the Secret containing the certificate.
+                          required:
+                          - certificate
+                          - secretName
+                        description: Trusted certificates for TLS connection.
+                    description: TLS configuration for connecting MirrorMaker to the cluster.
+                required:
+                - bootstrapServers
+                description: Configuration of target cluster.
+              resources:
+                type: object
+                properties:
+                  limits:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  requests:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                description: CPU and memory resources to reserve.
+              whitelist:
+                type: string
+                description: "List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the expression `A\\|B`. Or, as a special case, you can mirror all topics using the regular expression `*`. You can also specify multiple regular expressions separated by commas."
+              include:
+                type: string
+                description: "List of topics which are included for mirroring. This option allows any regular expression using Java-style regular expressions. Mirroring two topics named A and B is achieved by using the expression `A\\|B`. Or, as a special case, you can mirror all topics using the regular expression `*`. You can also specify multiple regular expressions separated by commas."
+              jvmOptions:
+                type: object
+                properties:
+                  "-XX":
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: A map of -XX options to the JVM.
+                  "-Xms":
+                    type: string
+                    pattern: "^[0-9]+[mMgG]?$"
+                    description: -Xms option to to the JVM.
+                  "-Xmx":
+                    type: string
+                    pattern: "^[0-9]+[mMgG]?$"
+                    description: -Xmx option to to the JVM.
+                  gcLoggingEnabled:
+                    type: boolean
+                    description: Specifies whether the Garbage Collection logging is enabled. The default is false.
+                  javaSystemProperties:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          description: The system property name.
+                        value:
+                          type: string
+                          description: The system property value.
+                    description: A map of additional system properties which will be passed using the `-D` option to the JVM.
+                description: JVM Options for pods.
+              logging:
+                type: object
+                properties:
+                  loggers:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: A Map from logger name to logger level.
+                  type:
+                    type: string
+                    enum:
+                    - inline
+                    - external
+                    description: "Logging type, must be either 'inline' or 'external'."
+                  valueFrom:
+                    type: object
+                    properties:
+                      configMapKeyRef:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        description: Reference to the key in the ConfigMap containing the configuration.
+                    description: '`ConfigMap` entry where the logging configuration is stored. '
+                required:
+                - type
+                description: Logging configuration for MirrorMaker.
+              metricsConfig:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                    - jmxPrometheusExporter
+                    description: Metrics type. Only 'jmxPrometheusExporter' supported currently.
+                  valueFrom:
+                    type: object
+                    properties:
+                      configMapKeyRef:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        description: Reference to the key in the ConfigMap containing the configuration.
+                    description: "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. For details of the structure of this configuration, see the {JMXExporter}."
+                required:
+                - type
+                - valueFrom
+                description: Metrics configuration.
+              tracing:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                    - jaeger
+                    - opentelemetry
+                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
+                required:
+                - type
+                description: The configuration of tracing in Kafka MirrorMaker.
+              template:
+                type: object
+                properties:
+                  deployment:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                      deploymentStrategy:
+                        type: string
+                        enum:
+                        - RollingUpdate
+                        - Recreate
+                        description: Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
+                    description: Template for Kafka MirrorMaker `Deployment`.
+                  pod:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                      imagePullSecrets:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        description: "List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored."
+                      securityContext:
+                        type: object
+                        properties:
+                          fsGroup:
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          supplementalGroups:
+                            type: array
+                            items:
+                              type: integer
+                          sysctls:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Configures pod-level security attributes and common container settings.
+                      terminationGracePeriodSeconds:
+                        type: integer
+                        minimum: 0
+                        description: "The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds."
+                      affinity:
+                        type: object
+                        properties:
+                          nodeAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    preference:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchFields:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: object
+                                properties:
+                                  nodeSelectorTerms:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchFields:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                          podAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaceSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaceSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                          podAntiAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaceSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaceSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                        description: The pod's affinity rules.
+                      tolerations:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              type: integer
+                            value:
+                              type: string
+                        description: The pod's tolerations.
+                      priorityClassName:
+                        type: string
+                        description: "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}."
+                      schedulerName:
+                        type: string
+                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                      hostAliases:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
+                            ip:
+                              type: string
+                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                      tmpDirSizeLimit:
+                        type: string
+                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services should be injected into Pod's environment variables.
+                      topologySpreadConstraints:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            labelSelector:
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            maxSkew:
+                              type: integer
+                            minDomains:
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                        description: The pod's topology spread constraints.
+                    description: Template for Kafka MirrorMaker `Pods`.
+                  podDisruptionBudget:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
+                      maxUnavailable:
+                        type: integer
+                        minimum: 0
+                        description: "Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1."
+                    description: Template for Kafka MirrorMaker `PodDisruptionBudget`.
+                  mirrorMakerContainer:
+                    type: object
+                    properties:
+                      env:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: The environment variable key.
+                            value:
+                              type: string
+                              description: The environment variable value.
+                        description: Environment variables which should be applied to the container.
+                      securityContext:
+                        type: object
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            type: object
+                            properties:
+                              add:
+                                type: array
+                                items:
+                                  type: string
+                              drop:
+                                type: array
+                                items:
+                                  type: string
+                          privileged:
+                            type: boolean
+                          procMount:
+                            type: string
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Security context for the container.
+                    description: Template for Kafka MirrorMaker container.
+                  serviceAccount:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                    description: Template for the Kafka MirrorMaker service account.
+                description: "Template to specify how Kafka MirrorMaker resources, `Deployments` and `Pods`, are generated."
+              livenessProbe:
+                type: object
+                properties:
+                  failureThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                  initialDelaySeconds:
+                    type: integer
+                    minimum: 0
+                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  periodSeconds:
+                    type: integer
+                    minimum: 1
+                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                  successThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                description: Pod liveness checking.
+              readinessProbe:
+                type: object
+                properties:
+                  failureThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                  initialDelaySeconds:
+                    type: integer
+                    minimum: 0
+                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  periodSeconds:
+                    type: integer
+                    minimum: 1
+                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                  successThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                description: Pod readiness checking.
+            oneOf:
+            - properties:
+                include: {}
+              required:
+              - include
+            - properties:
+                whitelist: {}
+              required:
+              - whitelist
+            required:
+            - replicas
+            - consumer
+            - producer
+            description: The specification of Kafka MirrorMaker.
+          status:
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
+                    status:
+                      type: string
+                      description: "The status of the condition, either True, False or Unknown."
+                    lastTransitionTime:
+                      type: string
+                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                    reason:
+                      type: string
+                      description: The reason for the condition's last transition (a single word in CamelCase).
+                    message:
+                      type: string
+                      description: Human-readable message indicating details about the condition's last transition.
+                description: List of status conditions.
+              observedGeneration:
+                type: integer
+                description: The generation of the CRD that was last reconciled by the operator.
+              labelSelector:
+                type: string
+                description: Label selector for pods providing this resource.
+              replicas:
+                type: integer
+                description: The current number of pods being used to provide this resource.
+            description: The status of Kafka MirrorMaker.
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: strimzi-cluster-operator-kafka-client-delegation
+  labels:
+    app: strimzi
+# The Kafka clients cluster role must be bound to the cluster operator service account so that it can delegate the
+# cluster role to the Kafka clients using it for consuming from closest replica.
+# This must be done to avoid escalating privileges which would be blocked by Kubernetes.
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: myproject
+roleRef:
+  kind: ClusterRole
+  name: strimzi-kafka-client
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: strimzi-cluster-operator-watched
+  labels:
+    app: strimzi
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: myproject
+roleRef:
+  kind: ClusterRole
+  name: strimzi-cluster-operator-watched
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkabridges.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  names:
+    kind: KafkaBridge
+    listKind: KafkaBridgeList
+    singular: kafkabridge
+    plural: kafkabridges
+    shortNames:
+    - kb
+    categories:
+    - strimzi
+  scope: Namespaced
+  conversion:
+    strategy: None
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+        labelSelectorPath: .status.labelSelector
+    additionalPrinterColumns:
+    - name: Desired replicas
+      description: The desired number of Kafka Bridge replicas
+      jsonPath: .spec.replicas
+      type: integer
+    - name: Bootstrap Servers
+      description: The boostrap servers
+      jsonPath: .spec.bootstrapServers
+      type: string
+      priority: 1
+    - name: Ready
+      description: The state of the custom resource
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+      type: string
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              replicas:
+                type: integer
+                minimum: 0
+                description: The number of pods in the `Deployment`.
+              image:
+                type: string
+                description: The docker image for the pods.
+              bootstrapServers:
+                type: string
+                description: A list of host:port pairs for establishing the initial connection to the Kafka cluster.
+              tls:
+                type: object
+                properties:
+                  trustedCertificates:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        certificate:
+                          type: string
+                          description: The name of the file certificate in the Secret.
+                        secretName:
+                          type: string
+                          description: The name of the Secret containing the certificate.
+                      required:
+                      - certificate
+                      - secretName
+                    description: Trusted certificates for TLS connection.
+                description: TLS configuration for connecting Kafka Bridge to the cluster.
+              authentication:
+                type: object
+                properties:
+                  accessToken:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                        description: The key under which the secret value is stored in the Kubernetes Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Kubernetes Secret containing the secret value.
+                    required:
+                    - key
+                    - secretName
+                    description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
+                  accessTokenIsJwt:
+                    type: boolean
+                    description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                  audience:
+                    type: string
+                    description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
+                  certificateAndKey:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                        description: The name of the file certificate in the Secret.
+                      key:
+                        type: string
+                        description: The name of the private key in the Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Secret containing the certificate.
+                    required:
+                    - certificate
+                    - key
+                    - secretName
+                    description: Reference to the `Secret` which holds the certificate and private key pair.
+                  clientId:
+                    type: string
+                    description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                  clientSecret:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                        description: The key under which the secret value is stored in the Kubernetes Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Kubernetes Secret containing the secret value.
+                    required:
+                    - key
+                    - secretName
+                    description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                  connectTimeoutSeconds:
+                    type: integer
+                    description: "The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds."
+                  disableTlsHostnameVerification:
+                    type: boolean
+                    description: Enable or disable TLS hostname verification. Default value is `false`.
+                  enableMetrics:
+                    type: boolean
+                    description: Enable or disable OAuth metrics. Default value is `false`.
+                  maxTokenExpirySeconds:
+                    type: integer
+                    description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
+                  passwordSecret:
+                    type: object
+                    properties:
+                      password:
+                        type: string
+                        description: The name of the key in the Secret under which the password is stored.
+                      secretName:
+                        type: string
+                        description: The name of the Secret containing the password.
+                    required:
+                    - password
+                    - secretName
+                    description: Reference to the `Secret` which holds the password.
+                  readTimeoutSeconds:
+                    type: integer
+                    description: "The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds."
+                  refreshToken:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                        description: The key under which the secret value is stored in the Kubernetes Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Kubernetes Secret containing the secret value.
+                    required:
+                    - key
+                    - secretName
+                    description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
+                  scope:
+                    type: string
+                    description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
+                  tlsTrustedCertificates:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        certificate:
+                          type: string
+                          description: The name of the file certificate in the Secret.
+                        secretName:
+                          type: string
+                          description: The name of the Secret containing the certificate.
+                      required:
+                      - certificate
+                      - secretName
+                    description: Trusted certificates for TLS connection to the OAuth server.
+                  tokenEndpointUri:
+                    type: string
+                    description: Authorization server token endpoint URI.
+                  type:
+                    type: string
+                    enum:
+                    - tls
+                    - scram-sha-256
+                    - scram-sha-512
+                    - plain
+                    - oauth
+                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                  username:
+                    type: string
+                    description: Username used for the authentication.
+                required:
+                - type
+                description: Authentication configuration for connecting to the cluster.
+              http:
+                type: object
+                properties:
+                  port:
+                    type: integer
+                    minimum: 1023
+                    description: The port which is the server listening on.
+                  cors:
+                    type: object
+                    properties:
+                      allowedOrigins:
+                        type: array
+                        items:
+                          type: string
+                        description: List of allowed origins. Java regular expressions can be used.
+                      allowedMethods:
+                        type: array
+                        items:
+                          type: string
+                        description: List of allowed HTTP methods.
+                    required:
+                    - allowedOrigins
+                    - allowedMethods
+                    description: CORS configuration for the HTTP Bridge.
+                description: The HTTP related configuration.
+              adminClient:
+                type: object
+                properties:
+                  config:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: The Kafka AdminClient configuration used for AdminClient instances created by the bridge.
+                description: Kafka AdminClient related configuration.
+              consumer:
+                type: object
+                properties:
+                  config:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: "The Kafka consumer configuration used for consumer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+                description: Kafka consumer related configuration.
+              producer:
+                type: object
+                properties:
+                  config:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: "The Kafka producer configuration used for producer instances created by the bridge. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, sasl., security. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+                description: Kafka producer related configuration.
+              resources:
+                type: object
+                properties:
+                  limits:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  requests:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                description: CPU and memory resources to reserve.
+              jvmOptions:
+                type: object
+                properties:
+                  "-XX":
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: A map of -XX options to the JVM.
+                  "-Xms":
+                    type: string
+                    pattern: "^[0-9]+[mMgG]?$"
+                    description: -Xms option to to the JVM.
+                  "-Xmx":
+                    type: string
+                    pattern: "^[0-9]+[mMgG]?$"
+                    description: -Xmx option to to the JVM.
+                  gcLoggingEnabled:
+                    type: boolean
+                    description: Specifies whether the Garbage Collection logging is enabled. The default is false.
+                  javaSystemProperties:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          description: The system property name.
+                        value:
+                          type: string
+                          description: The system property value.
+                    description: A map of additional system properties which will be passed using the `-D` option to the JVM.
+                description: '**Currently not supported** JVM Options for pods.'
+              logging:
+                type: object
+                properties:
+                  loggers:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: A Map from logger name to logger level.
+                  type:
+                    type: string
+                    enum:
+                    - inline
+                    - external
+                    description: "Logging type, must be either 'inline' or 'external'."
+                  valueFrom:
+                    type: object
+                    properties:
+                      configMapKeyRef:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        description: Reference to the key in the ConfigMap containing the configuration.
+                    description: '`ConfigMap` entry where the logging configuration is stored. '
+                required:
+                - type
+                description: Logging configuration for Kafka Bridge.
+              clientRackInitImage:
+                type: string
+                description: The image of the init container used for initializing the `client.rack`.
+              rack:
+                type: object
+                properties:
+                  topologyKey:
+                    type: string
+                    example: topology.kubernetes.io/zone
+                    description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
+                required:
+                - topologyKey
+                description: Configuration of the node label which will be used as the client.rack consumer configuration.
+              enableMetrics:
+                type: boolean
+                description: Enable the metrics for the Kafka Bridge. Default is false.
+              livenessProbe:
+                type: object
+                properties:
+                  failureThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                  initialDelaySeconds:
+                    type: integer
+                    minimum: 0
+                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  periodSeconds:
+                    type: integer
+                    minimum: 1
+                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                  successThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                description: Pod liveness checking.
+              readinessProbe:
+                type: object
+                properties:
+                  failureThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                  initialDelaySeconds:
+                    type: integer
+                    minimum: 0
+                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  periodSeconds:
+                    type: integer
+                    minimum: 1
+                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                  successThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                description: Pod readiness checking.
+              template:
+                type: object
+                properties:
+                  deployment:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                      deploymentStrategy:
+                        type: string
+                        enum:
+                        - RollingUpdate
+                        - Recreate
+                        description: Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
+                    description: Template for Kafka Bridge `Deployment`.
+                  pod:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                      imagePullSecrets:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        description: "List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored."
+                      securityContext:
+                        type: object
+                        properties:
+                          fsGroup:
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          supplementalGroups:
+                            type: array
+                            items:
+                              type: integer
+                          sysctls:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Configures pod-level security attributes and common container settings.
+                      terminationGracePeriodSeconds:
+                        type: integer
+                        minimum: 0
+                        description: "The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds."
+                      affinity:
+                        type: object
+                        properties:
+                          nodeAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    preference:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchFields:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: object
+                                properties:
+                                  nodeSelectorTerms:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchFields:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                          podAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaceSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaceSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                          podAntiAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaceSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaceSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                        description: The pod's affinity rules.
+                      tolerations:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              type: integer
+                            value:
+                              type: string
+                        description: The pod's tolerations.
+                      priorityClassName:
+                        type: string
+                        description: "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}."
+                      schedulerName:
+                        type: string
+                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                      hostAliases:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
+                            ip:
+                              type: string
+                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                      tmpDirSizeLimit:
+                        type: string
+                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services should be injected into Pod's environment variables.
+                      topologySpreadConstraints:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            labelSelector:
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            maxSkew:
+                              type: integer
+                            minDomains:
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                        description: The pod's topology spread constraints.
+                    description: Template for Kafka Bridge `Pods`.
+                  apiService:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                      ipFamilyPolicy:
+                        type: string
+                        enum:
+                        - SingleStack
+                        - PreferDualStack
+                        - RequireDualStack
+                        description: "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer."
+                      ipFamilies:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                          - IPv4
+                          - IPv6
+                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer."
+                    description: Template for Kafka Bridge API `Service`.
+                  podDisruptionBudget:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
+                      maxUnavailable:
+                        type: integer
+                        minimum: 0
+                        description: "Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1."
+                    description: Template for Kafka Bridge `PodDisruptionBudget`.
+                  bridgeContainer:
+                    type: object
+                    properties:
+                      env:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: The environment variable key.
+                            value:
+                              type: string
+                              description: The environment variable value.
+                        description: Environment variables which should be applied to the container.
+                      securityContext:
+                        type: object
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            type: object
+                            properties:
+                              add:
+                                type: array
+                                items:
+                                  type: string
+                              drop:
+                                type: array
+                                items:
+                                  type: string
+                          privileged:
+                            type: boolean
+                          procMount:
+                            type: string
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Security context for the container.
+                    description: Template for the Kafka Bridge container.
+                  clusterRoleBinding:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                    description: Template for the Kafka Bridge ClusterRoleBinding.
+                  serviceAccount:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                    description: Template for the Kafka Bridge service account.
+                  initContainer:
+                    type: object
+                    properties:
+                      env:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: The environment variable key.
+                            value:
+                              type: string
+                              description: The environment variable value.
+                        description: Environment variables which should be applied to the container.
+                      securityContext:
+                        type: object
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            type: object
+                            properties:
+                              add:
+                                type: array
+                                items:
+                                  type: string
+                              drop:
+                                type: array
+                                items:
+                                  type: string
+                          privileged:
+                            type: boolean
+                          procMount:
+                            type: string
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Security context for the container.
+                    description: Template for the Kafka Bridge init container.
+                description: Template for Kafka Bridge resources. The template allows users to specify how a `Deployment` and `Pod` is generated.
+              tracing:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                    - jaeger
+                    - opentelemetry
+                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
+                required:
+                - type
+                description: The configuration of tracing in Kafka Bridge.
+            required:
+            - bootstrapServers
+            description: The specification of the Kafka Bridge.
+          status:
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
+                    status:
+                      type: string
+                      description: "The status of the condition, either True, False or Unknown."
+                    lastTransitionTime:
+                      type: string
+                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                    reason:
+                      type: string
+                      description: The reason for the condition's last transition (a single word in CamelCase).
+                    message:
+                      type: string
+                      description: Human-readable message indicating details about the condition's last transition.
+                description: List of status conditions.
+              observedGeneration:
+                type: integer
+                description: The generation of the CRD that was last reconciled by the operator.
+              url:
+                type: string
+                description: The URL at which external client applications can access the Kafka Bridge.
+              labelSelector:
+                type: string
+                description: Label selector for pods providing this resource.
+              replicas:
+                type: integer
+                description: The current number of pods being used to provide this resource.
+            description: The status of the Kafka Bridge.
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-cluster-operator-watched
+  labels:
+    app: strimzi
+rules:
+  # Resources in this role are being watched by the operator. When operator is deployed as cluster-wide, these permissions
+  # need to be granted to the operator on a cluster wide level as well, even if the operands will be deployed only in
+  # few of the namespaces in given cluster. This is required to set up the Kubernetes watches and informers.
+  # Note: The rights included in this role might change in the future
+  - apiGroups:
+      - ""
+    resources:
+      # The cluster operator needs to access and delete pods, this is to allow it to monitor pod health and coordinate rolling updates
+      - pods
+    verbs:
+      - watch
+      - list
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
+      - kafkas
+      - kafkas/status
+      # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
+      - kafkaconnects
+      - kafkaconnects/status
+      # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
+      - kafkaconnectors
+      - kafkaconnectors/status
+      # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
+      - kafkamirrormakers
+      - kafkamirrormakers/status
+      # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
+      - kafkabridges
+      - kafkabridges/status
+      # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
+      - kafkamirrormaker2s
+      - kafkamirrormaker2s/status
+      # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
+      - kafkarebalances
+      - kafkarebalances/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - "core.strimzi.io"
+    resources:
+      # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
+      - strimzipodsets
+      - strimzipodsets/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkamirrormaker2s.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  names:
+    kind: KafkaMirrorMaker2
+    listKind: KafkaMirrorMaker2List
+    singular: kafkamirrormaker2
+    plural: kafkamirrormaker2s
+    shortNames:
+    - kmm2
+    categories:
+    - strimzi
+  scope: Namespaced
+  conversion:
+    strategy: None
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+        labelSelectorPath: .status.labelSelector
+    additionalPrinterColumns:
+    - name: Desired replicas
+      description: The desired number of Kafka MirrorMaker 2.0 replicas
+      jsonPath: .spec.replicas
+      type: integer
+    - name: Ready
+      description: The state of the custom resource
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+      type: string
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              version:
+                type: string
+                description: "The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version."
+              replicas:
+                type: integer
+                description: The number of pods in the Kafka Connect group.
+              image:
+                type: string
+                description: The docker image for the pods.
+              connectCluster:
+                type: string
+                description: The cluster alias used for Kafka Connect. The alias must match a cluster in the list at `spec.clusters`.
+              clusters:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    alias:
+                      type: string
+                      pattern: "^[a-zA-Z0-9\\._\\-]{1,100}$"
+                      description: Alias used to reference the Kafka cluster.
+                    bootstrapServers:
+                      type: string
+                      description: A comma-separated list of `host:port` pairs for establishing the connection to the Kafka cluster.
+                    tls:
+                      type: object
+                      properties:
+                        trustedCertificates:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              certificate:
+                                type: string
+                                description: The name of the file certificate in the Secret.
+                              secretName:
+                                type: string
+                                description: The name of the Secret containing the certificate.
+                            required:
+                            - certificate
+                            - secretName
+                          description: Trusted certificates for TLS connection.
+                      description: TLS configuration for connecting MirrorMaker 2.0 connectors to a cluster.
+                    authentication:
+                      type: object
+                      properties:
+                        accessToken:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                              description: The key under which the secret value is stored in the Kubernetes Secret.
+                            secretName:
+                              type: string
+                              description: The name of the Kubernetes Secret containing the secret value.
+                          required:
+                          - key
+                          - secretName
+                          description: Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
+                        accessTokenIsJwt:
+                          type: boolean
+                          description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                        audience:
+                          type: string
+                          description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
+                        certificateAndKey:
+                          type: object
+                          properties:
+                            certificate:
+                              type: string
+                              description: The name of the file certificate in the Secret.
+                            key:
+                              type: string
+                              description: The name of the private key in the Secret.
+                            secretName:
+                              type: string
+                              description: The name of the Secret containing the certificate.
+                          required:
+                          - certificate
+                          - key
+                          - secretName
+                          description: Reference to the `Secret` which holds the certificate and private key pair.
+                        clientId:
+                          type: string
+                          description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                        clientSecret:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                              description: The key under which the secret value is stored in the Kubernetes Secret.
+                            secretName:
+                              type: string
+                              description: The name of the Kubernetes Secret containing the secret value.
+                          required:
+                          - key
+                          - secretName
+                          description: Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+                        connectTimeoutSeconds:
+                          type: integer
+                          description: "The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds."
+                        disableTlsHostnameVerification:
+                          type: boolean
+                          description: Enable or disable TLS hostname verification. Default value is `false`.
+                        enableMetrics:
+                          type: boolean
+                          description: Enable or disable OAuth metrics. Default value is `false`.
+                        maxTokenExpirySeconds:
+                          type: integer
+                          description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
+                        passwordSecret:
+                          type: object
+                          properties:
+                            password:
+                              type: string
+                              description: The name of the key in the Secret under which the password is stored.
+                            secretName:
+                              type: string
+                              description: The name of the Secret containing the password.
+                          required:
+                          - password
+                          - secretName
+                          description: Reference to the `Secret` which holds the password.
+                        readTimeoutSeconds:
+                          type: integer
+                          description: "The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds."
+                        refreshToken:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                              description: The key under which the secret value is stored in the Kubernetes Secret.
+                            secretName:
+                              type: string
+                              description: The name of the Kubernetes Secret containing the secret value.
+                          required:
+                          - key
+                          - secretName
+                          description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
+                        scope:
+                          type: string
+                          description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
+                        tlsTrustedCertificates:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              certificate:
+                                type: string
+                                description: The name of the file certificate in the Secret.
+                              secretName:
+                                type: string
+                                description: The name of the Secret containing the certificate.
+                            required:
+                            - certificate
+                            - secretName
+                          description: Trusted certificates for TLS connection to the OAuth server.
+                        tokenEndpointUri:
+                          type: string
+                          description: Authorization server token endpoint URI.
+                        type:
+                          type: string
+                          enum:
+                          - tls
+                          - scram-sha-256
+                          - scram-sha-512
+                          - plain
+                          - oauth
+                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                        username:
+                          type: string
+                          description: Username used for the authentication.
+                      required:
+                      - type
+                      description: Authentication configuration for connecting to the cluster.
+                    config:
+                      x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                      description: "The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+                  required:
+                  - alias
+                  - bootstrapServers
+                description: Kafka clusters for mirroring.
+              mirrors:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    sourceCluster:
+                      type: string
+                      description: The alias of the source cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
+                    targetCluster:
+                      type: string
+                      description: The alias of the target cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.
+                    sourceConnector:
+                      type: object
+                      properties:
+                        tasksMax:
+                          type: integer
+                          minimum: 1
+                          description: The maximum number of tasks for the Kafka Connector.
+                        config:
+                          x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                        autoRestart:
+                          type: object
+                          properties:
+                            enabled:
+                              type: boolean
+                              description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                          description: Automatic restart of connector and tasks configuration.
+                        pause:
+                          type: boolean
+                          description: Whether the connector should be paused. Defaults to false.
+                      description: The specification of the Kafka MirrorMaker 2.0 source connector.
+                    heartbeatConnector:
+                      type: object
+                      properties:
+                        tasksMax:
+                          type: integer
+                          minimum: 1
+                          description: The maximum number of tasks for the Kafka Connector.
+                        config:
+                          x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                        autoRestart:
+                          type: object
+                          properties:
+                            enabled:
+                              type: boolean
+                              description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                          description: Automatic restart of connector and tasks configuration.
+                        pause:
+                          type: boolean
+                          description: Whether the connector should be paused. Defaults to false.
+                      description: The specification of the Kafka MirrorMaker 2.0 heartbeat connector.
+                    checkpointConnector:
+                      type: object
+                      properties:
+                        tasksMax:
+                          type: integer
+                          minimum: 1
+                          description: The maximum number of tasks for the Kafka Connector.
+                        config:
+                          x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                        autoRestart:
+                          type: object
+                          properties:
+                            enabled:
+                              type: boolean
+                              description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                          description: Automatic restart of connector and tasks configuration.
+                        pause:
+                          type: boolean
+                          description: Whether the connector should be paused. Defaults to false.
+                      description: The specification of the Kafka MirrorMaker 2.0 checkpoint connector.
+                    topicsPattern:
+                      type: string
+                      description: "A regular expression matching the topics to be mirrored, for example, \"topic1\\|topic2\\|topic3\". Comma-separated lists are also supported."
+                    topicsBlacklistPattern:
+                      type: string
+                      description: A regular expression matching the topics to exclude from mirroring. Comma-separated lists are also supported.
+                    topicsExcludePattern:
+                      type: string
+                      description: A regular expression matching the topics to exclude from mirroring. Comma-separated lists are also supported.
+                    groupsPattern:
+                      type: string
+                      description: A regular expression matching the consumer groups to be mirrored. Comma-separated lists are also supported.
+                    groupsBlacklistPattern:
+                      type: string
+                      description: A regular expression matching the consumer groups to exclude from mirroring. Comma-separated lists are also supported.
+                    groupsExcludePattern:
+                      type: string
+                      description: A regular expression matching the consumer groups to exclude from mirroring. Comma-separated lists are also supported.
+                  required:
+                  - sourceCluster
+                  - targetCluster
+                description: Configuration of the MirrorMaker 2.0 connectors.
+              resources:
+                type: object
+                properties:
+                  limits:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  requests:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                description: The maximum limits for CPU and memory resources and the requested initial resources.
+              livenessProbe:
+                type: object
+                properties:
+                  failureThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                  initialDelaySeconds:
+                    type: integer
+                    minimum: 0
+                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  periodSeconds:
+                    type: integer
+                    minimum: 1
+                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                  successThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                description: Pod liveness checking.
+              readinessProbe:
+                type: object
+                properties:
+                  failureThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                  initialDelaySeconds:
+                    type: integer
+                    minimum: 0
+                    description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  periodSeconds:
+                    type: integer
+                    minimum: 1
+                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                  successThreshold:
+                    type: integer
+                    minimum: 1
+                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                description: Pod readiness checking.
+              jvmOptions:
+                type: object
+                properties:
+                  "-XX":
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: A map of -XX options to the JVM.
+                  "-Xms":
+                    type: string
+                    pattern: "^[0-9]+[mMgG]?$"
+                    description: -Xms option to to the JVM.
+                  "-Xmx":
+                    type: string
+                    pattern: "^[0-9]+[mMgG]?$"
+                    description: -Xmx option to to the JVM.
+                  gcLoggingEnabled:
+                    type: boolean
+                    description: Specifies whether the Garbage Collection logging is enabled. The default is false.
+                  javaSystemProperties:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          description: The system property name.
+                        value:
+                          type: string
+                          description: The system property value.
+                    description: A map of additional system properties which will be passed using the `-D` option to the JVM.
+                description: JVM Options for pods.
+              jmxOptions:
+                type: object
+                properties:
+                  authentication:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                        - password
+                        description: Authentication type. Currently the only supported types are `password`.`password` type creates a username and protected port with no TLS.
+                    required:
+                    - type
+                    description: Authentication configuration for connecting to the JMX port.
+                description: JMX Options.
+              logging:
+                type: object
+                properties:
+                  loggers:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: A Map from logger name to logger level.
+                  type:
+                    type: string
+                    enum:
+                    - inline
+                    - external
+                    description: "Logging type, must be either 'inline' or 'external'."
+                  valueFrom:
+                    type: object
+                    properties:
+                      configMapKeyRef:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        description: Reference to the key in the ConfigMap containing the configuration.
+                    description: '`ConfigMap` entry where the logging configuration is stored. '
+                required:
+                - type
+                description: Logging configuration for Kafka Connect.
+              clientRackInitImage:
+                type: string
+                description: The image of the init container used for initializing the `client.rack`.
+              rack:
+                type: object
+                properties:
+                  topologyKey:
+                    type: string
+                    example: topology.kubernetes.io/zone
+                    description: "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0."
+                required:
+                - topologyKey
+                description: Configuration of the node label which will be used as the `client.rack` consumer configuration.
+              tracing:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                    - jaeger
+                    - opentelemetry
+                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
+                required:
+                - type
+                description: The configuration of tracing in Kafka Connect.
+              template:
+                type: object
+                properties:
+                  deployment:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                      deploymentStrategy:
+                        type: string
+                        enum:
+                        - RollingUpdate
+                        - Recreate
+                        description: Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.
+                    description: Template for Kafka Connect `Deployment`.
+                  pod:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                      imagePullSecrets:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        description: "List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored."
+                      securityContext:
+                        type: object
+                        properties:
+                          fsGroup:
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          supplementalGroups:
+                            type: array
+                            items:
+                              type: integer
+                          sysctls:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Configures pod-level security attributes and common container settings.
+                      terminationGracePeriodSeconds:
+                        type: integer
+                        minimum: 0
+                        description: "The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds."
+                      affinity:
+                        type: object
+                        properties:
+                          nodeAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    preference:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchFields:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: object
+                                properties:
+                                  nodeSelectorTerms:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchFields:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                          podAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaceSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaceSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                          podAntiAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaceSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaceSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                        description: The pod's affinity rules.
+                      tolerations:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              type: integer
+                            value:
+                              type: string
+                        description: The pod's tolerations.
+                      priorityClassName:
+                        type: string
+                        description: "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}."
+                      schedulerName:
+                        type: string
+                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                      hostAliases:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
+                            ip:
+                              type: string
+                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                      tmpDirSizeLimit:
+                        type: string
+                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services should be injected into Pod's environment variables.
+                      topologySpreadConstraints:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            labelSelector:
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            maxSkew:
+                              type: integer
+                            minDomains:
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                        description: The pod's topology spread constraints.
+                    description: Template for Kafka Connect `Pods`.
+                  apiService:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                      ipFamilyPolicy:
+                        type: string
+                        enum:
+                        - SingleStack
+                        - PreferDualStack
+                        - RequireDualStack
+                        description: "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer."
+                      ipFamilies:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                          - IPv4
+                          - IPv6
+                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer."
+                    description: Template for Kafka Connect API `Service`.
+                  connectContainer:
+                    type: object
+                    properties:
+                      env:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: The environment variable key.
+                            value:
+                              type: string
+                              description: The environment variable value.
+                        description: Environment variables which should be applied to the container.
+                      securityContext:
+                        type: object
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            type: object
+                            properties:
+                              add:
+                                type: array
+                                items:
+                                  type: string
+                              drop:
+                                type: array
+                                items:
+                                  type: string
+                          privileged:
+                            type: boolean
+                          procMount:
+                            type: string
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Security context for the container.
+                    description: Template for the Kafka Connect container.
+                  initContainer:
+                    type: object
+                    properties:
+                      env:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: The environment variable key.
+                            value:
+                              type: string
+                              description: The environment variable value.
+                        description: Environment variables which should be applied to the container.
+                      securityContext:
+                        type: object
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            type: object
+                            properties:
+                              add:
+                                type: array
+                                items:
+                                  type: string
+                              drop:
+                                type: array
+                                items:
+                                  type: string
+                          privileged:
+                            type: boolean
+                          procMount:
+                            type: string
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Security context for the container.
+                    description: Template for the Kafka init container.
+                  podDisruptionBudget:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
+                      maxUnavailable:
+                        type: integer
+                        minimum: 0
+                        description: "Maximum number of unavailable pods to allow automatic Pod eviction. A Pod eviction is allowed when the `maxUnavailable` number of pods or fewer are unavailable after the eviction. Setting this value to 0 prevents all voluntary evictions, so the pods must be evicted manually. Defaults to 1."
+                    description: Template for Kafka Connect `PodDisruptionBudget`.
+                  serviceAccount:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                    description: Template for the Kafka Connect service account.
+                  clusterRoleBinding:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                    description: Template for the Kafka Connect ClusterRoleBinding.
+                  buildPod:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                      imagePullSecrets:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        description: "List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored."
+                      securityContext:
+                        type: object
+                        properties:
+                          fsGroup:
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          supplementalGroups:
+                            type: array
+                            items:
+                              type: integer
+                          sysctls:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Configures pod-level security attributes and common container settings.
+                      terminationGracePeriodSeconds:
+                        type: integer
+                        minimum: 0
+                        description: "The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds."
+                      affinity:
+                        type: object
+                        properties:
+                          nodeAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    preference:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchFields:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: object
+                                properties:
+                                  nodeSelectorTerms:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchFields:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                          podAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaceSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaceSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                          podAntiAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaceSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaceSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                        description: The pod's affinity rules.
+                      tolerations:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              type: integer
+                            value:
+                              type: string
+                        description: The pod's tolerations.
+                      priorityClassName:
+                        type: string
+                        description: "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}."
+                      schedulerName:
+                        type: string
+                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                      hostAliases:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
+                            ip:
+                              type: string
+                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                      tmpDirSizeLimit:
+                        type: string
+                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services should be injected into Pod's environment variables.
+                      topologySpreadConstraints:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            labelSelector:
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            maxSkew:
+                              type: integer
+                            minDomains:
+                              type: integer
+                            nodeAffinityPolicy:
+                              type: string
+                            nodeTaintsPolicy:
+                              type: string
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                        description: The pod's topology spread constraints.
+                    description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
+                  buildContainer:
+                    type: object
+                    properties:
+                      env:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: The environment variable key.
+                            value:
+                              type: string
+                              description: The environment variable value.
+                        description: Environment variables which should be applied to the container.
+                      securityContext:
+                        type: object
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            type: object
+                            properties:
+                              add:
+                                type: array
+                                items:
+                                  type: string
+                              drop:
+                                type: array
+                                items:
+                                  type: string
+                          privileged:
+                            type: boolean
+                          procMount:
+                            type: string
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            type: integer
+                          seLinuxOptions:
+                            type: object
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                          seccompProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                          windowsOptions:
+                            type: object
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                        description: Security context for the container.
+                    description: Template for the Kafka Connect Build container. The build container is used only on Kubernetes.
+                  buildConfig:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
+                      pullSecret:
+                        type: string
+                        description: Container Registry Secret with the credentials for pulling the base image.
+                    description: Template for the Kafka Connect BuildConfig used to build new container images. The BuildConfig is used only on OpenShift.
+                  buildServiceAccount:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                    description: Template for the Kafka Connect Build service account.
+                  jmxSecret:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`."
+                        description: Metadata applied to the resource.
+                    description: Template for Secret of the Kafka Connect Cluster JMX authentication.
+                description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated."
+              externalConfiguration:
+                type: object
+                properties:
+                  env:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          description: Name of the environment variable which will be passed to the Kafka Connect pods. The name of the environment variable cannot start with `KAFKA_` or `STRIMZI_`.
+                        valueFrom:
+                          type: object
+                          properties:
+                            configMapKeyRef:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: Reference to a key in a ConfigMap.
+                            secretKeyRef:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: Reference to a key in a Secret.
+                          description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
+                      required:
+                      - name
+                      - valueFrom
+                    description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as environment variables.
+                  volumes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        configMap:
+                          type: object
+                          properties:
+                            defaultMode:
+                              type: integer
+                            items:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  mode:
+                                    type: integer
+                                  path:
+                                    type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
+                        name:
+                          type: string
+                          description: Name of the volume which will be added to the Kafka Connect pods.
+                        secret:
+                          type: object
+                          properties:
+                            defaultMode:
+                              type: integer
+                            items:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  mode:
+                                    type: integer
+                                  path:
+                                    type: string
+                            optional:
+                              type: boolean
+                            secretName:
+                              type: string
+                          description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
+                      required:
+                      - name
+                    description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
+                description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
+              metricsConfig:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                    - jmxPrometheusExporter
+                    description: Metrics type. Only 'jmxPrometheusExporter' supported currently.
+                  valueFrom:
+                    type: object
+                    properties:
+                      configMapKeyRef:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        description: Reference to the key in the ConfigMap containing the configuration.
+                    description: "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. For details of the structure of this configuration, see the {JMXExporter}."
+                required:
+                - type
+                - valueFrom
+                description: Metrics configuration.
+            required:
+            - connectCluster
+            description: The specification of the Kafka MirrorMaker 2.0 cluster.
+          status:
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
+                    status:
+                      type: string
+                      description: "The status of the condition, either True, False or Unknown."
+                    lastTransitionTime:
+                      type: string
+                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                    reason:
+                      type: string
+                      description: The reason for the condition's last transition (a single word in CamelCase).
+                    message:
+                      type: string
+                      description: Human-readable message indicating details about the condition's last transition.
+                description: List of status conditions.
+              observedGeneration:
+                type: integer
+                description: The generation of the CRD that was last reconciled by the operator.
+              url:
+                type: string
+                description: The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
+              autoRestartStatuses:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    count:
+                      type: integer
+                      description: The number of times the connector or task is restarted.
+                    connectorName:
+                      type: string
+                      description: The name of the connector being restarted.
+                    lastRestartTimestamp:
+                      type: string
+                      description: The last time the automatic restart was attempted. The required format is 'yyyy-MM-ddTHH:mm:ssZ' in the UTC time zone.
+                description: List of MirrorMaker 2.0 connector auto restart statuses.
+              connectorPlugins:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: The type of the connector plugin. The available types are `sink` and `source`.
+                    version:
+                      type: string
+                      description: The version of the connector plugin.
+                    class:
+                      type: string
+                      description: The class of the connector plugin.
+                description: The list of connector plugins available in this Kafka Connect deployment.
+              connectors:
+                type: array
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                description: "List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API."
+              labelSelector:
+                type: string
+                description: Label selector for pods providing this resource.
+              replicas:
+                type: integer
+                description: The current number of pods being used to provide this resource.
+            description: The status of the Kafka MirrorMaker 2.0 cluster.
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: strimzi
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: myproject
+roleRef:
+  kind: ClusterRole
+  name: strimzi-cluster-operator-namespaced
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: strimzi-cluster-operator-entity-operator-delegation
+  labels:
+    app: strimzi
+# The Entity Operator cluster role must be bound to the cluster operator service account so that it can delegate the cluster role to the Entity Operator.
+# This must be done to avoid escalating privileges which would be blocked by Kubernetes.
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: myproject
+roleRef:
+  kind: ClusterRole
+  name: strimzi-entity-operator
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-cluster-operator-leader-election
+  labels:
+    app: strimzi
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      # The cluster operator needs to access and manage leases for leader election
+      # The "create" verb cannot be used with "resourceNames"
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      # The cluster operator needs to access and manage leases for leader election
+      - leases
+    resourceNames:
+      # The default RBAC files give the operator only access to the Lease resource names strimzi-cluster-operator
+      # If you want to use another resource name or resource namespace, you have to configure the RBAC resources accordingly
+      - strimzi-cluster-operator
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - patch
+      - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-kafka-broker
+  labels:
+    app: strimzi
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      # The Kafka Brokers require "get" permissions to view the node they are on
+      # This information is used to generate a Rack ID that is used for High Availability configurations
+      - nodes
+    verbs:
+      - get
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: strimzi
+data:
+  log4j2.properties: |
+    name = COConfig
+    monitorInterval = 30
+
+    appender.console.type = Console
+    appender.console.name = STDOUT
+    appender.console.layout.type = PatternLayout
+    appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+    rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
+    rootLogger.appenderRefs = stdout
+    rootLogger.appenderRef.console.ref = STDOUT
+
+    # Kafka AdminClient logging is a bit noisy at INFO level
+    logger.kafka.name = org.apache.kafka
+    logger.kafka.level = WARN
+
+    # Zookeeper is very verbose even on INFO level -> We set it to WARN by default
+    logger.zookeepertrustmanager.name = org.apache.zookeeper
+    logger.zookeepertrustmanager.level = WARN
+
+    # Keeps separate level for Netty logging -> to not be changed by the root logger
+    logger.netty.name = io.netty
+    logger.netty.level = INFO
+
+    # Keeps separate log level for OkHttp client
+    logger.okhttp3.name = okhttp3
+    logger.okhttp3.level = INFO
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkarebalances.kafka.strimzi.io
+  labels:
+    app: strimzi
+    strimzi.io/crd-install: "true"
+spec:
+  group: kafka.strimzi.io
+  names:
+    kind: KafkaRebalance
+    listKind: KafkaRebalanceList
+    singular: kafkarebalance
+    plural: kafkarebalances
+    shortNames:
+    - kr
+    categories:
+    - strimzi
+  scope: Namespaced
+  conversion:
+    strategy: None
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Cluster
+      description: The name of the Kafka cluster this resource rebalances
+      jsonPath: .metadata.labels.strimzi\.io/cluster
+      type: string
+    - name: PendingProposal
+      description: A proposal has been requested from Cruise Control
+      jsonPath: ".status.conditions[?(@.type==\"PendingProposal\")].status"
+      type: string
+    - name: ProposalReady
+      description: A proposal is ready and waiting for approval
+      jsonPath: ".status.conditions[?(@.type==\"ProposalReady\")].status"
+      type: string
+    - name: Rebalancing
+      description: Cruise Control is doing the rebalance
+      jsonPath: ".status.conditions[?(@.type==\"Rebalancing\")].status"
+      type: string
+    - name: Ready
+      description: The rebalance is complete
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+      type: string
+    - name: NotReady
+      description: There is an error on the custom resource
+      jsonPath: ".status.conditions[?(@.type==\"NotReady\")].status"
+      type: string
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              mode:
+                type: string
+                enum:
+                - full
+                - add-brokers
+                - remove-brokers
+                description: "Mode to run the rebalancing. The supported modes are `full`, `add-brokers`, `remove-brokers`.\nIf not specified, the `full` mode is used by default. \n\n* `full` mode runs the rebalancing across all the brokers in the cluster.\n* `add-brokers` mode can be used after scaling up the cluster to move some replicas to the newly added brokers.\n* `remove-brokers` mode can be used before scaling down the cluster to move replicas out of the brokers to be removed.\n"
+              brokers:
+                type: array
+                items:
+                  type: integer
+                description: The list of newly added brokers in case of scaling up or the ones to be removed in case of scaling down to use for rebalancing. This list can be used only with rebalancing mode `add-brokers` and `removed-brokers`. It is ignored with `full` mode.
+              goals:
+                type: array
+                items:
+                  type: string
+                description: "A list of goals, ordered by decreasing priority, to use for generating and executing the rebalance proposal. The supported goals are available at https://github.com/linkedin/cruise-control#goals. If an empty goals list is provided, the goals declared in the default.goals Cruise Control configuration parameter are used."
+              skipHardGoalCheck:
+                type: boolean
+                description: Whether to allow the hard goals specified in the Kafka CR to be skipped in optimization proposal generation. This can be useful when some of those hard goals are preventing a balance solution being found. Default is false.
+              rebalanceDisk:
+                type: boolean
+                description: "Enables intra-broker disk balancing, which balances disk space utilization between disks on the same broker. Only applies to Kafka deployments that use JBOD storage with multiple disks. When enabled, inter-broker balancing is disabled. Default is false."
+              excludedTopics:
+                type: string
+                description: A regular expression where any matching topics will be excluded from the calculation of optimization proposals. This expression will be parsed by the java.util.regex.Pattern class; for more information on the supported format consult the documentation for that class.
+              concurrentPartitionMovementsPerBroker:
+                type: integer
+                minimum: 0
+                description: The upper bound of ongoing partition replica movements going into/out of each broker. Default is 5.
+              concurrentIntraBrokerPartitionMovements:
+                type: integer
+                minimum: 0
+                description: The upper bound of ongoing partition replica movements between disks within each broker. Default is 2.
+              concurrentLeaderMovements:
+                type: integer
+                minimum: 0
+                description: The upper bound of ongoing partition leadership movements. Default is 1000.
+              replicationThrottle:
+                type: integer
+                minimum: 0
+                description: "The upper bound, in bytes per second, on the bandwidth used to move replicas. There is no limit by default."
+              replicaMovementStrategies:
+                type: array
+                items:
+                  type: string
+                description: "A list of strategy class names used to determine the execution order for the replica movements in the generated optimization proposal. By default BaseReplicaMovementStrategy is used, which will execute the replica movements in the order that they were generated."
+            description: The specification of the Kafka rebalance.
+          status:
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
+                    status:
+                      type: string
+                      description: "The status of the condition, either True, False or Unknown."
+                    lastTransitionTime:
+                      type: string
+                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                    reason:
+                      type: string
+                      description: The reason for the condition's last transition (a single word in CamelCase).
+                    message:
+                      type: string
+                      description: Human-readable message indicating details about the condition's last transition.
+                description: List of status conditions.
+              observedGeneration:
+                type: integer
+                description: The generation of the CRD that was last reconciled by the operator.
+              sessionId:
+                type: string
+                description: The session identifier for requests to Cruise Control pertaining to this KafkaRebalance resource. This is used by the Kafka Rebalance operator to track the status of ongoing rebalancing operations.
+              optimizationResult:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+                description: A JSON object describing the optimization result.
+            description: The status of the Kafka rebalance.
 
 ---


### PR DESCRIPTION
## Proposed Changes

- Updating just the Strimzi Operator to 0.33
- Putting in the _pure_ manifest from upstream, and doing `sed` to replace namespaces... since https://github.com/knative-sandbox/eventing-kafka-broker/pull/2381 we do have some "patched" (hard-coded) `namespace: kafka` references on the manifest, which this PR changes

0.33 release notes: https://github.com/strimzi/strimzi-kafka-operator/releases/tag/0.33.0
Some highlights:
* Use Java 17 as the runtime for all containers...
* Improved FIPS (Federal Information Processing Standards) support

