### PR TITLE
Go 1.19 usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/eventing-kafka-broker
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Shopify/sarama v1.37.0


### PR DESCRIPTION
## Proposed Changes

- using go 1.19, since some vendor'ed deps are using `atomic.Bool`:
```

# knative.dev/eventing/pkg/scheduler/statefulset
Error: vendor/knative.dev/eventing/pkg/scheduler/statefulset/autoscaler.go:79:18: undefined: atomic.Bool
Error: vendor/knative.dev/eventing/pkg/scheduler/statefulset/autoscaler.go:115:29: undefined: atomic.Bool
note: module requires Go 1.19
```

which was introduced in [1.19](https://pkg.go.dev/sync/atomic#Bool)

See: https://github.com/knative/eventing/actions/runs/4741242354/jobs/8418053369?pr=6868

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
