### PR TITLE
Send namespace header in MT components

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
@@ -176,7 +176,9 @@ public final class WebClientCloudEventSender implements CloudEventSender {
     return VertxMessageFactory
       .createWriter(client.postAbs(target)
         .timeout(this.consumerVerticleContext.getEgressConfig().getTimeout() <= 0 ? DEFAULT_TIMEOUT_MS : this.consumerVerticleContext.getEgressConfig().getTimeout())
-        .putHeader("Prefer", "reply"))
+        .putHeader("Prefer", "reply")
+        .putHeader("Kn-Namespace", this.consumerVerticleContext.getEgress().getReference().getNamespace())
+      )
       .writeBinary(event)
       .onFailure(ex -> {
         logError(event, ex);


### PR DESCRIPTION
When running MT components [1] in mesh mode with Istio, 
we lose the ability to define fine grained policies since we
don't know the resource namespace that originated such
request, therefore, by having a `Kn-Namespace` header, 
in mesh mode, users case define fine-grained policies and
isolate namespaces.

[1] KafkaSource, Kafka Broker, and KafkaChannel

Related to https://github.com/knative/eventing/pull/7048