### PR TITLE
Fix linting issue from usage of deprecated zipkin variable

### DIFF
--- a/test/pkg/tracing/zipkin.go
+++ b/test/pkg/tracing/zipkin.go
@@ -31,6 +31,5 @@ func WithZipkin(ctx context.Context, env environment.Environment) (context.Conte
 		kubeclient.Get(ctx),
 		logging.FromContext(ctx).Infof,
 		knative.KnativeNamespaceFromContext(ctx))
-	zipkin.ZipkinTracingEnabled = true
 	return ctx, err
 }


### PR DESCRIPTION
Fixing a linting issue from using a deprecated variable from zipkin.
```
Error: SA1019: zipkin.ZipkinTracingEnabled is deprecated: Use IsTracingEnabled for checking the current state.  (staticcheck)
```

To check if zipkin tracining is enabled, `zipkin.IsTracingEnabled()` can be used. During the setup (`SetupZipkinTracingFromConfigTracing()` -> `SetupZipkinTracing()`) it is set to `true`:

https://github.com/knative-sandbox/eventing-kafka-broker/blob/fc17e7686e3fe8d2e071402d5ff6e2aaacf6572a/vendor/knative.dev/pkg/test/zipkin/util.go#L150