### PR TITLE
Increased tick time to improve test flakiness

### DIFF
--- a/control-plane/pkg/prober/async_prober_test.go
+++ b/control-plane/pkg/prober/async_prober_test.go
@@ -214,9 +214,9 @@ func TestAsyncProber(t *testing.T) {
 				return status == tc.wantStatus
 			}
 
-			require.Eventuallyf(t, probeFunc, 5*time.Second, 100*time.Millisecond, "")
-			require.Eventuallyf(t, func() bool { return wantRequestCountMin.Load() == 0 }, 5*time.Second, 100*time.Millisecond, "got %d, want 0", wantRequestCountMin.Load())
-			require.Eventuallyf(t, func() bool { return wantRequeueCountMin.Load() == 0 }, 5*time.Second, 100*time.Millisecond, "got %d, want 0", wantRequeueCountMin.Load())
+			require.Eventuallyf(t, probeFunc, 5*time.Second, 250*time.Millisecond, "")
+			require.Eventuallyf(t, func() bool { return wantRequestCountMin.Load() == 0 }, 5*time.Second, 250*time.Millisecond, "got %d, want 0", wantRequestCountMin.Load())
+			require.Eventuallyf(t, func() bool { return wantRequeueCountMin.Load() == 0 }, 5*time.Second, 250*time.Millisecond, "got %d, want 0", wantRequeueCountMin.Load())
 		})
 	}
 }
@@ -297,9 +297,9 @@ func TestAsyncProberRotateCACerts(t *testing.T) {
 	}
 
 	t.Run("one pod - TLS certs before rotation", func(tt *testing.T) {
-		require.Eventuallyf(t, probeFunc, 5*time.Second, 100*time.Millisecond, "")
-		require.Eventuallyf(t, func() bool { return wantRequestCountMin.Load() == 1 }, 5*time.Second, 100*time.Millisecond, "got %d, want 1", wantRequestCountMin.Load())
-		require.Eventuallyf(t, func() bool { return wantRequeueCountMin.Load() == 1 }, 5*time.Second, 100*time.Millisecond, "got %d, want 1", wantRequeueCountMin.Load())
+		require.Eventuallyf(tt, probeFunc, 5*time.Second, 250*time.Millisecond, "")
+		require.Eventuallyf(tt, func() bool { return wantRequestCountMin.Load() == 1 }, 5*time.Second, 250*time.Millisecond, "got %d, want 1", wantRequestCountMin.Load())
+		require.Eventuallyf(tt, func() bool { return wantRequeueCountMin.Load() == 1 }, 5*time.Second, 250*time.Millisecond, "got %d, want 1", wantRequeueCountMin.Load())
 	})
 	t.Run("one pod - TLS certs after rotation", func(tt *testing.T) {
 		prober.RotateRootCaCerts(pointer.String(string(CA2)))
@@ -308,9 +308,9 @@ func TestAsyncProberRotateCACerts(t *testing.T) {
 			return &cert, err
 		}
 		time.Sleep(time.Second * 10)
-		require.Eventuallyf(t, probeFunc, 5*time.Second, 100*time.Millisecond, "")
-		require.Eventuallyf(t, func() bool { return wantRequestCountMin.Load() == 0 }, 5*time.Second, 100*time.Millisecond, "got %d, want 0", wantRequestCountMin.Load())
-		require.Eventuallyf(t, func() bool { return wantRequeueCountMin.Load() == 0 }, 5*time.Second, 100*time.Millisecond, "got %d, want 0", wantRequeueCountMin.Load())
+		require.Eventuallyf(tt, probeFunc, 5*time.Second, 250*time.Millisecond, "")
+		require.Eventuallyf(tt, func() bool { return wantRequestCountMin.Load() == 0 }, 5*time.Second, 250*time.Millisecond, "got %d, want 0", wantRequestCountMin.Load())
+		require.Eventuallyf(tt, func() bool { return wantRequeueCountMin.Load() == 0 }, 5*time.Second, 250*time.Millisecond, "got %d, want 0", wantRequeueCountMin.Load())
 	})
 }
 


### PR DESCRIPTION
Fixes #3143 

<!-- Please include the 'why' behind your changes if no issue exists -->
From the test logs we can see that the probe requests are taking over 100ms to return:
```
 RUN   TestAsyncProberRotateCACerts
    logger.go:130: 2023-06-20T13:19:10.395Z	DEBUG	prober/prober.go:72	Sending probe request	{"scope": "prober", "IP": "127.0.0.1", "address": "https://127.0.0.1:39683/b1/b1"}
    logger.go:130: 2023-06-20T13:19:10.509Z	DEBUG	prober/async_prober.go:148	Probe status	{"scope": "prober", "IP": "127.0.0.1", "address": "https://127.0.0.1:39683/b1/b1", "status": "Ready"} 
```
This is causing test flakiness, as we are currently probing every 100ms and checking the number of times the probes have been done.

## Proposed Changes

- Increase the tick time in the prober tests so that they have enough time to run


