### PR TITLE
Do not inject namespace to additional resources using Manifestival's namespace injection

### DIFF
--- a/control-plane/pkg/reconciler/broker/namespaced_broker.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_broker.go
@@ -38,7 +38,6 @@ import (
 	rbaclisters "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/utils/pointer"
 
-	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
@@ -97,21 +96,6 @@ func (r *NamespacedReconciler) ReconcileKind(ctx context.Context, broker *eventi
 	}
 
 	br := r.createReconcilerForBrokerInstance(broker)
-
-	statusConditionManager := base.StatusConditionManager{
-		Object:     broker,
-		SetAddress: broker.Status.SetAddress,
-		Env:        r.Env,
-		Recorder:   controller.GetEventRecorder(ctx),
-	}
-
-	// Get contract config map. Do this in advance, otherwise
-	// the dataplane pods that need volume mounts to the contract configmap
-	// will get stuck and will never be ready.
-	_, err := br.GetOrCreateDataPlaneConfigMap(ctx)
-	if err != nil {
-		return statusConditionManager.FailedToGetConfigMap(err)
-	}
 
 	event := r.reconcileDataPlane(ctx, broker)
 	if event != nil {

--- a/control-plane/pkg/reconciler/broker/namespaced_broker.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_broker.go
@@ -277,7 +277,7 @@ func (r *NamespacedReconciler) getManifest(ctx context.Context, broker *eventing
 	// Not all transformations are good for the additional resources, so we apply them separately.
 	// One specific example is that we don't want to use Manifestival's namespace injection for the additional resources.
 	// Because, it touches e.g. the subjects' namespace of the ClusterRoleBindings, which is not desired.
-	manifestFromAdditionalResources, err := r.getManifestFromAdditionalResources(ctx, broker)
+	manifestFromAdditionalResources, err := r.getManifestFromAdditionalResources(broker)
 	if err != nil {
 		return mf.Manifest{}, fmt.Errorf("unable to get manifest from additional resources: %w", err)
 	}
@@ -369,7 +369,7 @@ func (r *NamespacedReconciler) getManifestFromSystemNamespace(broker *eventing.B
 	return manifest, nil
 }
 
-func (r *NamespacedReconciler) getManifestFromAdditionalResources(ctx context.Context, broker *eventing.Broker) (mf.Manifest, error) {
+func (r *NamespacedReconciler) getManifestFromAdditionalResources(broker *eventing.Broker) (mf.Manifest, error) {
 	additionalResources, err := r.resourcesFromConfigMap(NamespacedBrokerAdditionalResourcesConfigMapName, broker.Namespace)
 	if err != nil {
 		return mf.Manifest{}, err

--- a/test/rekt/features/namespaced_broker.go
+++ b/test/rekt/features/namespaced_broker.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"knative.dev/eventing/test/rekt/resources/broker"
-	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/feature"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
@@ -63,7 +62,7 @@ func NamespacedBrokerResourcesPropagation() *feature.Feature {
 			"kind":       "ConfigMap",
 			"metadata": map[string]interface{}{
 				"name":      additionalCMName,
-				"namespace": system.Namespace(),
+				"namespace": "{{.Namespace}}",
 			},
 			"data": map[string]string{
 				"config":           "x-unknown-config",
@@ -91,9 +90,6 @@ func NamespacedBrokerResourcesPropagation() *feature.Feature {
 	f.Requirement("Broker is ready", broker.IsReady(br))
 	f.Requirement("Broker is addressable", broker.IsAddressable(br))
 
-	f.Assert(fmt.Sprintf("%s ConfigMap is not present in %s as we override the namespace with the broker namespace",
-		additionalCMName, system.Namespace()),
-		configmap.DoesNotExist(additionalCMName, system.Namespace()))
 	f.Assert(fmt.Sprintf("%s ConfigMap is present in test namespace", additionalCMName),
 		configmap.ExistsInTestNamespace(additionalCMName))
 


### PR DESCRIPTION
In EKB controller, we use Manifestival to create resources that are in "additional resources". When we have the RoleBinding like this in the Manifest:

```
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: knative-prometheus-k8s
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: knative-prometheus-k8s
subjects:
- kind: ServiceAccount
  name: prometheus-k8s
  namespace: openshift-monitoring           # --> changed
```

will become:

```
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: knative-prometheus-k8s
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: knative-prometheus-k8s
subjects:
- kind: ServiceAccount
  name: prometheus-k8s
  namespace: <user-namespace>        # --> changed
```

This is done here https://github.com/manifestival/manifestival/blob/82196bd303e23c641fda3d002c0663b892092e9c/transform.go#L66-L73 

To prevent this, we don't run the Manifestival's namespace injection on "additional resources". We can inject namespaces to them with templating anyway.