### PR TITLE
LoggingSpanExporter constructor was Deprecated replace it with prefered `create()`

### DIFF
--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTracingTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTracingTest.java
@@ -84,7 +84,7 @@ public class ReceiverVerticleTracingTest {
     this.spanExporter = InMemorySpanExporter.create();
     SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
       .addSpanProcessor(SimpleSpanProcessor.create(this.spanExporter))
-      .addSpanProcessor(SimpleSpanProcessor.create(new LoggingSpanExporter()))
+      .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
       // Uncomment this line if you want to try locally
       //.addSpanProcessor(SimpleSpanProcessor.create(ZipkinSpanExporter.builder().build()))
       .setSampler(Sampler.alwaysOn())


### PR DESCRIPTION
`new LoggingSpanExporter()` was deprecated.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Replace it with `LoggingSpanExporter.create()` the preferred method. 