### PR TITLE
[WIP] Use broker template dir in rekt tests

### DIFF
--- a/test/e2e_new/templates/kafka-broker/broker.yaml
+++ b/test/e2e_new/templates/kafka-broker/broker.yaml
@@ -1,0 +1,77 @@
+# Copyright 2023 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+  {{ if or .brokerClass .annotations }}
+  annotations:
+  {{ if .brokerClass }}
+    eventing.knative.dev/broker.class: {{ .brokerClass }}
+  {{ end }}
+  {{ if .annotations }}
+    {{ range $key, $value := .annotations }}
+    {{ $key }}: {{ $value }}
+    {{ end }}
+  {{ end }}
+  {{ end }}
+spec:
+  {{ if .config }}
+  config:
+    kind: {{ .config.kind }}
+    {{ if .configNamespace }}
+    namespace: {{ .configNamespace }}
+    {{ else }}
+    namespace: {{ .namespace }}
+    {{ end }}
+    name: {{ .config.name }}
+    apiVersion: {{ .config.apiVersion }}
+  {{ else }}
+  # if no config is given, use our default config
+  config:
+    kind: ConfigMap
+    namespace: {{ .namespace }}
+    name: kafka-broker-config
+    apiVersion: v1
+  {{ end }}
+  {{ if .delivery }}
+  delivery:
+    {{ if .delivery.timeout }}
+    timeout: {{ .delivery.timeout }}
+    {{ end }}
+    {{ if .delivery.deadLetterSink }}
+    deadLetterSink:
+      {{ if .delivery.deadLetterSink.ref }}
+      ref:
+        kind: {{ .delivery.deadLetterSink.ref.kind }}
+        namespace: {{ .namespace }}
+        name: {{ .delivery.deadLetterSink.ref.name }}
+        apiVersion: {{ .delivery.deadLetterSink.ref.apiVersion }}
+      {{ end }}
+      {{ if .delivery.deadLetterSink.uri }}
+      uri: {{ .delivery.deadLetterSink.uri }}
+      {{ end }}
+    {{ end }}
+    {{ if .delivery.retry }}
+    retry: {{ .delivery.retry}}
+    {{ end }}
+    {{ if .delivery.backoffPolicy }}
+    backoffPolicy: {{ .delivery.backoffPolicy}}
+    {{ end }}
+    {{ if .delivery.backoffDelay }}
+    backoffDelay: "{{ .delivery.backoffDelay}}"
+    {{ end }}
+  {{ end }}

--- a/test/e2e_new/templates/kafka-broker/config.yaml
+++ b/test/e2e_new/templates/kafka-broker/config.yaml
@@ -1,0 +1,23 @@
+# Copyright 2023 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-broker-config
+  namespace: {{ .namespace }}
+data:
+  default.topic.partitions: "2"
+  default.topic.replication.factor: "3"
+  bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"

--- a/test/reconciler-tests.sh
+++ b/test/reconciler-tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 source $(dirname $0)/e2e-common.sh
+export BROKER_TEMPLATES=./templates/kafka-broker
 
 if ! ${SKIP_INITIALIZE}; then
   initialize $@ --skip-istio-addon --min-nodes=4 --max-nodes=4


### PR DESCRIPTION
Currently most of the broker rekt tests, define the same broker config. This PR addresses it and uses a broker template with some predefined default config (which still allows to specify the whole config).

## Proposed Changes

- :gift: Use the broker template dir in the rekt tests so we don't have to specify the same config each time and can rely more on defaults of the broker config.


WIP as I still need to run the tests and cleanup the tests from the redundant config declarations.