### PR TITLE
Fix broken initial offset on reset on a non64 bit boundary

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OffsetManager.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OffsetManager.java
@@ -293,8 +293,9 @@ public final class OffsetManager implements RecordDispatcherListener {
 
       final var prevCommittedOffsetsArr = committedOffsets.toLongArray();
       // Calculate the word index in the long array. Long size is 64.
+      final var wordSize = 64;
       final var relativeOffset = committed - initialOffset;
-      final var wordOfCommitted = (int) (relativeOffset / 64);
+      final var wordOfCommitted = (int) (relativeOffset / wordSize);
 
       // Copy from wordOfCommitted to the end: [..., wordOfCommitted, ...]
       final var newCommittedOffsetsArr = Arrays.copyOfRange(
@@ -305,7 +306,7 @@ public final class OffsetManager implements RecordDispatcherListener {
 
       // Re-create committedOffset BitSet and reset initialOffset.
       this.committedOffsets = BitSet.valueOf(newCommittedOffsetsArr);
-      this.initialOffset = committed;
+      this.initialOffset = committed - (relativeOffset % wordSize);
     }
   }
 


### PR DESCRIPTION
Fixes broken initial offset on reset on a non64 bit boundary

## Proposed Changes

- Take the `relativeOffset`/`wordSize` remainder into account when resetting `initialOffset`

@hadriansecurity