### PR TITLE
Skip `TestBrokerTiggersSink` test

### DIFF
--- a/test/e2e_new/broker_trigger_sink_test.go
+++ b/test/e2e_new/broker_trigger_sink_test.go
@@ -39,6 +39,7 @@ import (
 	           +--------+
 */
 func TestBrokerTriggersSink(t *testing.T) {
+	t.Skip("Skipping due to https://github.com/knative-sandbox/eventing-kafka-broker/issues/2951")
 
 	// Run Test In Parallel With Others
 	t.Parallel()


### PR DESCRIPTION
Skipping `TestBrokerTiggersSink` test due to #2951 and https://github.com/knative-sandbox/eventing-kafka-broker/pull/2932#discussion_r1094801731 to save resources until fixed.