### PR TITLE
Use k8s recommended labels

### DIFF
--- a/control-plane/config/eventing-kafka-broker/100-broker/100-kafka-broker-configmap.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-broker/100-kafka-broker-configmap.yaml
@@ -20,7 +20,7 @@ metadata:
   name: kafka-broker-config
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 data:
   default.topic.partitions: "10"
   default.topic.replication.factor: "3"

--- a/control-plane/config/eventing-kafka-broker/100-channel/100-kafka-channel-configmap.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-channel/100-kafka-channel-configmap.yaml
@@ -20,6 +20,6 @@ metadata:
   name: kafka-channel-config
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 data:
   bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"

--- a/control-plane/config/eventing-kafka-broker/100-channel/100-kafka-channel.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-channel/100-kafka-channel.yaml
@@ -1,1 +1,267 @@
-../../../../third_party/eventing-kafka-latest/channel-crds.yaml
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkachannels.messaging.knative.dev
+  labels:
+    app.kubernetes.io/version: devel
+    knative.dev/crd-install: "true"
+    messaging.knative.dev/subscribable: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: messaging.knative.dev
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: 'KafkaChannel is a resource representing a Channel that is backed by a topic of an Apache Kafka cluster.'
+          type: object
+          properties:
+            spec:
+              description: Spec defines the desired state of the Channel.
+              type: object
+              properties:
+                numPartitions:
+                  description: NumPartitions is the number of partitions of a Kafka topic. By default, it is set to 1.
+                  type: integer
+                  format: int32
+                  default: 1
+                replicationFactor:
+                  description: ReplicationFactor is the replication factor of a Kafka topic. By default, it is set to 1.
+                  type: integer
+                  maximum: 32767
+                  default: 1
+                retentionDuration:
+                  description: RetentionDuration is the retention time for events in a Kafka Topic represented as an ISO-8601 Duration.  By default it is set to 168 hours, which is the precise form of 7 days.
+                  type: string
+                delivery:
+                  description: DeliverySpec contains the default delivery spec for each subscription to this Channelable. Each subscription delivery spec, if any, overrides this global delivery spec.
+                  type: object
+                  properties:
+                    backoffDelay:
+                      description: 'BackoffDelay is the delay before retrying. More information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html - https://en.wikipedia.org/wiki/ISO_8601  For linear policy, backoff delay is backoffDelay*<numberOfRetries>. For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'
+                      type: string
+                    backoffPolicy:
+                      description: BackoffPolicy is the retry backoff policy (linear, exponential).
+                      type: string
+                    deadLetterSink:
+                      description: DeadLetterSink is the sink receiving event that could not be sent to a destination.
+                      type: object
+                      properties:
+                        ref:
+                          description: Ref points to an Addressable.
+                          type: object
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is optional field, it gets defaulted to the object holding it if left out.'
+                              type: string
+                        uri:
+                          description: URI can be an absolute URL(non-empty scheme and non-empty host) pointing to the target or a relative URI. Relative URIs will be resolved using the base URI retrieved from Ref.
+                          type: string
+                    retry:
+                      description: Retry is the minimum number of retries the sender should attempt when sending an event before moving it to the dead letter sink.
+                      type: integer
+                      format: int32
+                  x-kubernetes-preserve-unknown-fields: true # This is necessary to enable experimental features in the delivery
+                subscribers:
+                  description: This is the list of subscriptions for this subscribable.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      delivery:
+                        description: DeliverySpec contains options controlling the event delivery
+                        type: object
+                        properties:
+                          backoffDelay:
+                            description: 'BackoffDelay is the delay before retrying. More information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html - https://en.wikipedia.org/wiki/ISO_8601  For linear policy, backoff delay is backoffDelay*<numberOfRetries>. For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'
+                            type: string
+                          backoffPolicy:
+                            description: BackoffPolicy is the retry backoff policy (linear, exponential).
+                            type: string
+                          deadLetterSink:
+                            description: DeadLetterSink is the sink receiving event that could not be sent to a destination.
+                            type: object
+                            properties:
+                              ref:
+                                description: Ref points to an Addressable.
+                                type: object
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent.
+                                    type: string
+                                  kind:
+                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  namespace:
+                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is optional field, it gets defaulted to the object holding it if left out.'
+                                    type: string
+                              uri:
+                                description: URI can be an absolute URL(non-empty scheme and non-empty host) pointing to the target or a relative URI. Relative URIs will be resolved using the base URI retrieved from Ref.
+                                type: string
+                          retry:
+                            description: Retry is the minimum number of retries the sender should attempt when sending an event before moving it to the dead letter sink.
+                            type: integer
+                            format: int32
+                        x-kubernetes-preserve-unknown-fields: true # This is necessary to enable experimental features in the delivery
+                      generation:
+                        description: Generation of the origin of the subscriber with uid:UID.
+                        type: integer
+                        format: int64
+                      replyUri:
+                        description: ReplyURI is the endpoint for the reply
+                        type: string
+                      subscriberUri:
+                        description: SubscriberURI is the endpoint for the subscriber
+                        type: string
+                      uid:
+                        description: UID is used to understand the origin of the subscriber.
+                        type: string
+            status:
+              description: Status represents the current state of the KafkaChannel. This data may be out of date.
+              type: object
+              properties:
+                address:
+                  type: object
+                  required:
+                    - url
+                  properties:
+                    url:
+                      type: string
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                deadLetterChannel:
+                  description: DeadLetterChannel is a KReference and is set by the channel when it supports native error handling via a channel Failed messages are delivered here.
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is optional field, it gets defaulted to the object holding it if left out.'
+                      type: string
+                deadLetterSinkUri:
+                  description: DeadLetterSinkURI is the resolved URI of the dead letter ref if one is specified in the Spec.Delivery.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
+                subscribers:
+                  description: This is the list of subscription's statuses for this channel.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      message:
+                        description: A human readable message indicating details of Ready status.
+                        type: string
+                      observedGeneration:
+                        description: Generation of the origin of the subscriber with uid:UID.
+                        type: integer
+                        format: int64
+                      ready:
+                        description: Status of the subscriber.
+                        type: string
+                      uid:
+                        description: UID is used to understand the origin of the subscriber.
+                        type: string
+      additionalPrinterColumns:
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+        - name: URL
+          type: string
+          jsonPath: .status.address.url
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+  names:
+    kind: KafkaChannel
+    plural: kafkachannels
+    singular: kafkachannel
+    categories:
+      - all
+      - knative
+      - messaging
+      - channel
+    shortNames:
+      - kc
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: kafka-webhook
+          namespace: knative-eventing
+
+---

