### PR TITLE
Fix: Experemental filters `Any`Filter working bug

### DIFF
--- a/control-plane/pkg/contract/subscriptionsapi.go
+++ b/control-plane/pkg/contract/subscriptionsapi.go
@@ -96,7 +96,7 @@ func newAllFilter(filters []v1.SubscriptionsAPIFilter) *DialectedFilter {
 // newAnyFilter converts the SubscriptionsAPIFilter into the any dialect of the
 // DialectedFilter as defined in CloudEvents Subscriptions API.
 //
-// All filter evaluates to true when all nested filters evaluate to true.
+// Any filter evaluates to true when at least one nested filters evaluate to true.
 //
 // See "CNCF CloudEvents Subscriptions API" > "3.2.4.1 Filters Dialects"
 // https://github.com/cloudevents/spec/blob/main/subscriptions/spec.md#any-filter-dialect
@@ -162,7 +162,7 @@ func FromSubscriptionFilter(f v1.SubscriptionsAPIFilter) *DialectedFilter {
 		filters = append(filters, newAllFilter(f.All))
 	}
 	if len(f.Any) > 0 {
-		filters = append(filters, newAnyFilter(f.All))
+		filters = append(filters, newAnyFilter(f.Any))
 	}
 	if f.Not != nil {
 		filters = append(filters, newNotFilter(*f.Not))

--- a/control-plane/pkg/contract/subscriptionsapi_test.go
+++ b/control-plane/pkg/contract/subscriptionsapi_test.go
@@ -50,6 +50,13 @@ func TestFromSubscriptionFilter(t *testing.T) {
 						Suffix: map[string]string{"subject": "source"},
 					},
 					{
+						Any: []v1.SubscriptionsAPIFilter{
+							{
+								Exact: map[string]string{"type": "dev.knative.kafkasrc.kafkarecord"},
+							},
+						},
+					},
+					{
 						Not: &v1.SubscriptionsAPIFilter{
 							Prefix: map[string]string{"source": "dev.knative"},
 						},
@@ -85,6 +92,21 @@ func TestFromSubscriptionFilter(t *testing.T) {
 								},
 							},
 							{
+								Filter: &DialectedFilter_Any{
+									Any: &Any{
+										Filters: []*DialectedFilter{
+											{
+												Filter: &DialectedFilter_Exact{
+													Exact: &Exact{
+														Attributes: map[string]string{"type": "dev.knative.kafkasrc.kafkarecord"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
 								Filter: &DialectedFilter_Not{
 									Not: &Not{
 										Filter: &DialectedFilter{
@@ -115,7 +137,7 @@ func TestFromSubscriptionFilter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := FromSubscriptionFilter(tc.apiFilter)
 			if cmp.Diff(got, tc.want, cmpopts.IgnoreUnexported(DialectedFilter{},
-				All{}, Prefix{}, Suffix{}, Exact{}, Not{}, CESQL{})) != "" {
+				All{}, Any{}, Prefix{}, Suffix{}, Exact{}, Not{}, CESQL{})) != "" {
 				t.Errorf("FromSubscriptionFilter() = %v, want %v", got, tc.want)
 			}
 		})


### PR DESCRIPTION
Fixes #2942

instead of passing `f.any` filter as argument in `newAnyFilter()` it was passing `f.all` which was causing this issue

## Proposed Changes

- passing required arguments to create a proper `Any` filter.
- put the test to check if `any` filter gets its format or not
