### PR TITLE
Added empty FinalizeKind definition to prevent delete sources from hanging

### DIFF
--- a/control-plane/pkg/reconciler/source/source.go
+++ b/control-plane/pkg/reconciler/source/source.go
@@ -97,6 +97,11 @@ func GetLabels(name string) map[string]string {
 	}
 }
 
+// Need to have an empty definition here to ensure that we can delete older sources which had a finalizer
+func (r Reconciler) FinalizeKind(ctx context.Context, ks *sources.KafkaSource) reconciler.Event {
+	return nil
+}
+
 func (r Reconciler) reconcileConsumerGroup(ctx context.Context, ks *sources.KafkaSource) (*internalscg.ConsumerGroup, error) {
 	var deliverySpec *internalscg.DeliverySpec
 	deliveryOrder := DefaultDeliveryOrder

--- a/control-plane/pkg/reconciler/source/source_test.go
+++ b/control-plane/pkg/reconciler/source/source_test.go
@@ -54,6 +54,18 @@ import (
 	kedaclient "knative.dev/eventing-kafka-broker/third_party/pkg/client/injection/client/fake"
 )
 
+const (
+	finalizerName = "kafkasources.sources.knative.dev"
+)
+
+var (
+	finalizerUpdatedEvent = Eventf(
+		corev1.EventTypeNormal,
+		"FinalizerUpdate",
+		fmt.Sprintf(`Updated %q finalizers`, SourceName),
+	)
+)
+
 func TestGetLabels(t *testing.T) {
 
 	testLabels := GetLabels("testSourceName")
@@ -136,6 +148,12 @@ func TestReconcileKind(t *testing.T) {
 					),
 				},
 			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
 		},
 		{
 			Name: "Reconciled normal, offset earliest",
@@ -183,6 +201,12 @@ func TestReconcileKind(t *testing.T) {
 					),
 				},
 			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
 		},
 		{
 			Name: "Reconciled normal, offset latest",
@@ -229,6 +253,12 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceSelector(),
 					),
 				},
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
 			},
 		},
 		{
@@ -282,6 +312,12 @@ func TestReconcileKind(t *testing.T) {
 					),
 				},
 			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
 		},
 		{
 			Name: "Reconciled normal, key type label",
@@ -329,6 +365,12 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceSelector(),
 					),
 				},
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
 			},
 		},
 		{
@@ -459,6 +501,12 @@ func TestReconcileKind(t *testing.T) {
 					),
 				},
 			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
 		},
 		{
 			Name: "Reconciled normal with SASL without type",
@@ -572,6 +620,12 @@ func TestReconcileKind(t *testing.T) {
 					),
 				},
 			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
 		},
 		{
 			Name: "Reconciled normal - ce overrides",
@@ -627,6 +681,12 @@ func TestReconcileKind(t *testing.T) {
 					),
 				},
 			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
 		},
 		{
 			Name: "Reconciled normal - with autoscaling annotations",
@@ -674,6 +734,12 @@ func TestReconcileKind(t *testing.T) {
 						WithAutoscalingAnnotationsSource(),
 					),
 				},
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
 			},
 		},
 		{
@@ -758,6 +824,12 @@ func TestReconcileKind(t *testing.T) {
 					),
 				},
 			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
 		},
 		{
 			Name: "Reconciled normal - existing cg with update",
@@ -816,6 +888,12 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceSelector(),
 					),
 				},
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
 			},
 		},
 		{
@@ -877,6 +955,12 @@ func TestReconcileKind(t *testing.T) {
 					),
 				},
 			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
 		},
 		{
 			Name: "Reconciled normal - existing cg with update but not ready",
@@ -935,6 +1019,12 @@ func TestReconcileKind(t *testing.T) {
 					),
 				},
 			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
 		},
 		{
 			Name: "Reconciled normal - existing cg without update",
@@ -982,6 +1072,12 @@ func TestReconcileKind(t *testing.T) {
 					),
 				},
 			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
 		},
 		{
 			Name: "Reconciled normal - existing cg without update but not ready",
@@ -1026,6 +1122,12 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceSelector(),
 					),
 				},
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
 			},
 		},
 		{
@@ -1072,6 +1174,12 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceSelector(),
 					),
 				},
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
 			},
 		},
 		{
@@ -1120,6 +1228,12 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceSelector(),
 					),
 				},
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
 			},
 		},
 		{
@@ -1203,6 +1317,12 @@ func TestReconcileKind(t *testing.T) {
 					),
 				},
 			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
 		},
 		{
 			Name: "Reconciled normal - ignore source replicas when KEDA is enabled",
@@ -1254,6 +1374,12 @@ func TestReconcileKind(t *testing.T) {
 					),
 				},
 			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
 		},
 		{
 			Name: "Reconciled normal - with unordered consumer verticle",
@@ -1301,6 +1427,12 @@ func TestReconcileKind(t *testing.T) {
 					),
 				},
 			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
 		},
 		{
 			Name: "Reconciled normal - with ordered consumer verticle",
@@ -1347,6 +1479,12 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceSelector(),
 					),
 				},
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
 			},
 		},
 	}
@@ -1458,4 +1596,13 @@ func SourceNetSaslTls(withType bool) KRShapedOption {
 			}
 		}
 	}
+}
+
+func patchFinalizers() clientgotesting.PatchActionImpl {
+	action := clientgotesting.PatchActionImpl{}
+	action.Name = SourceName
+	action.Namespace = SourceNamespace
+	patch := `{"metadata":{"finalizers":["` + finalizerName + `"],"resourceVersion":""}}`
+	action.Patch = []byte(patch)
+	return action
 }


### PR DESCRIPTION
Fixes #3070 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add empty definition for `FinalizeKind` to ensure that deleting a source does not hang if it has a finalizer


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Fixed bug where deleting sources created before the sourcev2 upgrade caused the source to hang on finalization.
```