--- a/control-plane/config/eventing-kafka-broker/100-kafka-internal/100-consumer.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-kafka-internal/100-consumer.yaml
@@ -17,7 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
     knative.dev/crd-install: "true"
   name: consumers.internal.kafka.eventing.knative.dev
 spec:

--- a/control-plane/config/eventing-kafka-broker/100-kafka-internal/100-consumergroup.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-kafka-internal/100-consumergroup.yaml
@@ -17,7 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
     knative.dev/crd-install: "true"
   name: consumergroups.internal.kafka.eventing.knative.dev
 spec:

--- a/control-plane/config/eventing-kafka-broker/100-sink/100-kafka-sink.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-sink/100-kafka-sink.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     duck.knative.dev/addressable: "true"
     knative.dev/crd-install: "true"
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 spec:
   group: eventing.knative.dev
   names:

--- a/control-plane/config/eventing-kafka-broker/100-source/100-kafka-source.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-source/100-kafka-source.yaml
@@ -1,1 +1,86 @@
-../../../../third_party/eventing-kafka-latest/source-crd.yaml
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/version: devel
+    eventing.knative.dev/source: "true"
+    duck.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
+  annotations:
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "dev.knative.kafka.event" }
+      ]
+  name: kafkasources.sources.knative.dev
+spec:
+  group: sources.knative.dev
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          # this is a work around so we don't need to flush out the
+          # schema for each version at this time
+          #
+          # see issue: https://github.com/knative/serving/issues/912
+          x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+        scale:
+          # specReplicasPath defines the JSONPath inside of a custom resource that corresponds to Scale.Spec.Replicas.
+          specReplicasPath: .spec.consumers
+          # statusReplicasPath defines the JSONPath inside of a custom resource that corresponds to Scale.Status.Replicas.
+          statusReplicasPath: .status.consumers
+          # labelSelectorPath defines the JSONPath inside of a custom resource that corresponds to Scale.Status.Selector
+          labelSelectorPath: .status.selector
+      additionalPrinterColumns:
+        - name: Topics
+          type: string
+          jsonPath: ".spec.topics"
+        - name: BootstrapServers
+          type: string
+          jsonPath: ".spec.bootstrapServers"
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+  names:
+    categories:
+      - all
+      - knative
+      - eventing
+      - sources
+    kind: KafkaSource
+    plural: kafkasources
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: kafka-source-webhook
+          namespace: knative-eventing
+
+---

