### PR TITLE
Include io.fabric8 kubernetes-client in maven-shade-plugin to prevent ClassNotFoundException

### DIFF
--- a/data-plane/dispatcher-vertx/pom.xml
+++ b/data-plane/dispatcher-vertx/pom.xml
@@ -87,6 +87,12 @@
                     <include>**</include>
                   </includes>
                 </filter>
+                <filter>
+                  <artifact>io.fabric8:kubernetes-client</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
               </filters>
             </configuration>
           </execution>

--- a/data-plane/receiver-vertx/pom.xml
+++ b/data-plane/receiver-vertx/pom.xml
@@ -138,6 +138,12 @@
                     <include>**</include>
                   </includes>
                 </filter>
+                <filter>
+                  <artifact>io.fabric8:kubernetes-client</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
               </filters>
             </configuration>
           </execution>


### PR DESCRIPTION
Currently the fabric8 Kubernetes Client loads the Client Implementation class dynamically: https://github.com/fabric8io/kubernetes-client/blob/587657dc1bdd244cd4da5352ab97cd5668081696/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClientBuilder.java#L53

This can lead to a ClassNotFoundException, when using the maven-shade plugin to package an "uber jar" as the class is not directly referenced.
This PR addresses it and explicitly includes the kubernetes-client classes.