### PR TITLE
Use kubernetes.io/metadata.name for namespace selector

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-pod-defaulting.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-pod-defaulting.yaml
@@ -33,7 +33,7 @@ webhooks:
     matchPolicy: Equivalent
     namespaceSelector:
       matchLabels:
-        app.kubernetes.io/name: knative-eventing
+        kubernetes.io/metadata.name: knative-eventing
     objectSelector:
       matchLabels:
         app.kubernetes.io/kind: kafka-dispatcher


### PR DESCRIPTION
Instead of using the custom `app.kubernetes.io/name` for selecting a specific namespace we use the
`kubernetes.io/metadata.name` label that is enforced by the API server on each namespace
https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-metadata-name

The benefit is that some installations create the system namespace themself so the app.kubernetes.io/name that is defined in core might not be present, leading to a non functioning KafkaSource.