--- a/control-plane/config/eventing-kafka-broker/100-source/200-sources-observer-aggregated-clusterrole.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-source/200-sources-observer-aggregated-clusterrole.yaml
@@ -18,7 +18,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: eventing-kafka-source-observer
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
     duck.knative.dev/source: "true"
 rules:
   - apiGroups:

--- a/control-plane/config/eventing-kafka-broker/100-source/config-kafka-source-defaults.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-source/config-kafka-source-defaults.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-kafka-source-defaults
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
   annotations:
     knative.dev/example-checksum: "b6ed351d"
 data:

--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-autoscaler.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-autoscaler.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-kafka-autoscaler
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 data:
     class: "keda.autoscaling.knative.dev"
     min-scale: "0"

--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-descheduler.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-descheduler.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-kafka-descheduler
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 data:
     predicates: |+
                     []

--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-leader-election.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-leader-election.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
   name: config-kafka-leader-election
   namespace: knative-eventing
   annotations:

--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-scheduler.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-scheduler.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-kafka-scheduler
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 data:
     predicates: |+
                   [

--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-logging.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-logging.yaml
@@ -20,7 +20,7 @@ metadata:
   name: kafka-config-logging
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 data:
   config.xml: |
     <configuration>

--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-tracing
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
   annotations:

--- a/control-plane/config/eventing-kafka-broker/200-controller/200-addressable-resolver-cluster-role.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/200-addressable-resolver-cluster-role.yaml
@@ -17,7 +17,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-kafka-addressable-resolver
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:

--- a/control-plane/config/eventing-kafka-broker/200-controller/200-channelable-manipulator-clusterrole.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/200-channelable-manipulator-clusterrole.yaml
@@ -17,7 +17,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-channelable-manipulator
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
     duck.knative.dev/channelable: "true"
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:

--- a/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
@@ -19,7 +19,7 @@ kind: ClusterRole
 metadata:
   name: kafka-controller
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 rules:
   - apiGroups:
       - ""

--- a/control-plane/config/eventing-kafka-broker/200-controller/200-controller-service-account.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/200-controller-service-account.yaml
@@ -20,4 +20,4 @@ metadata:
   name: kafka-controller
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel

--- a/control-plane/config/eventing-kafka-broker/200-controller/201-controller-cluster-role-binding.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/201-controller-cluster-role-binding.yaml
@@ -19,7 +19,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -35,7 +35,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller-addressable-resolver
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-controller

--- a/control-plane/config/eventing-kafka-broker/200-controller/500-controller.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/500-controller.yaml
@@ -21,7 +21,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/component: kafka-controller
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels:
@@ -31,7 +33,9 @@ spec:
       name: kafka-controller
       labels:
         app: kafka-controller
-        kafka.eventing.knative.dev/release: devel
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/component: kafka-controller
+        app.kubernetes.io/name: knative-eventing
     spec:
       securityContext:
         runAsNonRoot: true

--- a/control-plane/config/eventing-kafka-broker/200-webhook/100-webhook-cluster-role.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-webhook/100-webhook-cluster-role.yaml
@@ -19,7 +19,7 @@ kind: ClusterRole
 metadata:
   name: kafka-webhook-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 rules:
   # For watching logging configuration and getting certs.
   - apiGroups:

--- a/control-plane/config/eventing-kafka-broker/200-webhook/100-webhook-service-account.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-webhook/100-webhook-service-account.yaml
@@ -20,4 +20,4 @@ metadata:
   name: kafka-webhook-eventing
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel

--- a/control-plane/config/eventing-kafka-broker/200-webhook/200-webhook-cluster-role-binding.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-webhook/200-webhook-cluster-role-binding.yaml
@@ -19,7 +19,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-webhook-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-webhook-eventing

--- a/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-defaulting.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-defaulting.yaml
@@ -17,7 +17,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 webhooks:
   - admissionReviewVersions: [ "v1", "v1beta1" ]
     clientConfig:

--- a/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-pod-defaulting.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-pod-defaulting.yaml
@@ -17,7 +17,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: pods.defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 webhooks:
   # Dispatcher pods webhook config.
   - admissionReviewVersions: [ "v1", "v1beta1" ]
@@ -36,4 +36,4 @@ webhooks:
         app.kubernetes.io/name: knative-eventing
     objectSelector:
       matchLabels:
-        app.kubernetes.io/component: kafka-dispatcher
+        app.kubernetes.io/kind: kafka-dispatcher

--- a/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-secret.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-secret.yaml
@@ -18,5 +18,5 @@ metadata:
   name: kafka-webhook-eventing-certs
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 # The data is populated at install time.

--- a/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-validation.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-validation.yaml
@@ -17,7 +17,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.kafka.eventing.knative.dev
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:

--- a/control-plane/config/eventing-kafka-broker/200-webhook/500-webhook.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-webhook/500-webhook.yaml
@@ -19,7 +19,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/component: kafka-webhook-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels:
@@ -28,7 +30,9 @@ spec:
     metadata:
       labels:
         app: kafka-webhook-eventing
-        kafka.eventing.knative.dev/release: devel
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/component: kafka-webhook-eventing
+        app.kubernetes.io/name: knative-eventing
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -120,7 +124,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/component: kafka-webhook-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   ports:
     - name: https-webhook

--- a/control-plane/config/eventing-kafka-source/200-controller/500-controller.yaml
+++ b/control-plane/config/eventing-kafka-source/200-controller/500-controller.yaml
@@ -21,7 +21,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-source-controller
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/component: kafka-source-controller
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels:
@@ -31,7 +33,9 @@ spec:
       name: kafka-source-controller
       labels:
         app: kafka-source-controller
-        kafka.eventing.knative.dev/release: devel
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/component: kafka-source-controller
+        app.kubernetes.io/name: knative-eventing
     spec:
       securityContext:
         runAsNonRoot: true

--- a/control-plane/config/post-install/200-controller-cluster-role.yaml
+++ b/control-plane/config/post-install/200-controller-cluster-role.yaml
@@ -19,7 +19,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 rules:
   - apiGroups:
       - apps

--- a/control-plane/config/post-install/200-controller-service-account.yaml
+++ b/control-plane/config/post-install/200-controller-service-account.yaml
@@ -20,4 +20,4 @@ metadata:
   name: knative-kafka-controller-post-install
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel

--- a/control-plane/config/post-install/200-storage-version-migrator-cluster-role.yaml
+++ b/control-plane/config/post-install/200-storage-version-migrator-cluster-role.yaml
@@ -17,7 +17,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 rules:
   # Storage version upgrader needs to be able to patch CRDs.
   - apiGroups:

--- a/control-plane/config/post-install/200-storage-version-migrator-service-account.yaml
+++ b/control-plane/config/post-install/200-storage-version-migrator-service-account.yaml
@@ -18,7 +18,7 @@ metadata:
   name: knative-kafka-storage-version-migrator
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 
 ---
 
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-storage-version-migrator

--- a/control-plane/config/post-install/201-controller-cluster-role-binding.yaml
+++ b/control-plane/config/post-install/201-controller-cluster-role-binding.yaml
@@ -19,7 +19,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-controller-post-install

--- a/control-plane/config/post-install/500-post-install-job.yaml
+++ b/control-plane/config/post-install/500-post-install-job.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller-post-install
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -27,7 +27,7 @@ spec:
     metadata:
       labels:
         app: kafka-controller-post-install
-        kafka.eventing.knative.dev/release: devel
+        app.kubernetes.io/version: devel
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/control-plane/config/post-install/500-storage-version-migrator.yaml
+++ b/control-plane/config/post-install/500-storage-version-migrator.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: "knative-kafka-storage-version-migrator"
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -27,7 +27,7 @@ spec:
     metadata:
       labels:
         app: "knative-kafka-storage-version-migrator"
-        kafka.eventing.knative.dev/release: devel
+        app.kubernetes.io/version: devel
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/data-plane/config/broker/100-config-kafka-broker-data-plane.yaml
+++ b/data-plane/config/broker/100-config-kafka-broker-data-plane.yaml
@@ -17,7 +17,7 @@ metadata:
   name: config-kafka-broker-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
   annotations:
     knative.dev/example-checksum: "57a32008"
 data:

--- a/data-plane/config/broker/200-broker-data-plane-cluster-role.yaml
+++ b/data-plane/config/broker/200-broker-data-plane-cluster-role.yaml
@@ -19,7 +19,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-broker-data-plane
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 rules:
   - apiGroups:
       - ""

--- a/data-plane/config/broker/200-broker-data-plane-service-account.yaml
+++ b/data-plane/config/broker/200-broker-data-plane-service-account.yaml
@@ -20,4 +20,4 @@ metadata:
   name: knative-kafka-broker-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel

--- a/data-plane/config/broker/201-broker-data-plane-cluster-role-binding.yaml
+++ b/data-plane/config/broker/201-broker-data-plane-cluster-role-binding.yaml
@@ -19,7 +19,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-broker-data-plane
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-broker-data-plane

--- a/data-plane/config/broker/500-dispatcher.yaml
+++ b/data-plane/config/broker/500-dispatcher.yaml
@@ -21,7 +21,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-dispatcher
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/component: kafka-broker-dispatcher
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels:
@@ -31,7 +33,9 @@ spec:
       name: kafka-broker-dispatcher
       labels:
         app: kafka-broker-dispatcher
-        kafka.eventing.knative.dev/release: devel
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/component: kafka-broker-dispatcher
+        app.kubernetes.io/name: knative-eventing
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:

--- a/data-plane/config/broker/500-receiver.yaml
+++ b/data-plane/config/broker/500-receiver.yaml
@@ -21,7 +21,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-receiver
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/component: kafka-broker-receiver
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels:
@@ -31,7 +33,9 @@ spec:
       name: kafka-broker-receiver
       labels:
         app: kafka-broker-receiver
-        kafka.eventing.knative.dev/release: devel
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/component: kafka-broker-receiver
+        app.kubernetes.io/name: knative-eventing
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -175,7 +179,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-receiver
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/component: kafka-broker-receiver
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     app: kafka-broker-receiver

--- a/data-plane/config/brokerv2/500-dispatcher.yaml
+++ b/data-plane/config/brokerv2/500-dispatcher.yaml
@@ -21,7 +21,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-dispatcher
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/component: kafka-broker-dispatcher
+    app.kubernetes.io/name: knative-eventing
 spec:
   serviceName: kafka-broker-dispatcher
   podManagementPolicy: "Parallel"
@@ -33,8 +35,10 @@ spec:
       name: kafka-broker-dispatcher
       labels:
         app: kafka-broker-dispatcher
-        app.kubernetes.io/component: kafka-dispatcher
-        kafka.eventing.knative.dev/release: devel
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/component: kafka-broker-dispatcher
+        app.kubernetes.io/name: knative-eventing
+        app.kubernetes.io/kind: kafka-dispatcher
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -153,7 +157,7 @@ spec:
             readOnlyRootFilesystem: true
             capabilities:
               drop:
-              - ALL
+                - ALL
             seccompProfile:
               type: RuntimeDefault
       volumes:

--- a/data-plane/config/channel/100-config-kafka-channel-data-plane.yaml
+++ b/data-plane/config/channel/100-config-kafka-channel-data-plane.yaml
@@ -17,7 +17,7 @@ metadata:
   name: config-kafka-channel-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
   annotations:
     knative.dev/example-checksum: "6ce544b6"
 data:

--- a/data-plane/config/channel/200-channel-data-plane-cluster-role.yaml
+++ b/data-plane/config/channel/200-channel-data-plane-cluster-role.yaml
@@ -19,7 +19,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-channel-data-plane
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 rules:
   - apiGroups:
       - ""

--- a/data-plane/config/channel/200-channel-data-plane-service-account.yaml
+++ b/data-plane/config/channel/200-channel-data-plane-service-account.yaml
@@ -20,4 +20,4 @@ metadata:
   name: knative-kafka-channel-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel

--- a/data-plane/config/channel/201-channel-data-plane-cluster-role-binding.yaml
+++ b/data-plane/config/channel/201-channel-data-plane-cluster-role-binding.yaml
@@ -19,7 +19,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-channel-data-plane
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-channel-data-plane

--- a/data-plane/config/channel/500-dispatcher.yaml
+++ b/data-plane/config/channel/500-dispatcher.yaml
@@ -21,7 +21,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-dispatcher
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/component: kafka-channel-dispatcher
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels:
@@ -31,7 +33,9 @@ spec:
       name: kafka-channel-dispatcher
       labels:
         app: kafka-channel-dispatcher
-        kafka.eventing.knative.dev/release: devel
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/component: kafka-channel-dispatcher
+        app.kubernetes.io/name: knative-eventing
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:

--- a/data-plane/config/channel/500-receiver.yaml
+++ b/data-plane/config/channel/500-receiver.yaml
@@ -21,7 +21,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-receiver
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/component: kafka-channel-receiver
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels:
@@ -31,7 +33,9 @@ spec:
       name: kafka-channel-receiver
       labels:
         app: kafka-channel-receiver
-        kafka.eventing.knative.dev/release: devel
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/component: kafka-channel-receiver
+        app.kubernetes.io/name: knative-eventing
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -175,7 +179,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-receiver
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/component: kafka-channel-receiver
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     app: kafka-channel-receiver

--- a/data-plane/config/channelv2/500-dispatcher.yaml
+++ b/data-plane/config/channelv2/500-dispatcher.yaml
@@ -21,7 +21,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-dispatcher
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/component: kafka-channel-dispatcher
+    app.kubernetes.io/name: knative-eventing
 spec:
   serviceName: kafka-channel-dispatcher
   podManagementPolicy: "Parallel"
@@ -33,8 +35,10 @@ spec:
       name: kafka-channel-dispatcher
       labels:
         app: kafka-channel-dispatcher
-        app.kubernetes.io/component: kafka-dispatcher
-        kafka.eventing.knative.dev/release: devel
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/component: kafka-channel-dispatcher
+        app.kubernetes.io/name: knative-eventing
+        app.kubernetes.io/kind: kafka-dispatcher
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:

--- a/data-plane/config/sink/100-config-kafka-sink-data-plane.yaml
+++ b/data-plane/config/sink/100-config-kafka-sink-data-plane.yaml
@@ -17,7 +17,7 @@ metadata:
   name: config-kafka-sink-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
   annotations:
     knative.dev/example-checksum: "a8ce4acb"
 data:

--- a/data-plane/config/sink/200-sink-data-plane-cluster-role.yaml
+++ b/data-plane/config/sink/200-sink-data-plane-cluster-role.yaml
@@ -19,7 +19,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-sink-data-plane
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 rules:
   - apiGroups:
       - ""

--- a/data-plane/config/sink/200-sink-data-plane-service-account.yaml
+++ b/data-plane/config/sink/200-sink-data-plane-service-account.yaml
@@ -20,4 +20,4 @@ metadata:
   name: knative-kafka-sink-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel

--- a/data-plane/config/sink/201-sink-data-plane-cluster-role-binding.yaml
+++ b/data-plane/config/sink/201-sink-data-plane-cluster-role-binding.yaml
@@ -19,7 +19,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-sink-data-plane
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-sink-data-plane

--- a/data-plane/config/sink/500-receiver.yaml
+++ b/data-plane/config/sink/500-receiver.yaml
@@ -21,7 +21,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-sink-receiver
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/component: kafka-sink-receiver
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels:
@@ -31,7 +33,9 @@ spec:
       name: kafka-sink-receiver
       labels:
         app: kafka-sink-receiver
-        kafka.eventing.knative.dev/release: devel
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/component: kafka-sink-receiver
+        app.kubernetes.io/name: knative-eventing
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -175,7 +179,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-sink-receiver
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/component: kafka-sink-receiver
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     app: kafka-sink-receiver

--- a/data-plane/config/source/100-config-kafka-source-data-plane.yaml
+++ b/data-plane/config/source/100-config-kafka-source-data-plane.yaml
@@ -17,7 +17,7 @@ metadata:
   name: config-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
   annotations:
     knative.dev/example-checksum: "8157ecb1"
 data:

--- a/data-plane/config/source/200-source-data-plane-cluster-role.yaml
+++ b/data-plane/config/source/200-source-data-plane-cluster-role.yaml
@@ -19,7 +19,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 rules:
   - apiGroups:
       - ""

--- a/data-plane/config/source/200-source-data-plane-service-account.yaml
+++ b/data-plane/config/source/200-source-data-plane-service-account.yaml
@@ -20,4 +20,4 @@ metadata:
   name: knative-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel

--- a/data-plane/config/source/201-source-data-plane-cluster-role-binding.yaml
+++ b/data-plane/config/source/201-source-data-plane-cluster-role-binding.yaml
@@ -19,7 +19,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-source-data-plane

--- a/data-plane/config/source/500-dispatcher.yaml
+++ b/data-plane/config/source/500-dispatcher.yaml
@@ -21,7 +21,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-source-dispatcher
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/component: kafka-source-dispatcher
+    app.kubernetes.io/name: knative-eventing
 spec:
   serviceName: kafka-source-dispatcher
   podManagementPolicy: "Parallel"
@@ -33,8 +35,10 @@ spec:
       name: kafka-source-dispatcher
       labels:
         app: kafka-source-dispatcher
-        app.kubernetes.io/component: kafka-dispatcher
-        kafka.eventing.knative.dev/release: devel
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/component: kafka-channel-dispatcher
+        app.kubernetes.io/name: knative-eventing
+        app.kubernetes.io/kind: kafka-dispatcher
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:

--- a/hack/label.sh
+++ b/hack/label.sh
@@ -16,5 +16,5 @@
 
 # Update release labels
 export TAG=${TAG:-$(git rev-parse HEAD)}
-echo "Updating release labels to kafka.eventing.knative.dev/release: \"${TAG}\""
-export LABEL_YAML_CMD=(sed -e "s|kafka.eventing.knative.dev/release: devel|kafka.eventing.knative.dev/release: \"${TAG}\"|")
+echo "Updating release labels to app.kubernetes.io/version: \"${TAG}\""
+export LABEL_YAML_CMD=(sed -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG}\"|")

