### PR TITLE
Remove `ConsumerRebalanceListener` from `ConsumerVerticleContext`

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/ConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/ConsumerVerticle.java
@@ -26,7 +26,6 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import java.util.Objects;
 import java.util.function.BiFunction;
-
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/ConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/ConsumerVerticle.java
@@ -26,6 +26,8 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import java.util.Objects;
 import java.util.function.BiFunction;
+
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +42,7 @@ public abstract class ConsumerVerticle extends AbstractVerticle {
     private final ConsumerVerticleContext consumerVerticleContext;
 
     ReactiveKafkaConsumer<Object, CloudEvent> consumer;
+    ConsumerRebalanceListener consumerRebalanceListener;
     RecordDispatcher recordDispatcher;
     private AsyncCloseable closeable;
 
@@ -85,6 +88,10 @@ public abstract class ConsumerVerticle extends AbstractVerticle {
         this.closeable = closeable;
     }
 
+    public void setRebalanceListener(ConsumerRebalanceListener consumerRebalanceListener) {
+        this.consumerRebalanceListener = consumerRebalanceListener;
+    }
+
     void exceptionHandler(Throwable cause) {
         logger.error("Consumer exception {}", consumerVerticleContext.getLoggingKeyValue(), cause);
 
@@ -96,6 +103,10 @@ public abstract class ConsumerVerticle extends AbstractVerticle {
 
     protected ConsumerVerticleContext getConsumerVerticleContext() {
         return consumerVerticleContext;
+    }
+
+    protected ConsumerRebalanceListener getConsumerRebalanceListener() {
+        return consumerRebalanceListener;
     }
 
     public abstract PartitionRevokedHandler getPartitionRevokedHandler();

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
@@ -94,12 +94,12 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
 
     @Override
     void startConsumer(Promise<Void> startPromise) {
-        Objects.requireNonNull(getConsumerVerticleContext().getConsumerRebalanceListener());
+        Objects.requireNonNull(getConsumerRebalanceListener());
         // We need to sub first, then we can start the polling loop
         this.consumer
                 .subscribe(
                         Set.copyOf(getConsumerVerticleContext().getResource().getTopicsList()),
-                        getConsumerVerticleContext().getConsumerRebalanceListener())
+                        getConsumerRebalanceListener())
                 .onFailure(startPromise::fail)
                 .onSuccess(v -> {
                     if (this.pollTimer.compareAndSet(-1, 0)) {

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
@@ -57,12 +57,12 @@ public final class UnorderedConsumerVerticle extends ConsumerVerticle {
 
     @Override
     void startConsumer(final Promise<Void> startPromise) {
-        Objects.requireNonNull(getConsumerVerticleContext().getConsumerRebalanceListener());
+        Objects.requireNonNull(getConsumerRebalanceListener());
 
         this.consumer
                 .subscribe(
                         Set.copyOf(getConsumerVerticleContext().getResource().getTopicsList()),
-                        getConsumerVerticleContext().getConsumerRebalanceListener())
+                        getConsumerRebalanceListener())
                 .onFailure(startPromise::tryFail)
                 .onSuccess(startPromise::tryComplete)
                 .onSuccess(v -> poll());

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
@@ -128,7 +128,7 @@ public class ConsumerVerticleBuilder {
 
         final var partitionRevokedHandlers =
                 List.of(consumerVerticle.getPartitionRevokedHandler(), offsetManager.getPartitionRevokedHandler());
-        this.consumerVerticleContext.withConsumerRebalanceListener(createRebalanceListener(partitionRevokedHandlers));
+        consumerVerticle.setRebalanceListener(createRebalanceListener(partitionRevokedHandlers));
     }
 
     private ConsumerVerticle createConsumerVerticle(final ConsumerVerticle.Initializer initializer) {

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleContext.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleContext.java
@@ -33,7 +33,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,8 +62,6 @@ public class ConsumerVerticleContext {
     private ConsumerVerticleLoggingContext loggingContext;
 
     private Tags tags;
-
-    private ConsumerRebalanceListener consumerRebalanceListener;
 
     public ConsumerVerticleContext withConsumerConfigs(final Map<String, Object> consumerConfigs) {
         this.consumerConfigs = new HashMap<>(consumerConfigs);
@@ -155,16 +152,6 @@ public class ConsumerVerticleContext {
     public ConsumerVerticleContext withProducerFactory(final ProducerFactory<String, CloudEvent> producerFactory) {
         this.producerFactory = producerFactory;
         return this;
-    }
-
-    public ConsumerVerticleContext withConsumerRebalanceListener(
-            final ConsumerRebalanceListener consumerRebalanceListener) {
-        this.consumerRebalanceListener = consumerRebalanceListener;
-        return this;
-    }
-
-    public ConsumerRebalanceListener getConsumerRebalanceListener() {
-        return consumerRebalanceListener;
     }
 
     public DataPlaneContract.Resource getResource() {

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/AbstractConsumerVerticleTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/AbstractConsumerVerticleTest.java
@@ -44,6 +44,7 @@ import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.backends.BackendRegistries;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -89,7 +90,13 @@ public abstract class AbstractConsumerVerticleTest {
             consumerVerticle.setConsumer(new MockReactiveKafkaConsumer<>(consumer));
             consumerVerticle.setRecordDispatcher(recordDispatcher);
             consumerVerticle.setCloser(Future::succeededFuture);
+            consumerVerticle.setRebalanceListener(new ConsumerRebalanceListener() {
+                @Override
+                public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {}
 
+                @Override
+                public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {}
+            });
             return Future.succeededFuture();
         });
 
@@ -130,6 +137,13 @@ public abstract class AbstractConsumerVerticleTest {
                     consumerVerticle.setConsumer(new MockReactiveKafkaConsumer<>(consumer));
                     consumerVerticle.setRecordDispatcher(recordDispatcher);
                     consumerVerticle.setCloser(Future::succeededFuture);
+                    consumerVerticle.setRebalanceListener(new ConsumerRebalanceListener() {
+                        @Override
+                        public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {}
+
+                        @Override
+                        public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {}
+                    });
 
                     return Future.succeededFuture();
                 });
@@ -207,7 +221,13 @@ public abstract class AbstractConsumerVerticleTest {
             consumerVerticle.setConsumer(consumer);
             consumerVerticle.setRecordDispatcher(recordDispatcher);
             consumerVerticle.setCloser(Future::succeededFuture);
+            consumerVerticle.setRebalanceListener(new ConsumerRebalanceListener() {
+                @Override
+                public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {}
 
+                @Override
+                public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {}
+            });
             return Future.succeededFuture();
         });
 

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticleTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticleTest.java
@@ -32,6 +32,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
@@ -123,7 +125,13 @@ public class OrderedConsumerVerticleTest extends AbstractConsumerVerticleTest {
                     consumerVerticle.setConsumer(new MockReactiveKafkaConsumer<>(consumer));
                     consumerVerticle.setRecordDispatcher(recordDispatcher);
                     consumerVerticle.setCloser(Future::succeededFuture);
+                    consumerVerticle.setRebalanceListener(new ConsumerRebalanceListener() {
+                        @Override
+                        public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {}
 
+                        @Override
+                        public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {}
+                    });
                     return Future.succeededFuture();
                 });
 

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/main/FakeConsumerVerticleContext.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/main/FakeConsumerVerticleContext.java
@@ -21,7 +21,6 @@ import dev.knative.eventing.kafka.broker.core.security.AuthProvider;
 import dev.knative.eventing.kafka.broker.core.testing.CoreObjects;
 import io.vertx.ext.web.client.WebClientOptions;
 import java.util.HashMap;
-import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 
 public class FakeConsumerVerticleContext {
 
@@ -30,16 +29,7 @@ public class FakeConsumerVerticleContext {
                 .withProducerConfigs(new HashMap<>())
                 .withConsumerConfigs(new HashMap<>())
                 .withMeterRegistry(Metrics.getRegistry())
-                .withResource(CoreObjects.resource1(), CoreObjects.egress1())
-                .withConsumerRebalanceListener(new ConsumerRebalanceListener() {
-                    @Override
-                    public void onPartitionsRevoked(
-                            final java.util.Collection<org.apache.kafka.common.TopicPartition> partitions) {}
-
-                    @Override
-                    public void onPartitionsAssigned(
-                            final java.util.Collection<org.apache.kafka.common.TopicPartition> partitions) {}
-                });
+                .withResource(CoreObjects.resource1(), CoreObjects.egress1());
     }
 
     public static ConsumerVerticleContext get(
@@ -50,15 +40,6 @@ public class FakeConsumerVerticleContext {
                 .withAuthProvider(AuthProvider.noAuth())
                 .withWebClientOptions(new WebClientOptions())
                 .withMeterRegistry(Metrics.getRegistry())
-                .withResource(resource, egress)
-                .withConsumerRebalanceListener(new ConsumerRebalanceListener() {
-                    @Override
-                    public void onPartitionsRevoked(
-                            final java.util.Collection<org.apache.kafka.common.TopicPartition> partitions) {}
-
-                    @Override
-                    public void onPartitionsAssigned(
-                            final java.util.Collection<org.apache.kafka.common.TopicPartition> partitions) {}
-                });
+                .withResource(resource, egress);
     }
 }


### PR DESCRIPTION
A clean conflict-free PR of #3195

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Put the `ConsumerRebalanceListener` into `ConsumerVerticle`
