### PR TITLE
Eventing TLS: Configure certificates to force rotate private keys

### DIFF
--- a/data-plane/config/broker-tls/broker-ingress-tls-certificate.yaml
+++ b/data-plane/config/broker-tls/broker-ingress-tls-certificate.yaml
@@ -36,6 +36,7 @@ spec:
     algorithm: RSA
     encoding: PKCS1
     size: 2048
+    rotationPolicy: Always
 
   dnsNames:
     - kafka-broker-ingress.knative-eventing.svc.cluster.local

--- a/data-plane/config/channel-tls/channel-ingress-tls-certificate.yaml
+++ b/data-plane/config/channel-tls/channel-ingress-tls-certificate.yaml
@@ -36,6 +36,7 @@ spec:
     algorithm: RSA
     encoding: PKCS1
     size: 2048
+    rotationPolicy: Always
 
   dnsNames:
     - kafka-channel-ingress.knative-eventing.svc.cluster.local

--- a/data-plane/config/sink-tls/sink-ingress-tls-certificate.yaml
+++ b/data-plane/config/sink-tls/sink-ingress-tls-certificate.yaml
@@ -36,6 +36,7 @@ spec:
     algorithm: RSA
     encoding: PKCS1
     size: 2048
+    rotationPolicy: Always
 
   dnsNames:
     - kafka-sink-ingress.knative-eventing.svc.cluster.local


### PR DESCRIPTION
As per title, without this configuration the private key is not rotated