--- a/manifests/monitoring/prometheus-operator/broker/kafka-broker-dispatcher-podmonitor.yaml
+++ b/manifests/monitoring/prometheus-operator/broker/kafka-broker-dispatcher-podmonitor.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-dispatcher
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 spec:
   selector:
     matchLabels:

--- a/manifests/monitoring/prometheus-operator/broker/kafka-broker-receiver-servicemonitor.yaml
+++ b/manifests/monitoring/prometheus-operator/broker/kafka-broker-receiver-servicemonitor.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-receiver
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 spec:
   endpoints:
     - path: /metrics

--- a/manifests/monitoring/prometheus-operator/channel/kafka-channel-dispatcher-podmonitor.yaml
+++ b/manifests/monitoring/prometheus-operator/channel/kafka-channel-dispatcher-podmonitor.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-dispatcher
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 spec:
   selector:
     matchLabels:

--- a/manifests/monitoring/prometheus-operator/channel/kafka-channel-receiver-servicemonitor.yaml
+++ b/manifests/monitoring/prometheus-operator/channel/kafka-channel-receiver-servicemonitor.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-receiver
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 spec:
   endpoints:
     - path: /metrics

--- a/manifests/monitoring/prometheus-operator/controller-source/kafka-source-controller-podmonitor.yaml
+++ b/manifests/monitoring/prometheus-operator/controller-source/kafka-source-controller-podmonitor.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-source-controller
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 spec:
   selector:
     matchLabels:

