### PR TITLE
Allow defining topic prefixes

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-features.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-features.yaml
@@ -4,7 +4,7 @@ metadata:
   name: config-kafka-features
   namespace: knative-eventing
   annotations:
-    knative.dev/example-checksum: "330d9f60"
+    knative.dev/example-checksum: "1192895d"
 data:
   _example: |-
     ################################

--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-features.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-features.yaml
@@ -36,7 +36,15 @@ data:
     # The Go text/template used to generate consumergroup ID for triggers.
     # The template can reference the trigger Kubernetes metadata only.
     triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+    # The Go text/template used to generate topics for Brokers.
+    # The template can reference the broker Kubernetes metadata only.
+    brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+    # The Go text/template used to generate topics for Channels.
+    # The template can reference the channel Kubernetes metadata only.
+    channels.topic.template: "knative-channel-{{ .Namespace }}-{{ .Name }}"
   dispatcher.rate-limiter: "disabled"
   dispatcher.ordered-executor-metrics: "disabled"
   controller.autoscaler: "disabled"
   triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+  brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+  channels.topic.template: "knative-channel-{{ .Namespace }}-{{ .Name }}"

--- a/control-plane/pkg/apis/config/features_test.go
+++ b/control-plane/pkg/apis/config/features_test.go
@@ -60,6 +60,11 @@ func TestGetFlags(t *testing.T) {
 	require.True(t, flags.IsControllerAutoscalerEnabled())
 	require.Len(t, flags.features.TriggersConsumerGroupTemplate.Tree.Root.Nodes, 4)
 	require.Equal(t, flags.features.TriggersConsumerGroupTemplate.Name(), "triggers.consumergroup.template")
+	require.Len(t, flags.features.BrokersTopicTemplate.Tree.Root.Nodes, 4)
+	require.Equal(t, flags.features.BrokersTopicTemplate.Name(), "brokers.topic.template")
+	require.Len(t, flags.features.ChannelsTopicTemplate.Tree.Root.Nodes, 4)
+	require.Equal(t, flags.features.ChannelsTopicTemplate.Name(), "channels.topic.template")
+
 }
 
 func TestStoreLoadWithConfigMap(t *testing.T) {
@@ -75,6 +80,8 @@ func TestStoreLoadWithConfigMap(t *testing.T) {
 	require.Equal(t, expected.IsDispatcherOrderedExecutorMetricsEnabled(), have.IsDispatcherOrderedExecutorMetricsEnabled())
 	require.Equal(t, expected.IsControllerAutoscalerEnabled(), have.IsControllerAutoscalerEnabled())
 	require.Equal(t, expected.features.TriggersConsumerGroupTemplate.Name(), have.features.TriggersConsumerGroupTemplate.Name())
+	require.Equal(t, expected.features.BrokersTopicTemplate.Name(), have.features.BrokersTopicTemplate.Name())
+	require.Equal(t, expected.features.ChannelsTopicTemplate.Name(), have.features.ChannelsTopicTemplate.Name())
 }
 
 func TestStoreLoadWithContext(t *testing.T) {
@@ -84,6 +91,8 @@ func TestStoreLoadWithContext(t *testing.T) {
 	require.False(t, have.IsDispatcherOrderedExecutorMetricsEnabled())
 	require.False(t, have.IsControllerAutoscalerEnabled())
 	require.Equal(t, have.features.TriggersConsumerGroupTemplate.Name(), "triggers.consumergroup.template")
+	require.Equal(t, have.features.BrokersTopicTemplate.Name(), "brokers.topic.template")
+	require.Equal(t, have.features.ChannelsTopicTemplate.Name(), "channels.topic.template")
 }
 
 func TestExecuteTriggersConsumerGroupTemplateDefault(t *testing.T) {
@@ -114,4 +123,64 @@ func TestExecuteTriggersConsumerGroupTemplateOverride(t *testing.T) {
 	}
 
 	require.Equal(t, result, "knative-trigger-namespace-trigger-138ac0ec-2694-4747-900d-45be3da5c9a9")
+}
+
+func TestExecuteBrokersTopicTemplateDefault(t *testing.T) {
+	nc := DefaultFeaturesConfig()
+	result, err := nc.ExecuteBrokersTopicTemplate(v1.ObjectMeta{
+		Name:      "topic",
+		Namespace: "namespace",
+		UID:       "138ac0ec-2694-4747-900d-45be3da5c9a9",
+	})
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, result, "knative-broker-namespace-topic")
+}
+
+func TestExecuteBrokersTopicTemplateOverride(t *testing.T) {
+	nc := DefaultFeaturesConfig()
+	nc.features.BrokersTopicTemplate, _ = template.New("custom-template").Parse("knative-broker-{{ .Namespace }}-{{ .Name }}-{{ .UID }}")
+
+	result, err := nc.ExecuteBrokersTopicTemplate(v1.ObjectMeta{
+		Name:      "topic",
+		Namespace: "namespace",
+		UID:       "138ac0ec-2694-4747-900d-45be3da5c9a9",
+	})
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, result, "knative-broker-namespace-topic-138ac0ec-2694-4747-900d-45be3da5c9a9")
+}
+
+func TestExecuteChannelsTopicTemplateDefault(t *testing.T) {
+	nc := DefaultFeaturesConfig()
+	result, err := nc.ExecuteChannelsTopicTemplate(v1.ObjectMeta{
+		Name:      "topic",
+		Namespace: "namespace",
+		UID:       "138ac0ec-2694-4747-900d-45be3da5c9a9",
+	})
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, result, "knative-channel-namespace-topic")
+}
+
+func TestExecuteChannelsTopicTemplateOverride(t *testing.T) {
+	nc := DefaultFeaturesConfig()
+	nc.features.ChannelsTopicTemplate, _ = template.New("custom-template").Parse("knative-channel-{{ .Namespace }}-{{ .Name }}-{{ .UID }}")
+
+	result, err := nc.ExecuteChannelsTopicTemplate(v1.ObjectMeta{
+		Name:      "topic",
+		Namespace: "namespace",
+		UID:       "138ac0ec-2694-4747-900d-45be3da5c9a9",
+	})
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, result, "knative-channel-namespace-topic-138ac0ec-2694-4747-900d-45be3da5c9a9")
 }

--- a/control-plane/pkg/apis/config/testdata/config-kafka-features.yaml
+++ b/control-plane/pkg/apis/config/testdata/config-kafka-features.yaml
@@ -9,3 +9,5 @@ data:
     dispatcher.ordered-executor-metrics: "enabled"
     controller.autoscaler: "enabled"
     triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+    brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+    channels.topic.template: "knative-channel-{{ .Namespace }}-{{ .Name }}"

--- a/test/config/100-config-kafka-features.yaml
+++ b/test/config/100-config-kafka-features.yaml
@@ -8,3 +8,5 @@ data:
   dispatcher.ordered-executor-metrics: "enabled"
   controller.autoscaler: "enabled"
   triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+  brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+  channels.topic.template: "knative-channel-{{ .Namespace }}-{{ .Name }}"


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
As part of #3153 we need to be able to add broker and channel topic prefixes.
## Proposed Changes

- Update the kafka features to support broker topic template and channel topic template
