### PR TITLE
Added nil as return value for rebuildCMFromStatusAnnotations

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -545,9 +545,6 @@ func rebuildCMFromStatusAnnotations(br *eventing.Broker) *corev1.ConfigMap {
 			Name:      br.Spec.Config.Name,
 		},
 	}
-	if len(br.Status.Annotations) == 0 {
-		return nil
-	}
 	for k, v := range br.Status.Annotations {
 		if cm.Data == nil {
 			cm.Data = make(map[string]string, len(br.Status.Annotations))

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -506,6 +506,9 @@ func (r *Reconciler) brokerConfigMap(logger *zap.Logger, broker *eventing.Broker
 	if apierrors.IsNotFound(getCmError) {
 		// will at least return an empty CM
 		cm = rebuildCMFromStatusAnnotations(broker)
+		if cm == nil {
+			return cm, fmt.Errorf("failed to get configmap %s/%s: %w", namespace, broker.Spec.Config.Name, getCmError)
+		}
 	}
 
 	return cm, getCmError
@@ -544,6 +547,9 @@ func rebuildCMFromStatusAnnotations(br *eventing.Broker) *corev1.ConfigMap {
 			Namespace: br.Spec.Config.Namespace,
 			Name:      br.Spec.Config.Name,
 		},
+	}
+	if len(br.Status.Annotations) == 0 {
+		return nil
 	}
 	for k, v := range br.Status.Annotations {
 		if cm.Data == nil {

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -545,6 +545,9 @@ func rebuildCMFromStatusAnnotations(br *eventing.Broker) *corev1.ConfigMap {
 			Name:      br.Spec.Config.Name,
 		},
 	}
+	if len(br.Status.Annotations) == 0 {
+		return nil
+	}
 	for k, v := range br.Status.Annotations {
 		if cm.Data == nil {
 			cm.Data = make(map[string]string, len(br.Status.Annotations))


### PR DESCRIPTION
Signed-off-by: Vishal Choudhary <sendtovishalchoudhary@gmail.com>

Fixes #2577 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- :broom: Update or clean up current behavior
- RebuildCMFromAnnotations should only return a configmap if there are values on the status annotations

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- 
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Added nil as return value for rebuildCMFromStatusAnnotations if there are values on the status annotations
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