--- a/manifests/monitoring/prometheus-operator/controller/kafka-controller-podmonitor.yaml
+++ b/manifests/monitoring/prometheus-operator/controller/kafka-controller-podmonitor.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 spec:
   selector:
     matchLabels:

--- a/manifests/monitoring/prometheus-operator/sink/kafka-sink-receiver-servicemonitor.yaml
+++ b/manifests/monitoring/prometheus-operator/sink/kafka-sink-receiver-servicemonitor.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-sink-receiver
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 spec:
   endpoints:
     - path: /metrics

--- a/manifests/monitoring/prometheus-operator/source/kafka-source-dispatcher-podmonitor.yaml
+++ b/manifests/monitoring/prometheus-operator/source/kafka-source-dispatcher-podmonitor.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-source-dispatcher
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 spec:
   selector:
     matchLabels:

--- a/manifests/monitoring/prometheus-operator/webhook/kafka-webhook-servicemonitor.yaml
+++ b/manifests/monitoring/prometheus-operator/webhook/kafka-webhook-servicemonitor.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    kafka.eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
 spec:
   endpoints:
     - port: http-metrics

--- a/test/config/100-config-logging.yaml
+++ b/test/config/100-config-logging.yaml
@@ -19,8 +19,6 @@ kind: ConfigMap
 metadata:
   name: kafka-config-logging
   namespace: knative-eventing
