### PR TITLE
`ReactiveKafkaConsumer` Interface and it's Vert.x Implementation

### DIFF
--- a/data-plane/dispatcher-vertx/src/main/java/dev/knative/eventing/kafka/broker/dispatchervertx/VertxConsumerFactory.java
+++ b/data-plane/dispatcher-vertx/src/main/java/dev/knative/eventing/kafka/broker/dispatchervertx/VertxConsumerFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.dispatchervertx;
 
 import java.util.Map;

--- a/data-plane/dispatcher-vertx/src/main/java/dev/knative/eventing/kafka/broker/dispatchervertx/VertxConsumerFactory.java
+++ b/data-plane/dispatcher-vertx/src/main/java/dev/knative/eventing/kafka/broker/dispatchervertx/VertxConsumerFactory.java
@@ -1,0 +1,19 @@
+package dev.knative.eventing.kafka.broker.dispatchervertx;
+
+import java.util.Map;
+
+import dev.knative.eventing.kafka.broker.dispatcher.ReactiveConsumerFactory;
+import dev.knative.eventing.kafka.broker.dispatcher.ReactiveKafkaConsumer;
+import io.vertx.core.Vertx;
+import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.kafka.client.common.KafkaClientOptions;
+
+public class VertxConsumerFactory<K, V> implements ReactiveConsumerFactory<K, V> {
+
+    @Override
+    public ReactiveKafkaConsumer<K, V> create(Vertx vertx, Map<String, Object> configs) {
+        return new VertxKafkaConsumer<>(vertx, new KafkaClientOptions().setConfig(configs).setTracingPolicy(TracingPolicy.IGNORE));
+    }
+
+    
+}

--- a/data-plane/dispatcher-vertx/src/main/java/dev/knative/eventing/kafka/broker/dispatchervertx/VertxKafkaConsumer.java
+++ b/data-plane/dispatcher-vertx/src/main/java/dev/knative/eventing/kafka/broker/dispatchervertx/VertxKafkaConsumer.java
@@ -30,11 +30,11 @@ import io.vertx.core.Vertx;
 import io.vertx.kafka.client.common.KafkaClientOptions;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 
