### PR TITLE
Don't override ports for KafkaChannel's service

### DIFF
--- a/control-plane/pkg/reconciler/channel/resources/service.go
+++ b/control-plane/pkg/reconciler/channel/resources/service.go
@@ -53,11 +53,8 @@ func MakeChannelServiceName(name string) string {
 // pointing to the specified service in a namespace.
 func ExternalService(namespace, service string) ServiceOption {
 	return func(svc *corev1.Service) error {
-		// TODO this overrides the current serviceSpec. Is this correct?
-		svc.Spec = corev1.ServiceSpec{
-			Type:         corev1.ServiceTypeExternalName,
-			ExternalName: network.GetServiceHostname(service, namespace),
-		}
+		svc.Spec.Type = corev1.ServiceTypeExternalName
+		svc.Spec.ExternalName = network.GetServiceHostname(service, namespace)
 		return nil
 	}
 }

--- a/control-plane/pkg/reconciler/testing/objects_channel.go
+++ b/control-plane/pkg/reconciler/testing/objects_channel.go
@@ -26,13 +26,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/utils/pointer"
-	messagingv1beta1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/messaging/v1beta1"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/channel/resources"
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/network"
+
+	messagingv1beta1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/messaging/v1beta1"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/channel/resources"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
@@ -352,6 +353,13 @@ func NewPerChannelService(env *config.Env) *corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Type:         corev1.ServiceTypeExternalName,
 			ExternalName: network.GetServiceHostname(env.IngressName, env.SystemNamespace),
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "http",
+					Protocol: corev1.ProtocolTCP,
+					Port:     80,
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
By not having the port defined on the KafkaChannel's external
name service, istio (actually Envoy) can't find a matching route
for requests to the channel's service without any port, see [1]

[1] https://www.envoyproxy.io/docs/envoy/latest/faq/debugging/why_is_my_route_not_found

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add ports to KafkaChannel's external name service

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Add ports to KafkaChannel's externalName services
```

**Docs**

N/A