-  labels:
-    kafka.eventing.knative.dev/release: devel
 data:
   config.xml: |
     <configuration>
@@ -40,7 +38,6 @@ metadata:
   name: config-logging
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: devel
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
 data:

--- a/test/config/chaos/chaosduck.yaml
+++ b/test/config/chaos/chaosduck.yaml
@@ -17,8 +17,6 @@ kind: ServiceAccount
 metadata:
   name: chaosduck
   namespace: knative-eventing
-  labels:
-    kafka.eventing.knative.dev/release: devel
 
 ---
 kind: Role
@@ -26,8 +24,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: chaosduck
   namespace: knative-eventing
-  labels:
-    kafka.eventing.knative.dev/release: devel
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -42,8 +38,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: chaosduck
   namespace: knative-eventing
-  labels:
-    kafka.eventing.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -59,8 +53,6 @@ kind: Deployment
 metadata:
   name: chaosduck
   namespace: knative-eventing
-  labels:
-    kafka.eventing.knative.dev/release: devel
 spec:
   selector:
     matchLabels:

--- a/test/config/cm-watcher-broker.yaml
+++ b/test/config/cm-watcher-broker.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: knative-eventing
   labels:
     app: test-kafka-broker-cm-watcher
-    kafka.eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -30,7 +29,6 @@ spec:
       name: test-kafka-broker-cm-watcher
       labels:
         app: test-kafka-broker-cm-watcher
