### PR TITLE
Upgrade workflow's java version to 20

### DIFF
--- a/.github/workflows/build-dependabot-pr.yaml
+++ b/.github/workflows/build-dependabot-pr.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v1
         with:
-          java-version: 15
+          java-version: 17
 
       - run: mvn --no-transfer-progress -B --file data-plane/pom.xml -Dlicense.outputDirectory=. license:aggregate-add-third-party
       - run: mkdir ./dependabot-pr

--- a/.github/workflows/knative-java-test.yaml
+++ b/.github/workflows/knative-java-test.yaml
@@ -28,7 +28,7 @@ jobs:
     name: Java Unit Tests
     strategy:
       matrix:
-        java-version: [ 17 ]
+        java-version: [ 20 ]
         platform: [ ubuntu-latest ]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/knative-profile-data-plane.yaml
+++ b/.github/workflows/knative-profile-data-plane.yaml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         java-version:
-          - 17
+          - 20
         go-version:
           - 1.17.x
         platform: [ ubuntu-latest ]


### PR DESCRIPTION
As we are planning to build the receiver and dispatcher with loom virtual thread through #2928  the workflow needs to upgrade to 20+ JAVA version.

## Proposed Changes

- Update the `knative-java-test` and `knative-profile-data-plane` to use JAVA 20. 
- Update the `dependent-bot` java version to 17 the current LTS.
