### PR TITLE
Allow `retention.ms` & `cleanup.policy` configuration of topic

### DIFF
--- a/control-plane/config/eventing-kafka-broker/100-broker/100-kafka-broker-configmap.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-broker/100-kafka-broker-configmap.yaml
@@ -24,4 +24,5 @@ metadata:
 data:
   default.topic.partitions: "10"
   default.topic.replication.factor: "3"
+  default.topic.retention.ms: "604800000" # default 7 days
   bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"

--- a/control-plane/config/eventing-kafka-broker/100-broker/100-kafka-broker-configmap.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-broker/100-kafka-broker-configmap.yaml
@@ -25,4 +25,5 @@ data:
   default.topic.partitions: "10"
   default.topic.replication.factor: "3"
   default.topic.retention.ms: "604800000" # default 7 days
+  default.topic.cleanup.policy: "delete"
   bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"


### PR DESCRIPTION
Partially Fixes #1638

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- add fields to configure [`retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_retention.ms) and [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) of a kafka topic.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Now further configuration of kafka topic is possible,
``
  default.topic.retention.ms: "604800000"    # posible range [-1,0,1...]
  default.topic.cleanup.policy: "delete"     # posible values "delete", "compact" or "delete,compact"
``
above two fields can be used to set retention.ms and cleanup.policy add those to the broker spec configMap
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