-        kafka.eventing.knative.dev/release: devel
     spec:
       securityContext:
         runAsNonRoot: true

--- a/test/config/cm-watcher-channel.yaml
+++ b/test/config/cm-watcher-channel.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: knative-eventing
   labels:
     app: test-kafka-channel-cm-watcher
-    kafka.eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -30,7 +29,6 @@ spec:
       name: test-kafka-channel-cm-watcher
       labels:
         app: test-kafka-channel-cm-watcher
-        kafka.eventing.knative.dev/release: devel
     spec:
       securityContext:
         runAsNonRoot: true

--- a/test/config/cm-watcher-sink.yaml
+++ b/test/config/cm-watcher-sink.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: knative-eventing
   labels:
     app: test-kafka-sink-cm-watcher
-    kafka.eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -30,7 +29,6 @@ spec:
       name: test-kafka-sink-cm-watcher
       labels:
         app: test-kafka-sink-cm-watcher
-        kafka.eventing.knative.dev/release: devel
     spec:
       securityContext:
         runAsNonRoot: true

--- a/test/config/config-br-defaults.yaml
+++ b/test/config/config-br-defaults.yaml
@@ -17,8 +17,6 @@ kind: ConfigMap
 metadata:
   name: config-br-defaults
   namespace: knative-eventing
-  labels:
-    kafka.eventing.knative.dev/release: devel
 data:
   default-br-config: |
     clusterDefault:


### PR DESCRIPTION
Fixes #2812 

This allows integrating istio with eventing on well-known labels.

https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use k8s recommended labels, for example
  ```
   app.kubernetes.io/version: <version>
   app.kubernetes.io/component: kafka-channel-dispatcher
   app.kubernetes.io/name: knative-eventing
  ```

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
`kafka.eventing.knative.dev/release` label on resources has been removed, `use app.kubernetes.io/version` instead
```