### PR TITLE
Deprecation of the NamespacedKafka broker class

### DIFF
--- a/control-plane/pkg/kafka/broker_class.go
+++ b/control-plane/pkg/kafka/broker_class.go
@@ -24,7 +24,8 @@ import (
 
 const (
 	// Kafka broker class annotation value.
-	BrokerClass           = "Kafka"
+	BrokerClass = "Kafka"
+	// Deprecated
 	NamespacedBrokerClass = "KafkaNamespaced"
 )
 
@@ -36,6 +37,7 @@ func BrokerClassFilter() func(interface{}) bool {
 	)
 }
 
+// Deprecated
 func NamespacedBrokerClassFilter() func(interface{}) bool {
 	return pkgreconciler.AnnotationFilterFunc(
 		brokerreconciler.ClassAnnotationKey,

--- a/control-plane/pkg/reconciler/broker/namespaced_broker.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_broker.go
@@ -59,6 +59,7 @@ import (
 // TODO: IPListerWithMapping struct can leak resources in case of a leader change
 // TODO: We might need to create a TTL mechanism
 
+// Deprecated
 type NamespacedReconciler struct {
 	*base.Reconciler
 	*config.Env

--- a/control-plane/pkg/reconciler/broker/namespaced_controller.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_controller.go
@@ -67,6 +67,7 @@ const (
 	NamespacedBrokerAdditionalResourcesConfigMapName = "config-namespaced-broker-resources"
 )
 
+// Deprecated
 func NewNamespacedController(ctx context.Context, watcher configmap.Watcher, env *config.Env) *controller.Impl {
 	logger := logging.FromContext(ctx)
 

--- a/control-plane/pkg/reconciler/trigger/namespaced_controller.go
+++ b/control-plane/pkg/reconciler/trigger/namespaced_controller.go
@@ -49,6 +49,7 @@ const (
 	NamespacedFinalizerName = "kafka.namespaced.triggers.eventing.knative.dev"
 )
 
+// Deprecated
 func NewNamespacedController(ctx context.Context, watcher configmap.Watcher, configs *config.Env) *controller.Impl {
 
 	logger := logging.FromContext(ctx).Desugar()

--- a/control-plane/pkg/reconciler/trigger/namespaced_trigger.go
+++ b/control-plane/pkg/reconciler/trigger/namespaced_trigger.go
@@ -33,6 +33,7 @@ import (
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
 )
 
+// Deprecated
 type NamespacedReconciler struct {
 	*base.Reconciler
 	*FlagsHolder


### PR DESCRIPTION
## Proposed Changes

- deprecation of the `NamespacedKafka` broker class annotation

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
The Namespaced Kafka broker is being deprecated. The feature will be removed in a future release
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
