### PR TITLE
Update e2e tests to have default value for BROKER_CLASS

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -29,10 +29,11 @@ if [ "${EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO:-""}" != "" ]; then
 fi
 
 if [[ -z "${BROKER_CLASS}" ]]; then
-  fail_test "Broker class is not defined. Specify it with 'BROKER_CLASS' env var."
-else
-  echo "BROKER_CLASS is set to '${BROKER_CLASS}'. Running tests for that broker class."
+  BROKER_CLASS=KafkaBroker
+  echo "BROKER_CLASS is not defined, falling back to the default BROKER_CLASS=KafkaBroker. Override this with the 'BROKER_CLASS' env var."
 fi
+
+echo "BROKER_CLASS is set to '${BROKER_CLASS}'. Running tests for that broker class."
 
 go_test_e2e -timeout=1h ./test/e2e/...        || fail_test "E2E suite failed (directory: ./e2e/...)"
 go_test_e2e -timeout=1h ./test/e2e_sink/...   || fail_test "E2E suite failed (directory: ./e2e_sink/...)"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -29,8 +29,8 @@ if [ "${EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO:-""}" != "" ]; then
 fi
 
 if [[ -z "${BROKER_CLASS}" ]]; then
-  BROKER_CLASS=KafkaBroker
-  echo "BROKER_CLASS is not defined, falling back to the default BROKER_CLASS=KafkaBroker. Override this with the 'BROKER_CLASS' env var."
+  export BROKER_CLASS=Kafka
+  echo "BROKER_CLASS is not defined, falling back to the default BROKER_CLASS=Kafka. Override this with the 'BROKER_CLASS' env var."
 fi
 
 echo "BROKER_CLASS is set to '${BROKER_CLASS}'. Running tests for that broker class."


### PR DESCRIPTION
# Fixes

When trying to run the e2e tests by following the guide provided in `DEVELOPMENT.md`, I was shown the following error: `ERROR: Broker class is not defined. Specify it with 'BROKER_CLASS' env var`.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Set a default value for `BROKER_CLASS` if it is undefined when running the e2e tests.


