### PR TITLE
Increase receivers memory requests

### DIFF
--- a/data-plane/config/broker/500-receiver.yaml
+++ b/data-plane/config/broker/500-receiver.yaml
@@ -119,7 +119,7 @@ spec:
           resources:
             requests:
               cpu: 200m
-              memory: 300Mi
+              memory: 450Mi
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/data-plane/config/channel/500-receiver.yaml
+++ b/data-plane/config/channel/500-receiver.yaml
@@ -119,7 +119,7 @@ spec:
           resources:
             requests:
               cpu: 200m
-              memory: 300Mi
+              memory: 450Mi
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/data-plane/config/sink/500-receiver.yaml
+++ b/data-plane/config/sink/500-receiver.yaml
@@ -119,7 +119,7 @@ spec:
           resources:
             requests:
               cpu: 200m
-              memory: 300Mi
+              memory: 450Mi
           livenessProbe:
             failureThreshold: 3
             httpGet:


### PR DESCRIPTION
## Proposed Changes

- Increase memory limits of kafka broker receiver to get arround [SRVKE-1409](https://issues.redhat.com/browse/SRVKE-1409)
- Increase memory limits of kafka channel receiver
- Increase memory limits of kafka sink receiver