-public class VertxKafkaConsumer<K, V> implements ReactiveKafkaConsumer<K, V>{
+public class VertxKafkaConsumer<K, V> implements ReactiveKafkaConsumer<K, V> {
 
     private KafkaConsumer<K, V> consumer;
 
-    public VertxKafkaConsumer(Vertx v, KafkaClientOptions configs){
+    public VertxKafkaConsumer(Vertx v, KafkaClientOptions configs) {
         consumer = KafkaConsumer.create(v, configs);
     }
 

--- a/data-plane/dispatcher-vertx/src/main/java/dev/knative/eventing/kafka/broker/dispatchervertx/VertxKafkaConsumer.java
+++ b/data-plane/dispatcher-vertx/src/main/java/dev/knative/eventing/kafka/broker/dispatchervertx/VertxKafkaConsumer.java
@@ -15,8 +15,90 @@
  */
 package dev.knative.eventing.kafka.broker.dispatchervertx;
 
-public class VertxKafkaConsumer {
-    public static void main(String[] args) {
-        System.out.println("Hello Vertx KafkaConsumer!");
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+
+import dev.knative.eventing.kafka.broker.dispatcher.ReactiveKafkaConsumer;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.kafka.client.common.KafkaClientOptions;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+
+public class VertxKafkaConsumer<K, V> implements ReactiveKafkaConsumer<K, V>{
+
+    private KafkaConsumer<K, V> consumer;
+
+    public VertxKafkaConsumer(Vertx v, KafkaClientOptions configs){
+        consumer = KafkaConsumer.create(v, configs);
     }
+
+    @Override
+    public Future<Void> assign(Collection<TopicPartition> partitions) {
+        Set<io.vertx.kafka.client.common.TopicPartition> vertxTopicPartitions = new HashSet<>();
+
+        for(TopicPartition kafkTopicPartition: partitions){
+            vertxTopicPartitions.add(new io.vertx.kafka.client.common.TopicPartition(kafkTopicPartition.topic(), kafkTopicPartition.partition()));
+        }
+
+        return consumer.assign(vertxTopicPartitions);
+    }
+
+    @Override
+    public Future<Void> close() {
+        return consumer.close();
+    }
+
+    @Override
+    public Future<Void> pause(Collection<TopicPartition> partitions) {
+        Set<io.vertx.kafka.client.common.TopicPartition> vertxTopicPartitions = new HashSet<>();
+
+        for(TopicPartition kafkTopicPartition: partitions){
+            vertxTopicPartitions.add(new io.vertx.kafka.client.common.TopicPartition(kafkTopicPartition.topic(), kafkTopicPartition.partition()));
+        }
+
+        return consumer.pause(vertxTopicPartitions);
+    }
+
+    @Override
+    public Future<ConsumerRecords<K, V>> poll(Duration timeout) {
+        return consumer.poll(timeout).map(kafkaConsumerRecords -> {
+            return kafkaConsumerRecords.records();
+        });
+    }
+
+    @Override
+    public Future<Void> resume(Collection<TopicPartition> partitions) {
+        Set<io.vertx.kafka.client.common.TopicPartition> vertxTopicPartitions = new HashSet<>();
+
+        for(TopicPartition kafkTopicPartition: partitions){
+            vertxTopicPartitions.add(new io.vertx.kafka.client.common.TopicPartition(kafkTopicPartition.topic(), kafkTopicPartition.partition()));
+        }
+
+        return consumer.resume(vertxTopicPartitions);
+    }
+
+    @Override
+    public Future<Void> subscribe(Collection<String> topics) {
+        return consumer.subscribe(new HashSet<>(topics));
+    }
+
+    @Override
+    public Consumer<K, V> unwrap() {
+        return consumer.unwrap();
+    }
+
+    @Override
+    public ReactiveKafkaConsumer<K, V> exceptionHandler(Handler<Throwable> handler) {
+        consumer = consumer.exceptionHandler(handler);
+        return this;
+    }
+
 }

--- a/data-plane/dispatcher-vertx/src/main/java/dev/knative/eventing/kafka/broker/dispatchervertx/VertxKafkaConsumer.java
+++ b/data-plane/dispatcher-vertx/src/main/java/dev/knative/eventing/kafka/broker/dispatchervertx/VertxKafkaConsumer.java
@@ -18,13 +18,11 @@ package dev.knative.eventing.kafka.broker.dispatchervertx;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
-
 import dev.knative.eventing.kafka.broker.dispatcher.ReactiveKafkaConsumer;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ReactiveConsumerFactory.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ReactiveConsumerFactory.java
@@ -25,6 +25,7 @@ import io.vertx.core.Vertx;
  * @param <K> The type of the Kafka message key.
  * @param <V> The type of the Kafka message value.
  */
+@FunctionalInterface
 public interface ReactiveConsumerFactory<K, V> {
 
     /**

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ReactiveConsumerFactory.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ReactiveConsumerFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.dispatcher;
 
 import java.util.Map;
@@ -21,4 +36,3 @@ public interface ReactiveConsumerFactory<K, V> {
      */
     ReactiveKafkaConsumer<K, V> create(Vertx vertx, Map<String, Object> configs);
 }
-

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ReactiveConsumerFactory.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ReactiveConsumerFactory.java
@@ -1,0 +1,24 @@
+package dev.knative.eventing.kafka.broker.dispatcher;
+
+import java.util.Map;
+
+import io.vertx.core.Vertx;
+
+/**
+ * A factory interface for creating reactive Kafka consumers.
+ *
+ * @param <K> The type of the Kafka message key.
+ * @param <V> The type of the Kafka message value.
+ */
+public interface ReactiveConsumerFactory<K, V> {
+
+    /**
+     * Creates a new reactive Kafka consumer using the provided Vertx instance and configuration.
+     *
+     * @param vertx   The Vertx instance to be used by the vertx consumer only.
+     * @param configs The configuration options for the consumer.
+     * @return The created reactive Kafka consumer.
+     */
+    ReactiveKafkaConsumer<K, V> create(Vertx vertx, Map<String, Object> configs);
+}
+

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ReactiveKafkaConsumer.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ReactiveKafkaConsumer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.dispatcher;
 
 import java.time.Duration;
@@ -6,7 +21,6 @@ import java.util.Collection;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
-
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ReactiveKafkaConsumer.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ReactiveKafkaConsumer.java
@@ -40,7 +40,7 @@ public interface ReactiveKafkaConsumer<K, V> {
      * @param offsets The offsets to commit.
      * @return A future containing the offsets that were committed.
      */
-    Future<Map<TopicPartition,OffsetAndMetadata>> commit(Map<TopicPartition,OffsetAndMetadata> offset);
+    Future<Map<TopicPartition, OffsetAndMetadata>> commit(Map<TopicPartition, OffsetAndMetadata> offset);
 
     /**
      * Closes the consumer.

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ReactiveKafkaConsumer.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ReactiveKafkaConsumer.java
@@ -1,0 +1,82 @@
+package dev.knative.eventing.kafka.broker.dispatcher;
+
+import java.time.Duration;
+import java.util.Collection;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+/**
+ * A reactive Kafka consumer interface for handling Kafka communication.
+ *
+ * @param <K> The type of the Kafka message key.
+ * @param <V> The type of the Kafka message value.
+ */
+public interface ReactiveKafkaConsumer<K, V> {
+
+    /**
+     * Assigns the specified partitions to this consumer.
+     *
+     * @param partitions The partitions to assign.
+     * @return A future indicating the success or failure of the assignment.
+     */
+    Future<Void> assign(Collection<TopicPartition> partitions);
+
+    /**
+     * Closes the consumer.
+     *
+     * @return A future indicating the success or failure of the close operation.
+     */
+    Future<Void> close();
+
+    /**
+     * Pauses consumption from the specified partitions.
+     *
+     * @param partitions The partitions to pause consumption from.
+     * @return A future indicating the success or failure of the pause operation.
+     */
+    Future<Void> pause(Collection<TopicPartition> partitions);
+
+    /**
+     * Polls for records from Kafka with a specified timeout.
+     *
+     * @param timeout The maximum time to wait for records to be available.
+     * @return A future containing the records retrieved from Kafka.
+     */
+    Future<ConsumerRecords<K, V>> poll(Duration timeout);
+
+    /**
+     * Resumes consumption from the specified partitions.
+     *
+     * @param partitions The partitions to resume consumption from.
+     * @return A future indicating the success or failure of the resume operation.
+     */
+    Future<Void> resume(Collection<TopicPartition> partitions);
+
+    /**
+     * Subscribes to the specified topics to start consuming from them.
+     *
+     * @param topics The topics to subscribe to.
+     * @return A future indicating the success or failure of the subscribe operation.
+     */
+    Future<Void> subscribe(Collection<String> topics);
+
+    /**
+     * Retrieves the underlying Kafka Consumer instance.
+     *
+     * @return The KafkaConsumer instance.
+     */
+    Consumer<K, V> unwrap();
+
+    /**
+     * Sets an exception handler for handling exceptions thrown by the consumer.
+     *
+     * @param handler The exception handler.
+     * @return This consumer instance with the exception handler set.
+     */
+    ReactiveKafkaConsumer<K, V> exceptionHandler(Handler<Throwable> handler);
+}

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ReactiveKafkaConsumer.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/ReactiveKafkaConsumer.java
@@ -17,9 +17,11 @@ package dev.knative.eventing.kafka.broker.dispatcher;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Map;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -33,12 +35,12 @@ import io.vertx.core.Handler;
 public interface ReactiveKafkaConsumer<K, V> {
 
     /**
-     * Assigns the specified partitions to this consumer.
+     * Commits the specified offsets.
      *
-     * @param partitions The partitions to assign.
-     * @return A future indicating the success or failure of the assignment.
+     * @param offsets The offsets to commit.
+     * @return A future containing the offsets that were committed.
      */
-    Future<Void> assign(Collection<TopicPartition> partitions);
+    Future<Map<TopicPartition,OffsetAndMetadata>> commit(Map<TopicPartition,OffsetAndMetadata> offset);
 
     /**
      * Closes the consumer.


### PR DESCRIPTION
Progress on #2928 


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Identifies all the Consumer functions used and needs to be implemented in specialised modules.
- Implement all of these methods in the dispatcher vertx module with vertx implementation.

It may require some additional changes while migrating the base dispatcher to use `ReactiveKafkaConsumer`

