### PR TITLE
Fix bash scripts import paths

### DIFF
--- a/hack/control-plane.sh
+++ b/hack/control-plane.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source $(pwd)/hack/label.sh
+source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/label.sh
 
 readonly CONTROL_PLANE_CONFIG_DIR=control-plane/config/eventing-kafka-broker
 readonly CONTROL_PLANE_POST_INSTALL_CONFIG_DIR=control-plane/config/post-install

--- a/hack/data-plane.sh
+++ b/hack/data-plane.sh
@@ -17,7 +17,7 @@
 # variables used:
 # - KO_DOCKER_REPO (required)
 
-source "$(pwd)"/hack/label.sh
+source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/label.sh
 
 readonly DATA_PLANE_DIR=data-plane
 readonly DATA_PLANE_CONFIG_DIR=${DATA_PLANE_DIR}/config

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -19,10 +19,12 @@ readonly LOCAL_DEVELOPMENT=${LOCAL_DEVELOPMENT:-false}
 export REPLICAS=${REPLICAS:-3}
 export KO_FLAGS="${KO_FLAGS:-}"
 
-source $(pwd)/vendor/knative.dev/hack/e2e-tests.sh
-source $(pwd)/hack/data-plane.sh
-source $(pwd)/hack/control-plane.sh
-source $(pwd)/hack/artifacts-env.sh
+repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
+
+source "${repo_root_dir}"/vendor/knative.dev/hack/e2e-tests.sh
+source "${repo_root_dir}"/hack/data-plane.sh
+source "${repo_root_dir}"/hack/control-plane.sh
+source "${repo_root_dir}"/hack/artifacts-env.sh
 
 # If gcloud is not available make it a no-op, not an error.
 which gcloud &>/dev/null || gcloud() { echo "[ignore-gcloud $*]" 1>&2; }


### PR DESCRIPTION
`pwd` or `dirname $0` is not reliable way of getting the repo root
dir, so I'm using `$(dirname "$(realpath "${BASH_SOURCE[0]}")")`.

Tested this in eventing-istio.